### PR TITLE
Updated the utils.__init__ and documentation

### DIFF
--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -4,34 +4,6 @@ title: Utils
 
 # Utils
 
-## Visualization
-
-```{eval-rst}
-.. autofunction:: gymnasium.utils.play.play
-.. autoclass:: gymnasium.utils.play.PlayPlot
-    
-    .. automethod:: callback
-
-.. autoclass:: gymnasium.utils.play.PlayableGame
-    
-    .. automethod:: process_event
-```
-
-## Save Rendering Videos
-
-```{eval-rst}
-.. autofunction:: gymnasium.utils.save_video.save_video
-.. autofunction:: gymnasium.utils.save_video.capped_cubic_video_schedule
-```
-
-## Old to New Step API Compatibility
-
-```{eval-rst}
-.. autofunction:: gymnasium.utils.step_api_compatibility.step_api_compatibility
-.. autofunction:: gymnasium.utils.step_api_compatibility.convert_to_terminated_truncated_step_api
-.. autofunction:: gymnasium.utils.step_api_compatibility.convert_to_done_step_api
-```
-
 ## Seeding
 
 ```{eval-rst}
@@ -41,5 +13,35 @@ title: Utils
 ## Environment Checking
 
 ```{eval-rst}
-.. autofunction:: gymnasium.utils.env_checker.check_env
+.. autofunction:: gymnasium.utils.check_env
 ``` 
+
+## Visualization
+
+```{eval-rst}
+.. autofunction:: gymnasium.utils.play
+
+.. autoclass:: gymnasium.utils.PlayPlot
+    
+    .. automethod:: callback
+    
+.. autoclass:: gymnasium.utils.PlayableGame
+    
+    .. automethod:: process_event
+```
+
+## Save Rendering Videos
+
+```{eval-rst}
+.. autofunction:: gymnasium.utils.save_video
+.. autofunction:: gymnasium.utils.capped_cubic_video_schedule
+```
+
+## Done to Terminated / Truncated Step API Compatibility
+
+```{eval-rst}
+.. autofunction:: gymnasium.utils.step_api_compatibility
+.. autofunction:: gymnasium.utils.convert_to_terminated_truncated_step_api
+.. autofunction:: gymnasium.utils.convert_to_done_step_api
+```
+

--- a/gymnasium/utils/__init__.py
+++ b/gymnasium/utils/__init__.py
@@ -7,4 +7,12 @@ These are not intended as API functions, and will not remain stable over time.
 # We want this since we use `utils` during our import-time sanity checks
 # that verify that our dependencies are actually present.
 from gymnasium.utils.colorize import colorize
+from gymnasium.utils.env_checker import check_env
 from gymnasium.utils.ezpickle import EzPickle
+from gymnasium.utils.play import PlayableGame, PlayPlot, play
+from gymnasium.utils.save_video import capped_cubic_video_schedule, save_video
+from gymnasium.utils.step_api_compatibility import (
+    convert_to_done_step_api,
+    convert_to_terminated_truncated_step_api,
+    step_api_compatibility,
+)


### PR DESCRIPTION
`utils.__init__` has not been updated to include all of the new utils functions that users will commonly used.
Adding these functions to the `__init__` should make the imports shorter and easier to remember for users.
In addition, we can update the documentation to use these shorter links