### PR TITLE
Added atari tests to CI, fixed test_gym_conversion that was failing due to missing ROMs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,5 @@ reportPrivateUsage = "warning"
 reportUnboundVariable = "warning"
 
 [tool.pytest.ini_options]
+filterwarnings = ['ignore:.*The environment .* is out of date.*']
 # filterwarnings = ['ignore:.*step API.*:DeprecationWarning']

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras = {
 testing_group = set(extras.keys()) - {"accept-rom-license", "atari"}
 extras["testing"] = list(
     set(itertools.chain.from_iterable(map(lambda group: extras[group], testing_group)))
-) + ["pytest==7.1.3", "gym[testing, atari, accpet-rom-license]==0.26.2"]
+) + ["pytest==7.1.3", "gym[testing, atari, accept-rom-license]==0.26.2"]
 
 # All dependency groups - accept rom license as requires user to run
 all_groups = set(extras.keys()) - {"accept-rom-license"}

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,10 @@ extras = {
 testing_group = set(extras.keys()) - {"accept-rom-license", "atari"}
 extras["testing"] = list(
     set(itertools.chain.from_iterable(map(lambda group: extras[group], testing_group)))
-) + ["pytest==7.1.3", "gym[testing, atari, accept-rom-license]==0.26.2"]
+) + [
+    "pytest==7.1.3",
+    "gym[classic_control, mujoco_py, mujoco, toy_text, other, atari, accept-rom-license]==0.26.2",
+]
 
 # All dependency groups - accept rom license as requires user to run
 all_groups = set(extras.keys()) - {"accept-rom-license"}

--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,7 @@ extras = {
     "other": ["lz4>=3.1.0", "opencv-python>=3.0", "matplotlib>=3.0", "moviepy>=1.0.0"],
 }
 
