### PR TITLE
Fix integer overflow in MultiDiscrete.flatten()

### DIFF
--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -150,7 +150,7 @@ def _flatten_discrete(space, x) -> np.ndarray:
 
 @flatten.register(MultiDiscrete)
 def _flatten_multidiscrete(space, x) -> np.ndarray:
-    offsets = np.zeros((space.nvec.size + 1,), dtype=space.dtype)
+    offsets = np.zeros((space.nvec.size + 1,), dtype=np.int32)
     offsets[1:] = np.cumsum(space.nvec.flatten())
 
     onehot = np.zeros((offsets[-1],), dtype=space.dtype)

--- a/tests/spaces/test_multidiscrete.py
+++ b/tests/spaces/test_multidiscrete.py
@@ -1,6 +1,7 @@
+import numpy as np
 import pytest
 
-from gymnasium.spaces import Discrete, MultiDiscrete
+from gymnasium.spaces import Discrete, MultiDiscrete, flatten, unflatten
 from gymnasium.utils.env_checker import data_equivalence
 
 
@@ -64,3 +65,14 @@ def test_multidiscrete_length():
         match="Getting the length of a multi-dimensional MultiDiscrete space.",
     ):
         assert len(space) == 2
+
+
+def test_multidiscrete_integer_overflow():
+    # Check if space can be flattened and unflattened without an integer overflow
+    space = MultiDiscrete(nvec=[101, 101, 101, 101], dtype=np.int8)
+    x = space.sample()
+    y = flatten(space, x)
+    z = unflatten(space, y)
+
+    assert len(z) == 4
+    assert np.array_equal(x, z)


### PR DESCRIPTION
# Description

Fixes integer overflow in the flatten function when dtype is small. 

The current code will calculate the offsets as is, overflowing the max integer value and going to negatives. Once this is passed to `one_hot` we get an error as per the linked issue.

```
File "C:\Users\user\Anaconda3\envs\TRG\lib\site-packages\gym\spaces\utils.py", line 90, in _flatten_multidiscrete
    onehot = np.zeros((offsets[-1],), dtype=space.dtype)
ValueError: negative dimensions are not allowed
```


## Fixes
#53 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test

```
import gym
import numpy as np

space = gym.spaces.MultiDiscrete([101, 101, 101, 101], dtype=np.int8)
x = space.sample()

y = gym.spaces.flatten(space, x)

x = gym.spaces.unflatten(space, y)

print(x)
```

```
[82 52 50 66]
```

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
