### PR TITLE
Faster EpisodeStatisticsRecorder, converted from gym PR

### DIFF
--- a/gymnasium/envs/toy_text/cliffwalking.py
+++ b/gymnasium/envs/toy_text/cliffwalking.py
@@ -287,5 +287,6 @@ class CliffWalkingEnv(Env):
         with closing(outfile):
             return outfile.getvalue()
 
+
 # Elf and stool from https://franuka.itch.io/rpg-snow-tileset
 # All other assets by ____

--- a/gymnasium/wrappers/record_episode_statistics.py
+++ b/gymnasium/wrappers/record_episode_statistics.py
@@ -68,7 +68,7 @@ class RecordEpisodeStatistics(gym.Wrapper):
         """Resets the environment using kwargs and resets the episode returns and lengths."""
         observations = super().reset(**kwargs)
         self.episode_returns = np.zeros(self.num_envs, dtype=np.float32)
-        self.episode_lengths = np.zeros(self.num_envs, dtype=np.int32)
+        self.episode_lengths = np.zeros(self.num_envs, dtype=np.float32)
         return observations
 
     def step(self, action):
@@ -92,7 +92,7 @@ class RecordEpisodeStatistics(gym.Wrapper):
                 "episode": {
                     "r": np.where(dones, self.episode_returns, 0),
                     "l": np.where(dones, self.episode_lengths, 0),
-                    "t": round(time.perf_counter() - self.t0, 6),
+                    "t": np.full((self.num_envs,), round(time.perf_counter() - self.t0, 6), dtype=np.float32),
                 },
             }
             if self.is_vector_env:

--- a/gymnasium/wrappers/record_episode_statistics.py
+++ b/gymnasium/wrappers/record_episode_statistics.py
@@ -92,7 +92,9 @@ class RecordEpisodeStatistics(gym.Wrapper):
                 "episode": {
                     "r": np.where(dones, self.episode_returns, 0),
                     "l": np.where(dones, self.episode_lengths, 0),
-                    "t": np.full((self.num_envs,), round(time.perf_counter() - self.t0, 6)),
+                    "t": np.full(
+                        (self.num_envs,), round(time.perf_counter() - self.t0, 6)
+                    ),
                 },
             }
             if self.is_vector_env:

--- a/gymnasium/wrappers/record_episode_statistics.py
+++ b/gymnasium/wrappers/record_episode_statistics.py
@@ -8,35 +8,6 @@ import numpy as np
 import gymnasium as gym
 
 