-# Testing dependency groups.
-testing_group = set(extras.keys()) - {"accept-rom-license", "atari"}
-extras["testing"] = list(
-    set(itertools.chain.from_iterable(map(lambda group: extras[group], testing_group)))
-) + [
+extras["testing"] = list(set(itertools.chain.from_iterable(extras.values()))) + [
     "pytest==7.1.3",
     "gym[classic_control, mujoco_py, mujoco, toy_text, other, atari, accept-rom-license]==0.26.2",
 ]

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras = {
 testing_group = set(extras.keys()) - {"accept-rom-license", "atari"}
 extras["testing"] = list(
     set(itertools.chain.from_iterable(map(lambda group: extras[group], testing_group)))
-) + ["pytest==7.1.3", "gym==0.26.2"]
+) + ["pytest==7.1.3", "gym[testing, atari, accpet-rom-license]==0.26.2"]
 
 # All dependency groups - accept rom license as requires user to run
 all_groups = set(extras.keys()) - {"accept-rom-license"}

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -12,8 +12,6 @@ from tests.envs.utils import (
     all_testing_env_specs,
     all_testing_initialised_envs,
     assert_equals,
-    atari_env_specs,
-    atari_initialized_envs,
 )
 
 # This runs a smoketest on each official registered env. We may want
@@ -39,8 +37,8 @@ CHECK_ENV_IGNORE_WARNINGS = [
 
 @pytest.mark.parametrize(
     "spec",
-    all_testing_env_specs + atari_env_specs,
-    ids=[spec.id for spec in all_testing_env_specs + atari_env_specs],
+    all_testing_env_specs,
+    ids=[spec.id for spec in all_testing_env_specs],
 )
 def test_envs_pass_env_checker(spec):
     """Check that all environments pass the environment checker with no warnings other than the expected."""
@@ -63,8 +61,8 @@ NUM_STEPS = 50
 
 @pytest.mark.parametrize(
     "env_spec",
-    all_testing_env_specs + atari_env_specs,
-    ids=[env.id for env in all_testing_env_specs + atari_env_specs],
+    all_testing_env_specs,
+    ids=[env.id for env in all_testing_env_specs],
 )
 def test_env_determinism_rollout(env_spec: EnvSpec):
     """Run a rollout with two environments and assert equality.
@@ -193,8 +191,8 @@ def test_render_modes(spec):
 
 @pytest.mark.parametrize(
     "env",
-    all_testing_initialised_envs + atari_initialized_envs,
-    ids=[env.spec.id for env in all_testing_initialised_envs + atari_initialized_envs],
+    all_testing_initialised_envs,
+    ids=[env.spec.id for env in all_testing_initialised_envs],
 )
 def test_pickle_env(env: gym.Env):
     pickled_env = pickle.loads(pickle.dumps(env))

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -12,6 +12,8 @@ from tests.envs.utils import (
     all_testing_env_specs,
     all_testing_initialised_envs,
     assert_equals,
+    atari_env_specs,
+    atari_initialized_envs,
 )
 
 # This runs a smoketest on each official registered env. We may want
@@ -36,7 +38,9 @@ CHECK_ENV_IGNORE_WARNINGS = [
 
 
 @pytest.mark.parametrize(
-    "spec", all_testing_env_specs, ids=[spec.id for spec in all_testing_env_specs]
+    "spec",
+    all_testing_env_specs + atari_env_specs,
+    ids=[spec.id for spec in all_testing_env_specs + atari_env_specs],
 )
 def test_envs_pass_env_checker(spec):
     """Check that all environments pass the environment checker with no warnings other than the expected."""
@@ -58,7 +62,9 @@ NUM_STEPS = 50
 
 
 @pytest.mark.parametrize(
-    "env_spec", all_testing_env_specs, ids=[env.id for env in all_testing_env_specs]
+    "env_spec",
+    all_testing_env_specs + atari_env_specs,
+    ids=[env.id for env in all_testing_env_specs + atari_env_specs],
 )
 def test_env_determinism_rollout(env_spec: EnvSpec):
     """Run a rollout with two environments and assert equality.
@@ -152,8 +158,7 @@ def check_rendered(rendered_frame, mode: str):
 render_mode_env_specs = [
     spec
     for spec in all_testing_env_specs
-    if ("mujoco" not in spec.entry_point or "v4" in spec.id)
-    and ("GymEnvironment" not in spec.entry_point)
+    if "mujoco" not in spec.entry_point or "v4" in spec.id
 ]
 
 
@@ -188,8 +193,8 @@ def test_render_modes(spec):
 
 @pytest.mark.parametrize(
     "env",
-    all_testing_initialised_envs,
-    ids=[env.spec.id for env in all_testing_initialised_envs],
+    all_testing_initialised_envs + atari_initialized_envs,
+    ids=[env.spec.id for env in all_testing_initialised_envs + atari_initialized_envs],
 )
 def test_pickle_env(env: gym.Env):
     pickled_env = pickle.loads(pickle.dumps(env))

--- a/tests/envs/test_gym_conversion.py
+++ b/tests/envs/test_gym_conversion.py
@@ -7,7 +7,12 @@ pytest.importorskip("gym")
 
 import gym  # noqa: E402, isort: skip
 
-ALL_GYM_ENVS = gym.envs.registry.keys()
+# We do not test Atari environment's here because we check all variants of Pong in test_envs.py (There are too many Atari environments)
+ALL_GYM_ENVS = [
+    env_id
+    for env_id, spec in gym.envs.registry.items()
+    if "ale_py" not in spec.entry_point
+]
 
 
 @pytest.mark.parametrize(

--- a/tests/envs/test_gym_conversion.py
+++ b/tests/envs/test_gym_conversion.py
@@ -14,7 +14,7 @@ import gym  # noqa: E402, isort: skip
 ALL_GYM_ENVS = [
     env_id
     for env_id, spec in gym.envs.registry.items()
-    if "ale_py" not in spec.entry_point
+    if ("ale_py" not in spec.entry_point or "Pong" in env_id)
 ]
 
 

--- a/tests/envs/test_gym_conversion.py
+++ b/tests/envs/test_gym_conversion.py
@@ -1,7 +1,10 @@
+import warnings
+
 import pytest
 
 import gymnasium
 from gymnasium.utils.env_checker import check_env
+from tests.envs.test_envs import CHECK_ENV_IGNORE_WARNINGS
 
 pytest.importorskip("gym")
 
@@ -19,8 +22,12 @@ ALL_GYM_ENVS = [
     "env_id", ALL_GYM_ENVS, ids=[env_id for env_id in ALL_GYM_ENVS]
 )
 def test_gym_conversion_by_id(env_id):
-    env = gymnasium.make("GymV26Environment-v0", env_id=env_id)
-    check_env(env)
+    env = gymnasium.make("GymV26Environment-v0", env_id=env_id).unwrapped
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        check_env(env)
+    for warning in caught_warnings:
+        if warning.message.args[0] not in CHECK_ENV_IGNORE_WARNINGS:
+            raise gym.error.Error(f"Unexpected warning: {warning.message}")
 
 
 @pytest.mark.parametrize(
@@ -28,5 +35,9 @@ def test_gym_conversion_by_id(env_id):
 )
 def test_gym_conversion_instantiated(env_id):
     env = gym.make(env_id)
-    env = gymnasium.make("GymV26Environment-v0", env=env)
-    check_env(env)
+    env = gymnasium.make("GymV26Environment-v0", env=env).unwrapped
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        check_env(env)
+    for warning in caught_warnings:
+        if warning.message.args[0] not in CHECK_ENV_IGNORE_WARNINGS:
+            raise gym.error.Error(f"Unexpected warning: {warning.message}")

--- a/tests/envs/utils.py
+++ b/tests/envs/utils.py
@@ -31,6 +31,8 @@ all_testing_initialised_envs: List[Optional[gym.Env]] = [
     try_make_env(env_spec) for env_spec in gym.envs.registry.values()
 ]
 
+atari_initialized_envs = []
+atari_initialized_env_specs = []
 try:
     # We check whether gym can be imported
     import gym as old_gym
@@ -46,9 +48,10 @@ try:
         "Pong-ramDeterministic-v4",
         "Pong-ramNoFrameskip-v4",
     ]
-    all_testing_initialised_envs += [
+    atari_initialized_envs = [
         gym.make("GymV26Environment-v0", env_id=env_id) for env_id in atari_ids
     ]
+    atari_env_specs = [env.spec for env in atari_initialized_envs]
 except ImportError:
     # Failure because gym isn't available
     logger.warn("Skipping tests of atari environments because gym seems to be missing")

--- a/tests/envs/utils.py
+++ b/tests/envs/utils.py
@@ -30,35 +30,6 @@ def try_make_env(env_spec: EnvSpec) -> Optional[gym.Env]:
 all_testing_initialised_envs: List[Optional[gym.Env]] = [
     try_make_env(env_spec) for env_spec in gym.envs.registry.values()
 ]
-
-atari_initialized_envs = []
-atari_initialized_env_specs = []
-try:
-    # We check whether gym can be imported
-    import gym as old_gym
-
-    # We are testing all variations of Pong which are registered in (old) Gym
-    atari_ids = [
-        "ALE/Pong-v5",
-        "ALE/Pong-ram-v5",
-        "Pong-v4",
-        "PongDeterministic-v4",
-        "PongNoFrameskip-v4",
-        "Pong-ram-v4",
-        "Pong-ramDeterministic-v4",
-        "Pong-ramNoFrameskip-v4",
-    ]
-    atari_initialized_envs = [
-        gym.make("GymV26Environment-v0", env_id=env_id) for env_id in atari_ids
-    ]
-    atari_env_specs = [env.spec for env in atari_initialized_envs]
-except ImportError:
-    # Failure because gym isn't available
-    logger.warn("Skipping tests of atari environments because gym seems to be missing")
-except (old_gym.error.DependencyNotInstalled, old_gym.error.NamespaceNotFound):
-    # Failure because ale isn't available
-    logger.warn("Skipping tests of atari environments because ALE seems to be missing")
-
 all_testing_initialised_envs: List[gym.Env] = [
     env for env in all_testing_initialised_envs if env is not None
 ]


### PR DESCRIPTION
We add `gym[testing, atari, accept-rom-license]` to the testing requirements to make `test_gym_conversion` and Atari tests run in CI.