### PR TITLE
added instructions for mujoco v3 and older

### DIFF
--- a/docs/environments/mujoco.md
+++ b/docs/environments/mujoco.md
@@ -33,7 +33,9 @@ The unique dependencies for this set of environments can be installed via:
 pip install gymnasium[mujoco]
 ````
 
-These environments also require that the MuJoCo engine be installed. As of October 2021 DeepMind has acquired MuJoCo and is open-sourcing it in 2022, making it free for everyone. Instructions on installing the MuJoCo engine can be found on their [website](https://mujoco.org) and [GitHub repository](https://github.com/deepmind/mujoco). Using MuJoCo with Gymnasium also requires that the framework `mujoco-py` be installed, which can be found in the [GitHub repository](https://github.com/openai/mujoco-py/tree/master/mujoco_py) (this dependency is installed with the above command).
+These environments also require that the MuJoCo engine be installed. As of October 2021 DeepMind has acquired MuJoCo and is open-sourcing it in 2022, making it free for everyone. Instructions on installing the MuJoCo engine can be found on their [website](https://mujoco.org) and [GitHub repository](https://github.com/deepmind/mujoco). Using MuJoCo with Gymnasium also requires that the framework `mujoco` be installed (this dependency is installed with the above command)..
+
+For MuJoCo V3 enviroments and older the `mujoco-py` framework is required (`pip install mujoco-py`) which can be found in the [GitHub repository](https://github.com/openai/mujoco-py/tree/master/mujoco_py) 
 
 There are ten Mujoco environments: Ant, HalfCheetah, Hopper, Humanoid, HumanoidStandup, IvertedDoublePendulum, InvertedPendulum, Reacher, Swimmer, and Walker. All of these environments are stochastic in terms of their initial state, with a Gaussian noise added to a fixed initial state in order to add stochasticity. The state spaces for MuJoCo environments in Gymnasium consist of two parts that are flattened and concatenated together: a position of a body part ('*mujoco-py.mjsim.qpos*') or joint and its corresponding velocity ('*mujoco-py.mjsim.qvel*'). Often, some of the first positional elements are omitted from the state space since the reward is calculated based on their values, leaving it up to the algorithm to infer those hidden values indirectly.
 

--- a/docs/environments/mujoco.md
+++ b/docs/environments/mujoco.md
@@ -33,7 +33,7 @@ The unique dependencies for this set of environments can be installed via:
 pip install gymnasium[mujoco]
 ````
 
-These environments also require that the MuJoCo engine be installed. As of October 2021 DeepMind has acquired MuJoCo and is open-sourcing it in 2022, making it free for everyone. Instructions on installing the MuJoCo engine can be found on their [website](https://mujoco.org) and [GitHub repository](https://github.com/deepmind/mujoco). Using MuJoCo with Gymnasium also requires that the framework `mujoco` be installed (this dependency is installed with the above command)..
+These environments also require that the MuJoCo engine be installed. As of October 2021 DeepMind has acquired MuJoCo and is open-sourcing it in 2022, making it free for everyone. Instructions on installing the MuJoCo engine can be found on their [website](https://mujoco.org) and [GitHub repository](https://github.com/deepmind/mujoco). Using MuJoCo with Gymnasium also requires that the framework `mujoco` be installed (this dependency is installed with the above command).
 
 For MuJoCo V3 enviroments and older the `mujoco-py` framework is required (`pip install mujoco-py`) which can be found in the [GitHub repository](https://github.com/openai/mujoco-py/tree/master/mujoco_py) 
 


### PR DESCRIPTION
# Description

added instructions for MuJoCo v3 and older

source:
https://discord.com/channels/961771112864313344/961772009770074142/1032587824626675722

Fixes # (issue)
did not provide instructions for MuJoCo v3 and older
`pip install gymnasium[mujoco]` does not work for mujoco-v3

note: it might be a good idea to add something like `pip install gymnasium[mujoco-old]` that would install `mujoco-py` instead of `mujoco`

## Type of change

Doc Change

