### PR TITLE
MujocoEnv: Include shape in error message

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -153,7 +153,9 @@ class BaseMujocoEnv(gym.Env):
         """
         # Check control input is contained in the action space
         if np.array(ctrl).shape != self.action_space.shape:
-            raise ValueError("Action dimension mismatch")
+            raise ValueError(
+                "Action dimension mismatch. Expected {self.action_space.shape}, found {np.array(ctrl).shape}"
+            )
         self._step_mujoco_simulation(ctrl, n_frames)
 
     def close(self):

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -154,7 +154,7 @@ class BaseMujocoEnv(gym.Env):
         # Check control input is contained in the action space
         if np.array(ctrl).shape != self.action_space.shape:
             raise ValueError(
-                "Action dimension mismatch. Expected {self.action_space.shape}, found {np.array(ctrl).shape}"
+                f"Action dimension mismatch. Expected {self.action_space.shape}, found {np.array(ctrl).shape}"
             )
         self._step_mujoco_simulation(ctrl, n_frames)
 


### PR DESCRIPTION
# Description

Current error message forces user to add extra debugging code for info that's already available

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

