### PR TITLE
EnvPool's Async API

### DIFF
--- a/a.py
+++ b/a.py
@@ -1,0 +1,40 @@
+import gymnasium
+import gym
+import time
+import numpy as np
+num_steps = 1000
+batch_size = 4
+num_envs = 8
+
+def make_env():
+    env = gym.make("ALE/Pong-v5")
+    env.observation_space = gymnasium.spaces.Box(low=0, high=255, shape=(210, 160, 3), dtype=np.uint8)
+    env.action_space = gymnasium.spaces.Discrete(6)
+    return env
+
+
+envs = gymnasium.vector.AsyncVectorEnv(
+    [make_env for _ in range(num_envs)],
+    batch_size=batch_size
+)
+start_time = time.time()
+for i in range(num_steps * (num_envs // batch_size)):
+    if i == 0:
+        envs.reset_async()
+    obs, rewards, terminateds, truncateds, infos = envs.recv()
+    # print(obs.shape, infos)
+    envs.send(np.random.randint(envs.single_action_space.n, size=batch_size), infos["env_ids"])
+end_time = time.time()
+print("======Time taken: ", end_time - start_time)
+
+
+envs = gymnasium.vector.AsyncVectorEnv(
+    [make_env for _ in range(num_envs)],
+)
+start_time = time.time()
+for i in range(num_steps):
+    if i == 0:
+        envs.reset()
+    envs.step(np.random.randint(envs.single_action_space.n, size=num_envs))
+end_time = time.time()
+print("======Time taken: ", end_time - start_time)

--- a/a.py
+++ b/a.py
@@ -3,8 +3,8 @@ import gym
 import time
 import numpy as np
 num_steps = 1000
-batch_size = 4
-num_envs = 8
+batch_size = 16
+num_envs = 64
 
 def make_env():
     env = gym.make("ALE/Pong-v5")

--- a/t.py
+++ b/t.py
@@ -1,0 +1,34 @@
+import gymnasium
+import time
+import numpy as np
+num_steps = 100
+batch_size = 16
+num_envs = 64
+
+
+envs = gymnasium.vector.AsyncVectorEnv(
+    [lambda: gymnasium.make("MountainCar-v0") for _ in range(num_envs)],
+    batch_size=batch_size
+)
+start_time = time.time()
+for i in range(num_steps * (num_envs // batch_size)):
+    if i == 0:
+        envs.reset_async()
+    obs, rewards, terminateds, truncateds, infos = envs.recv()
+    print(obs, infos)
+    raise
+    envs.send(np.random.randint(envs.single_action_space.n, size=batch_size), infos["env_ids"])
+end_time = time.time()
+print("Time taken: ", end_time - start_time)
+
+
+envs = gymnasium.vector.AsyncVectorEnv(
+    [lambda: gymnasium.make("MountainCar-v0") for _ in range(num_envs)],
+)
+start_time = time.time()
+for i in range(num_steps):
+    if i == 0:
+        envs.reset()
+    envs.step(np.random.randint(envs.single_action_space.n, size=num_envs))
+end_time = time.time()
+print("Time taken: ", end_time - start_time)

--- a/t.py
+++ b/t.py
@@ -7,7 +7,7 @@ num_envs = 64
 
 
 envs = gymnasium.vector.AsyncVectorEnv(
-    [lambda: gymnasium.make("MountainCar-v0") for _ in range(num_envs)],
+    [lambda: gymnasium.make("CartPole-v1") for _ in range(num_envs)],
     batch_size=batch_size
 )
 start_time = time.time()
@@ -23,7 +23,7 @@ print("Time taken: ", end_time - start_time)
 
 
 envs = gymnasium.vector.AsyncVectorEnv(
-    [lambda: gymnasium.make("MountainCar-v0") for _ in range(num_envs)],
+    [lambda: gymnasium.make("CartPole-v1") for _ in range(num_envs)],
 )
 start_time = time.time()
 for i in range(num_steps):


### PR DESCRIPTION
# Description

This PR prototypes an async API like EnvPool, which looks like

```python
import gymnasium
import time
import numpy as np
batch_size = 8
num_envs = 16

envs = gymnasium.vector.AsyncVectorEnv(
    [lambda: gymnasium.make("CartPole-v1") for _ in range(num_envs)],
    batch_size=batch_size
)
start_time = time.time()
envs.reset_async()
obs, rewards, terminateds, truncateds, infos = envs.recv()
print(obs.shape, infos)
envs.send(np.random.randint(envs.single_action_space.n, size=batch_size), infos["env_ids"])
obs, rewards, terminateds, truncateds, infos = envs.recv()
print(obs.shape, infos)
envs.send(np.random.randint(envs.single_action_space.n, size=batch_size), infos["env_ids"])
obs, rewards, terminateds, truncateds, infos = envs.recv()
print(obs.shape, infos)
envs.send(np.random.randint(envs.single_action_space.n, size=batch_size), infos["env_ids"])
```
```
(8, 4) {'env_ids': array([1, 3, 8, 2, 5, 4, 7, 0])}
(8, 4) {'env_ids': array([11, 10,  6,  9, 13, 12,  1, 14])}
(8, 4) {'env_ids': array([ 8,  2,  3,  5,  7,  4,  0, 15])}
```


Preliminary tests show that this API can provide further speed up. E.g., when using `num_envs=64` and `batch_size=16`, this new async API offers a 2x speed improvement compared to regular Async mode. Further optimizations should be possible, too, but this PR mainly points out a proof-of-concept

https://github.com/vwxyzjn/Gymnasium/blob/9259d296d2097671a5f793bdb5164dd649c43b4a/a.py



Related to #93 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
