### PR TITLE
fix: remove auto close feature in VideoRecorder

### DIFF
--- a/gymnasium/wrappers/monitoring/video_recorder.py
+++ b/gymnasium/wrappers/monitoring/video_recorder.py
@@ -155,7 +155,7 @@ class VideoRecorder:
 
             logger.debug(f"Closing video encoder: path={self.path}")
             clip = ImageSequenceClip(self.recorded_frames, fps=self.frames_per_sec)
-            clip.write_videofile(self.path)
+            clip.write_videofile(self.path, logger=None)
         else:
             # No frames captured. Set metadata.
             if self.metadata is None:

--- a/gymnasium/wrappers/monitoring/video_recorder.py
+++ b/gymnasium/wrappers/monitoring/video_recorder.py
@@ -24,7 +24,7 @@ class VideoRecorder:
         metadata: Optional[dict] = None,
         enabled: bool = True,
         base_path: Optional[str] = None,
-        disable_logger: bool = False
+        disable_logger: bool = False,
     ):
         """Video recorder renders a nice movie of a rollout, frame by frame.
 
@@ -157,7 +157,7 @@ class VideoRecorder:
                 )
 
             clip = ImageSequenceClip(self.recorded_frames, fps=self.frames_per_sec)
-            moviepy_logger = None if self.disable_logger else 'bar'
+            moviepy_logger = None if self.disable_logger else "bar"
             clip.write_videofile(self.path, logger=moviepy_logger)
         else:
             # No frames captured. Set metadata.

--- a/gymnasium/wrappers/monitoring/video_recorder.py
+++ b/gymnasium/wrappers/monitoring/video_recorder.py
@@ -51,7 +51,7 @@ class VideoRecorder:
         self._async = env.metadata.get("semantics.async")
         self.enabled = enabled
         self.disable_logger = disable_logger
-        self.closed = False
+        self._closed = False
 
         self.render_history = []
         self.env = env
@@ -118,7 +118,7 @@ class VideoRecorder:
 
         if not self.functional:
             return
-        if self.closed:
+        if self._closed:
             logger.warn(
                 "The video recorder has been closed and no frames will be captured anymore."
             )
@@ -141,7 +141,7 @@ class VideoRecorder:
 
     def close(self):
         """Flush all data to disk and close any open frame encoders."""
-        if not self.enabled or self.closed:
+        if not self.enabled or self._closed:
             return
 
         # First close the environment
@@ -168,7 +168,7 @@ class VideoRecorder:
         self.write_metadata()
 
         # Stop tracking this for autoclose
-        self.closed = True
+        self._closed = True
 
     def write_metadata(self):
         """Writes metadata to metadata path."""
@@ -178,5 +178,5 @@ class VideoRecorder:
     def __del__(self):
         """Closes the environment correctly when the recorder is deleted."""
         # Make sure we've closed up shop when garbage collecting
-        if not self.closed:
+        if not self._closed:
             logger.warn("Unable to save last video! Did you call close()?")

--- a/gymnasium/wrappers/record_video.py
+++ b/gymnasium/wrappers/record_video.py
@@ -45,6 +45,7 @@ class RecordVideo(gym.Wrapper):
         step_trigger: Callable[[int], bool] = None,
         video_length: int = 0,
         name_prefix: str = "rl-video",
+        disable_logger: bool = False
     ):
         """Wrapper records videos of rollouts.
 
@@ -56,6 +57,8 @@ class RecordVideo(gym.Wrapper):
             video_length (int): The length of recorded episodes. If 0, entire episodes are recorded.
                 Otherwise, snippets of the specified length are captured
             name_prefix (str): Will be prepended to the filename of the recordings
+            disable_logger (bool): Whether to disable moviepy logger or not.
+
         """
         super().__init__(env)
 
@@ -68,6 +71,7 @@ class RecordVideo(gym.Wrapper):
         self.episode_trigger = episode_trigger
         self.step_trigger = step_trigger
         self.video_recorder: Optional[video_recorder.VideoRecorder] = None
+        self.disable_logger = disable_logger
 
         self.video_folder = os.path.abspath(video_folder)
         # Create output folder if needed
@@ -119,6 +123,7 @@ class RecordVideo(gym.Wrapper):
             env=self.env,
             base_path=base_path,
             metadata={"step_id": self.step_id, "episode_id": self.episode_id},
+            disable_logger=self.disable_logger
         )
 
         self.video_recorder.capture_frame()
@@ -204,8 +209,4 @@ class RecordVideo(gym.Wrapper):
     def close(self):
         """Closes the wrapper then the video recorder."""
         super().close()
-        self.close_video_recorder()
-
-    def __del__(self):
-        """Closes the video recorder."""
         self.close_video_recorder()

--- a/gymnasium/wrappers/record_video.py
+++ b/gymnasium/wrappers/record_video.py
@@ -45,7 +45,7 @@ class RecordVideo(gym.Wrapper):
         step_trigger: Callable[[int], bool] = None,
         video_length: int = 0,
         name_prefix: str = "rl-video",
-        disable_logger: bool = False
+        disable_logger: bool = False,
     ):
         """Wrapper records videos of rollouts.
 
@@ -123,7 +123,7 @@ class RecordVideo(gym.Wrapper):
             env=self.env,
             base_path=base_path,
             metadata={"step_id": self.step_id, "episode_id": self.episode_id},
-            disable_logger=self.disable_logger
+            disable_logger=self.disable_logger,
         )
 
         self.video_recorder.capture_frame()

--- a/tests/wrappers/test_video_recorder.py
+++ b/tests/wrappers/test_video_recorder.py
@@ -1,7 +1,5 @@
-import gc
 import os
 import re
-import time
 
 import pytest
 

--- a/tests/wrappers/test_video_recorder.py
+++ b/tests/wrappers/test_video_recorder.py
@@ -45,31 +45,6 @@ def test_record_simple():
     assert os.fstat(f.fileno()).st_size > 100
 
 
-def test_autoclose():
-    def record():
-        env = gym.make(
-            "CartPole-v1", render_mode="rgb_array_list", disable_env_checker=True
-        )
-        rec = VideoRecorder(env)
-        env.reset()
-        rec.capture_frame()
-
-        rec_path = rec.path
-
-        # The function ends without an explicit `rec.close()` call
-        # The Python interpreter will implicitly do `del rec` on garbage cleaning
-        return rec_path
-
-    rec_path = record()
-
-    gc.collect()  # do explicit garbage collection for test
-    time.sleep(5)  # wait for subprocess exiting
-
-    assert os.path.exists(rec_path)
-    f = open(rec_path)
-    assert os.fstat(f.fileno()).st_size > 100
-
-
 def test_no_frames():
     env = BrokenRecordableEnv()
     rec = VideoRecorder(env)


### PR DESCRIPTION
If user forgets to call `close`, and the VideoRecorder is deleted by the garbage collector, the class tries to save the video, but it raises an error (and it is not easy to understand the reason). With this PR, RecordVideo just warns the user that the last video is not saved and to call close. 

It also adds a parameter `disable_logger` to disable MoviePy messages.
![Screenshot from 2022-10-08 13-33-51](https://user-images.githubusercontent.com/42100908/194705629-a98241fb-4e43-4598-813e-1305d49f0d4c.png)
