### PR TITLE
Added Atari environments to tests, removed dead code

### DIFF
--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -148,15 +148,17 @@ def check_rendered(rendered_frame, mode: str):
         )
 
 
-non_mujoco_py_env_specs = [
+# We do not check render_mode for some mujoco envs and any old Gym environment wrapped by `GymEnvironment`
+render_mode_env_specs = [
     spec
     for spec in all_testing_env_specs
-    if "mujoco" not in spec.entry_point or "v4" in spec.id
+    if ("mujoco" not in spec.entry_point or "v4" in spec.id)
+    and ("GymEnvironment" not in spec.entry_point)
 ]
 
 
 @pytest.mark.parametrize(
-    "spec", non_mujoco_py_env_specs, ids=[spec.id for spec in non_mujoco_py_env_specs]
+    "spec", render_mode_env_specs, ids=[spec.id for spec in render_mode_env_specs]
 )
 def test_render_modes(spec):
     """There is a known issue where rendering a mujoco environment then mujoco-py will cause an error on non-mac based systems.

--- a/tests/envs/utils.py
+++ b/tests/envs/utils.py
@@ -33,7 +33,7 @@ all_testing_initialised_envs: List[Optional[gym.Env]] = [
 
 try:
     # We check whether gym can be imported
-    import gym as _  # noqa: F401
+    import gym as old_gym
 
     atari_ids = [
         "ALE/Pong-v5",
@@ -48,11 +48,12 @@ try:
     all_testing_initialised_envs += [
         gym.make("GymV26Environment-v0", env_id=env_id) for env_id in atari_ids
     ]
-except (ImportError, gym.error.DependencyNotInstalled, gym.error.NamespaceNotFound):
-    # Failure because gym or ale isn't available
-    logger.warn(
-        "Skipping tests of atari environments because gym[atari] appears to be missing"
-    )
+except ImportError:
+    # Failure because gym isn't available
+    logger.warn("Skipping tests of atari environments because gym seems to be missing")
+except (old_gym.error.DependencyNotInstalled, old_gym.error.NamespaceNotFound):
+    # Failure because ale isn't available
+    logger.warn("Skipping tests of atari environments because ALE seems to be missing")
 
 all_testing_initialised_envs: List[gym.Env] = [
     env for env in all_testing_initialised_envs if env is not None

--- a/tests/envs/utils.py
+++ b/tests/envs/utils.py
@@ -30,6 +30,30 @@ def try_make_env(env_spec: EnvSpec) -> Optional[gym.Env]:
 all_testing_initialised_envs: List[Optional[gym.Env]] = [
     try_make_env(env_spec) for env_spec in gym.envs.registry.values()
 ]
+
+try:
+    # We check whether gym can be imported
+    import gym as _  # noqa: F401
+
+    atari_ids = [
+        "ALE/Pong-v5",
+        "ALE/Pong-ram-v5",
+        "Pong-v4",
+        "PongDeterministic-v4",
+        "PongNoFrameskip-v4",
+        "Pong-ram-v4",
+        "Pong-ramDeterministic-v4",
+        "Pong-ramNoFrameskip-v4",
+    ]
+    all_testing_initialised_envs += [
+        gym.make("GymV26Environment-v0", env_id=env_id) for env_id in atari_ids
+    ]
+except (ImportError, gym.error.DependencyNotInstalled):
+    # Failure because gym or ale isn't available
+    logger.warn(
+        "Skipping tests of atari environments because gym[atari] appears to be missing"
+    )
+
 all_testing_initialised_envs: List[gym.Env] = [
     env for env in all_testing_initialised_envs if env is not None
 ]
@@ -52,19 +76,6 @@ gym_testing_env_specs: List[EnvSpec] = [
     )
 ]
 # TODO, add minimum testing env spec in testing
-minimum_testing_env_specs = [
-    env_spec
-    for env_spec in [
-        "CartPole-v1",
-        "MountainCarContinuous-v0",
-        "LunarLander-v2",
-        "LunarLanderContinuous-v2",
-        "CarRacing-v2",
-        "Blackjack-v1",
-        "Reacher-v4",
-    ]
-    if env_spec in all_testing_env_specs
-]
 
 
 def assert_equals(a, b, prefix=None):

--- a/tests/envs/utils.py
+++ b/tests/envs/utils.py
@@ -35,6 +35,7 @@ try:
     # We check whether gym can be imported
     import gym as old_gym
 
+    # We are testing all variations of Pong which are registered in (old) Gym
     atari_ids = [
         "ALE/Pong-v5",
         "ALE/Pong-ram-v5",

--- a/tests/envs/utils.py
+++ b/tests/envs/utils.py
@@ -48,7 +48,7 @@ try:
     all_testing_initialised_envs += [
         gym.make("GymV26Environment-v0", env_id=env_id) for env_id in atari_ids
     ]
-except (ImportError, gym.error.DependencyNotInstalled):
+except (ImportError, gym.error.DependencyNotInstalled, gym.error.NamespaceNotFound):
     # Failure because gym or ale isn't available
     logger.warn(
         "Skipping tests of atari environments because gym[atari] appears to be missing"


### PR DESCRIPTION
- Adds some atari environments to tested environments (if gym and ale are available)
- Removed definition of `minimum_testing_env_specs`, which was dead code, also didn't make sense (compared specs to strings, I think)
- Atari environments are currently not being tested for `render_mode` because `GymEnvironment` doesn't support that kwarg

Tests are currently not passing locally, which seems to be due to an unrelated problem