### PR TITLE
Support list of options in VectorEnv.reset().

### DIFF
--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -1,5 +1,5 @@
 """Base class for vectorized environments."""
-from typing import TYPE_CHECKING, Generic, List, Optional, Tuple, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, Generic, Optional, Tuple, TypeVar
 
 import numpy as np
 
@@ -68,20 +68,19 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
             num_envs: Number of environments in the vectorized environment.
         """
         self.is_vector_env = True
-
         self.closed = False
 
     def reset(
         self,
         *,
-        seed: Optional[Union[int, List[int]]] = None,
-        options: Optional[dict] = None,
+        seed: Optional[int] = None,
+        options: Optional[Dict[str, Any]] = None,
     ) -> Tuple[ObsType, dict]:  # type: ignore
         """Reset all parallel environments and return a batch of initial observations and info.
 
         Args:
-            seed: The environment reset seeds
-            options: If to return the options
+            seed: The environment reset seed
+            options: Option information for the environment reset
 
         Returns:
             A batch of observations and info from the vectorized environment.


### PR DESCRIPTION
# Description

Following a [discussion on Discord](https://discord.com/channels/961771112864313344/1029089576398114846/1037714004040237117), this PR changes `VectorEnv.reset(...)` to accept a list of options similar to seeds, i.e. one options dict per sub env. This is also mentioned in issue #32.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
