### PR TITLE
Remove Mujoco rendering import

### DIFF
--- a/gymnasium/envs/mujoco/__init__.py
+++ b/gymnasium/envs/mujoco/__init__.py
@@ -1,8 +1,4 @@
 from gymnasium.envs.mujoco.mujoco_env import MujocoEnv, MuJocoPyEnv  # isort:skip
-from gymnasium.envs.mujoco.mujoco_rendering import (  # isort:skip
-    RenderContextOffscreen,
-    Viewer,
-)
 
 # ^^^^^ so that user gets the correct error
 # message if mujoco is not installed correctly


### PR DESCRIPTION
# Description

Fixes #103 
The module import `__init__.py` for the mujoco environments imported the `mujoco_rendering.py` classes, which depend on the `mujoco` package. If only installing the `mujoco_py`environment dependencies  with `pip install gymnasium[mujoco_py]` , thie rendering module shouldn't be imported because ModuleNotFoundError for "mujoco" will be raised.
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots
Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
