### PR TITLE
Rename the repo link in the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -24,4 +24,4 @@ Add any other context about the problem here.
 
 ### Checklist
 
-- [ ] I have checked that there is no similar [issue](https://github.com/openai/gym/issues) in the repo (**required**)
+- [ ] I have checked that there is no similar [issue](https://github.com/Farama-Foundation/Gymnasium/issues) in the repo (**required**)

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -30,4 +30,4 @@ Add any other context or screenshots about the feature request here.
 
 ### Checklist
 
-- [ ] I have checked that there is no similar [issue](https://github.com/openai/gym/issues) in the repo (**required**)
+- [ ] I have checked that there is no similar [issue](https://github.com/Farama-Foundation/Gymnasium/issues) in the repo (**required**)


### PR DESCRIPTION
The templates still linked to openai/gym, now they link here.

There's an argument to revamp the templates as a whole since people seem to misunderstand them **a lot**, but that's not a high priority