### PR TITLE
Re-add timelimit truncation information

### DIFF
--- a/gymnasium/wrappers/time_limit.py
+++ b/gymnasium/wrappers/time_limit.py
@@ -53,6 +53,8 @@ class TimeLimit(gym.Wrapper):
         if self._elapsed_steps >= self._max_episode_steps:
             truncated = True
             # Store the info that time limit was reached
+            # Note: in gym 0.21, truncated=False
+            # if the episode was already terminated
             info["TimeLimit.truncated"] = True
 
         return observation, reward, terminated, truncated, info

--- a/gymnasium/wrappers/time_limit.py
+++ b/gymnasium/wrappers/time_limit.py
@@ -52,6 +52,8 @@ class TimeLimit(gym.Wrapper):
 
         if self._elapsed_steps >= self._max_episode_steps:
             truncated = True
+            # Store the info that time limit was reached
+            info["TimeLimit.truncated"] = True
 
         return observation, reward, terminated, truncated, info
 

--- a/tests/wrappers/test_time_limit.py
+++ b/tests/wrappers/test_time_limit.py
@@ -33,6 +33,8 @@ def test_time_limit_wrapper(double_wrap):
 
     assert n_steps == max_episode_length
     assert truncated
+    assert "TimeLimit.truncated" in info
+    assert info["TimeLimit.truncated"] is True
 
 
 @pytest.mark.parametrize("double_wrap", [False, True])
@@ -52,6 +54,8 @@ def test_termination_on_last_step(double_wrap):
     if double_wrap:
         env = TimeLimit(env, max_episode_length)
     env.reset()
-    _, _, terminated, truncated, _ = env.step(env.action_space.sample())
+    _, _, terminated, truncated, info = env.step(env.action_space.sample())
     assert terminated is True
     assert truncated is True
+    assert "TimeLimit.truncated" in info
+    assert info["TimeLimit.truncated"] is True


### PR DESCRIPTION
# Description

Partial fix of https://github.com/openai/gym/issues/3102
Migration guide and release notes still need to be updated.

In gym 0.21, there was a key in the info dict that gave the information that truncation was due to timelimit.
This information is lost in gym 0.26 (causing failure in https://github.com/DLR-RM/rl-baselines3-zoo/pull/256 for instance).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

