### PR TITLE
Change seeding error message to report seed type

### DIFF
--- a/gymnasium/utils/seeding.py
+++ b/gymnasium/utils/seeding.py
@@ -19,7 +19,10 @@ def np_random(seed: Optional[int] = None) -> Tuple[np.random.Generator, Any]:
         Error: Seed must be a non-negative integer or omitted
     """
     if seed is not None and not (isinstance(seed, int) and 0 <= seed):
-        raise error.Error(f"Seed must be a non-negative integer or omitted, not {type(seed)} (got {seed})")
+        if isinstance(seed, int) is False: 
+            raise Error(f"Seed must be a python integer, actual type: {type(seed)}")
+        else:
+            raise Error(f"Seed must be greater or equal to zero, actual value: {seed}")
 
     seed_seq = np.random.SeedSequence(seed)
     np_seed = seed_seq.entropy

--- a/gymnasium/utils/seeding.py
+++ b/gymnasium/utils/seeding.py
@@ -19,10 +19,14 @@ def np_random(seed: Optional[int] = None) -> Tuple[np.random.Generator, Any]:
         Error: Seed must be a non-negative integer or omitted
     """
     if seed is not None and not (isinstance(seed, int) and 0 <= seed):
-        if isinstance(seed, int) is False: 
-            raise Error(f"Seed must be a python integer, actual type: {type(seed)}")
+        if isinstance(seed, int) is False:
+            raise error.Error(
+                f"Seed must be a python integer, actual type: {type(seed)}"
+            )
         else:
-            raise Error(f"Seed must be greater or equal to zero, actual value: {seed}")
+            raise error.Error(
+                f"Seed must be greater or equal to zero, actual value: {seed}"
+            )
 
     seed_seq = np.random.SeedSequence(seed)
     np_seed = seed_seq.entropy

--- a/gymnasium/utils/seeding.py
+++ b/gymnasium/utils/seeding.py
@@ -19,7 +19,7 @@ def np_random(seed: Optional[int] = None) -> Tuple[np.random.Generator, Any]:
         Error: Seed must be a non-negative integer or omitted
     """
     if seed is not None and not (isinstance(seed, int) and 0 <= seed):
-        raise error.Error(f"Seed must be a non-negative integer or omitted, not {seed}")
+        raise error.Error(f"Seed must be a non-negative integer or omitted, not {type(seed)} (got {seed})")
 
     seed_seq = np.random.SeedSequence(seed)
     np_seed = seed_seq.entropy


### PR DESCRIPTION
Identical changes to [pull request 3128 on OpenAI Gym repository](https://github.com/openai/gym/pull/3128).
Pull requested repeated here:

# Description
Changed error message produced when `seed` argument of `env.reset(seed=seed)` is the incorrect type to include the *type* of the incorrect seed rather than the *value*. This is in line with most other Python error messages.

Fixes #3127

## Type of change
Bug fix (non-breaking change which fixes an issue)

# Example
```
import numpy as np
import gym

rng = np.random.default_rng()
seed = rng.integers(2**32)

env = gym.make("MountainCarContinuous-v0")
env.reset(seed=seed)
```
| Before | After |
|----------|--------|
| `gym.error.Error: Seed must be a non-negative integer or omitted, not 1407292551` | `gym.error.Error: Seed must be a non-negative integer or omitted, not <class 'numpy.int64'> (got 1407292551)` |


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

**I have not followed the above checklist because I changed so little. Any problems with this PR exist externally in the openai/gym repo.**