-def add_vector_episode_statistics(
-    info: dict, episode_info: dict, num_envs: int, env_num: int
-):
-    """Add episode statistics.
-
-    Add statistics coming from the vectorized environment.
-
-    Args:
-        info (dict): info dict of the environment.
-        episode_info (dict): episode statistics data.
-        num_envs (int): number of environments.
-        env_num (int): env number of the vectorized environments.
-
-    Returns:
-        info (dict): the input info dict with the episode statistics.
-    """
-    info["episode"] = info.get("episode", {})
-
-    info["_episode"] = info.get("_episode", np.zeros(num_envs, dtype=bool))
-    info["_episode"][env_num] = True
-
-    for k in episode_info.keys():
-        info_array = info["episode"].get(k, np.zeros(num_envs))
-        info_array[env_num] = episode_info[k]
-        info["episode"][k] = info_array
-
-    return info
-
-
 class RecordEpisodeStatistics(gym.Wrapper):
     """This wrapper will keep track of cumulative rewards and episode lengths.
 
@@ -114,38 +85,28 @@ class RecordEpisodeStatistics(gym.Wrapper):
         ), f"`info` dtype is {type(infos)} while supported dtype is `dict`. This may be due to usage of other wrappers in the wrong order."
         self.episode_returns += rewards
         self.episode_lengths += 1
-        if not self.is_vector_env:
-            terminateds = [terminateds]
-            truncateds = [truncateds]
-        terminateds = list(terminateds)
-        truncateds = list(truncateds)
-
-        for i in range(len(terminateds)):
-            if terminateds[i] or truncateds[i]:
-                episode_return = self.episode_returns[i]
-                episode_length = self.episode_lengths[i]
-                episode_info = {
-                    "episode": {
-                        "r": episode_return,
-                        "l": episode_length,
-                        "t": round(time.perf_counter() - self.t0, 6),
-                    }
-                }
-                if self.is_vector_env:
-                    infos = add_vector_episode_statistics(
-                        infos, episode_info["episode"], self.num_envs, i
-                    )
-                else:
-                    infos = {**infos, **episode_info}
-                self.return_queue.append(episode_return)
-                self.length_queue.append(episode_length)
-                self.episode_count += 1
-                self.episode_returns[i] = 0
-                self.episode_lengths[i] = 0
+        dones = truncateds | terminateds
+        num_dones = np.sum(dones)
+        if num_dones:
+            episode_info = {
+                "episode": {
+                    "r": np.where(dones, self.episode_returns, 0),
+                    "l": np.where(dones, self.episode_lengths, 0),
+                    "t": round(time.perf_counter() - self.t0, 6),
+                },
+            }
+            if self.is_vector_env:
+                episode_info["_episode"] = np.where(dones, True, False)
+            infos = {**infos, **episode_info}
+            self.return_queue.extend(self.episode_returns[dones])
+            self.length_queue.extend(self.episode_lengths[dones])
+            self.episode_count += num_dones
+            self.episode_lengths[dones] = 0
+            self.episode_returns[dones] = 0
         return (
             observations,
             rewards,
-            terminateds if self.is_vector_env else terminateds[0],
-            truncateds if self.is_vector_env else truncateds[0],
+            terminateds,
+            truncateds,
             infos,
         )

--- a/gymnasium/wrappers/record_episode_statistics.py
+++ b/gymnasium/wrappers/record_episode_statistics.py
@@ -67,8 +67,8 @@ class RecordEpisodeStatistics(gym.Wrapper):
     def reset(self, **kwargs):
         """Resets the environment using kwargs and resets the episode returns and lengths."""
         observations = super().reset(**kwargs)
-        self.episode_returns = np.zeros(self.num_envs, dtype=np.float32)
-        self.episode_lengths = np.zeros(self.num_envs, dtype=np.float32)
+        self.episode_returns = np.zeros(self.num_envs)
+        self.episode_lengths = np.zeros(self.num_envs)
         return observations
 
     def step(self, action):
@@ -92,7 +92,7 @@ class RecordEpisodeStatistics(gym.Wrapper):
                 "episode": {
                     "r": np.where(dones, self.episode_returns, 0),
                     "l": np.where(dones, self.episode_lengths, 0),
-                    "t": np.full((self.num_envs,), round(time.perf_counter() - self.t0, 6), dtype=np.float32),
+                    "t": np.full((self.num_envs,), round(time.perf_counter() - self.t0, 6)),
                 },
             }
             if self.is_vector_env:

--- a/tests/wrappers/test_record_episode_statistics.py
+++ b/tests/wrappers/test_record_episode_statistics.py
@@ -3,7 +3,6 @@ import pytest
 
 import gymnasium as gym
 from gymnasium.wrappers import RecordEpisodeStatistics, VectorListInfo
-from gymnasium.wrappers.record_episode_statistics import add_vector_episode_statistics
 
 
 @pytest.mark.parametrize("env_id", ["CartPole-v1", "Pendulum-v1"])
@@ -74,29 +73,3 @@ def test_wrong_wrapping_order():
 
     with pytest.raises(AssertionError):
         wrapped_env.step(wrapped_env.action_space.sample())
-
-
-def test_add_vector_episode_statistics():
-    NUM_ENVS = 5
-
-    info = {}
-    for i in range(NUM_ENVS):
-        episode_info = {
-            "episode": {
-                "r": i,
-                "l": i,
-                "t": i,
-            }
-        }
-        info = add_vector_episode_statistics(info, episode_info["episode"], NUM_ENVS, i)
-        assert np.alltrue(info["_episode"][: i + 1])
-
-        for j in range(NUM_ENVS):
-            if j <= i:
-                assert info["episode"]["r"][j] == j
-                assert info["episode"]["l"][j] == j
-                assert info["episode"]["t"][j] == j
-            else:
-                assert info["episode"]["r"][j] == 0
-                assert info["episode"]["l"][j] == 0
-                assert info["episode"]["t"][j] == 0

--- a/tests/wrappers/test_vector_list_info.py
+++ b/tests/wrappers/test_vector_list_info.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 import gymnasium as gym
@@ -53,6 +54,6 @@ def test_info_to_list_statistics():
                 assert "episode" in list_info[i]
                 for stats in ["r", "l", "t"]:
                     assert stats in list_info[i]["episode"]
-                    assert isinstance(list_info[i]["episode"][stats], float)
+                    assert np.isscalar(list_info[i]["episode"][stats])
             else:
                 assert "episode" not in list_info[i]


### PR DESCRIPTION
# Description

(Re-PR for gymnasium, this was reviewed and approved on the old gym repo [PR #3101](https://github.com/openai/gym/pull/3101)) 

This addresses two issues I've run into with RecordEpisodeStatistics

1) Silent list conversion in vectorized environments. Currently, RecordEpisodeStatistics converts terminated and truncated into lists, but obs and reward may still be arrays, and the new vectorized `info` interface uses arrays. I particularly run into this in my code if I do something like `dones.any()`. This PR leaves the underlying details of terminated/truncated alone by using NumPy array functionality.

2) Speed. Instead of looping through a potentially large batch of environments, this PR uses NumPy functions with their underlying vectorization to achieve the same task.

I considered building this with Jumpy, but I'm not sure on its status in the project, and it would also eat the cost of creating new arrays wherever I'm doing in-place modifications. 

I tested to make sure that this replicates the exact functionality of the original wrapper. To prove my speedup, I need to come up with some decent micro benchmarks; a couple attempts on Colab were fairly noisy.

## Type of change

- [x] Existing feature enhancement (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
