### PR TITLE
Added testing for render return

### DIFF
--- a/gymnasium/envs/box2d/car_racing.py
+++ b/gymnasium/envs/box2d/car_racing.py
@@ -632,8 +632,7 @@ class CarRacing(gym.Env, EzPickle):
             self.screen.fill(0)
             self.screen.blit(self.surf, (0, 0))
             pygame.display.flip()
-
-        if mode == "rgb_array":
+        elif mode == "rgb_array":
             return self._create_image_array(self.surf, (VIDEO_W, VIDEO_H))
         elif mode == "state_pixels":
             return self._create_image_array(self.surf, (STATE_W, STATE_H))

--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -307,4 +307,7 @@ def check_env(env: gym.Env, warn: bool = None, skip_render_check: bool = False):
         if env.render_mode is not None:
             env_render_passive_checker(env)
 
-        # todo: recreate the environment with a different render_mode for check that each work
+        for render_mode in env.metadata["render_modes"]:
+            new_env = env.spec.make(render_mode=render_mode)
+            new_env.reset()
+            env_render_passive_checker(new_env)

--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -311,3 +311,4 @@ def check_env(env: gym.Env, warn: bool = None, skip_render_check: bool = False):
             new_env = env.spec.make(render_mode=render_mode)
             new_env.reset()
             env_render_passive_checker(new_env)
+            new_env.close()

--- a/gymnasium/utils/passive_env_checker.py
+++ b/gymnasium/utils/passive_env_checker.py
@@ -267,7 +267,6 @@ def env_step_passive_checker(env, action):
 
 def _check_render_return(render_mode, render_return):
     """Produces warning if `render_return` doesn't match `render_mode`."""
-    # This many if statements are ugly, but we need it for short-circuiting in the rgb_array case (dict approach become difficult here)
     if render_mode == "human":
         if render_return is not None:
             logger.warn(
@@ -278,22 +277,19 @@ def _check_render_return(render_mode, render_return):
             logger.warn(
                 f"RGB-array rendering should return a numpy array, got {type(render_return)}"
             )
-        if isinstance(render_return, np.ndarray) and render_return.dtype != np.uint8:
-            logger.warn(
-                f"RGB-array rendering should return a numpy array with dtype uint8, got {render_return.dtype}"
-            )
-        if isinstance(render_return, np.ndarray) and render_return.ndim != 3:
-            logger.warn(
-                f"RGB-array rendering should return a numpy array with three axes, got {render_return.ndim}"
-            )
-        if (
-            isinstance(render_return, np.ndarray)
-            and render_return.ndim == 3
-            and render_return.shape[2] != 3
-        ):
-            logger.warn(
-                f"RGB-array rendering should return a numpy array in which the last axis has three dimensions, got {render_return.shape[2]}"
-            )
+        else:
+            if render_return.dtype != np.uint8:
+                logger.warn(
+                    f"RGB-array rendering should return a numpy array with dtype uint8, got {render_return.dtype}"
+                )
+            if render_return.ndim != 3:
+                logger.warn(
+                    f"RGB-array rendering should return a numpy array with three axes, got {render_return.ndim}"
+                )
+            if render_return.ndim == 3 and render_return.shape[2] != 3:
+                logger.warn(
+                    f"RGB-array rendering should return a numpy array in which the last axis has three dimensions, got {render_return.shape[2]}"
+                )
     elif render_mode == "depth_array":
         if not isinstance(render_return, np.ndarray):
             logger.warn(

--- a/gymnasium/utils/passive_env_checker.py
+++ b/gymnasium/utils/passive_env_checker.py
@@ -265,6 +265,48 @@ def env_step_passive_checker(env, action):
     return result
 
 
+def _check_render_return(render_mode, render_return):
+    """Produces warning if `render_return` doesn't match `render_mode`."""
+    # This many if statements are ugly, but we need it for short-circuiting in the rgb_array case (dict approach become difficult here)
+    if render_mode == "human" and render_return is not None:
+        logger.warn(f"Human rendering should return `None`, got {type(render_return)}")
+    if render_mode == "rgb_array":
+        if not isinstance(render_return, np.ndarray):
+            logger.warn(
+                f"RGB-array rendering should return a numpy array, got {type(render_return)}"
+            )
+        if isinstance(render_return, np.ndarray) and render_return.dtype != np.uint8:
+            logger.warn(
+                f"RGB-array rendering should return a numpy array with dtype uint8, got {render_return.dtype}"
+            )
+        if isinstance(render_return, np.ndarray) and render_return.ndim != 3:
+            logger.warn(
+                f"RGB-array rendering should return a numpy array with three axes, got {render_return.ndim}"
+            )
+        if (
+            isinstance(render_return, np.ndarray)
+            and render_return.ndim == 3
+            and render_return.shape[2] != 3
+        ):
+            logger.warn(
+                f"RGB-array rendering should return a numpy array in which the last axis has three dimensions, got {render_return.shape[2]}"
+            )
+    if render_mode == "ansi" and not isinstance(render_return, str):
+        logger.warn(
+            f"ANSI rendering should produce a string, got {type(render_return)}"
+        )
+    if render_mode.endswith("_list"):
+        if not isinstance(render_return, list):
+            logger.warn(
+                f"Render mode `{render_mode}` should produce a list, got {type(render_return)}"
+            )
+        else:
+            base_render_mode = render_mode[: -len("_list")]
+            [
+                _check_render_return(base_render_mode, item) for item in render_return
+            ]  # Check that each item of the list matches the base render mode
+
+
 def env_render_passive_checker(env, *args, **kwargs):
     """A passive check of the `Env.render` that the declared render modes/fps in the metadata of the environment is declared."""
     render_modes = env.metadata.get("render_modes")
@@ -314,7 +356,7 @@ def env_render_passive_checker(env, *args, **kwargs):
             )
 
     result = env.render(*args, **kwargs)
-
-    # TODO: Check that the result is correct
+    if env.render_mode is not None:
+        _check_render_return(env.render_mode, result)
 
     return result

--- a/tests/envs/test_gym_conversion.py
+++ b/tests/envs/test_gym_conversion.py
@@ -24,7 +24,7 @@ ALL_GYM_ENVS = [
 def test_gym_conversion_by_id(env_id):
     env = gymnasium.make("GymV26Environment-v0", env_id=env_id).unwrapped
     with warnings.catch_warnings(record=True) as caught_warnings:
-        check_env(env)
+        check_env(env, skip_render_check=True)
     for warning in caught_warnings:
         if warning.message.args[0] not in CHECK_ENV_IGNORE_WARNINGS:
             raise gym.error.Error(f"Unexpected warning: {warning.message}")
@@ -37,7 +37,7 @@ def test_gym_conversion_instantiated(env_id):
     env = gym.make(env_id)
     env = gymnasium.make("GymV26Environment-v0", env=env).unwrapped
     with warnings.catch_warnings(record=True) as caught_warnings:
-        check_env(env)
+        check_env(env, skip_render_check=True)
     for warning in caught_warnings:
         if warning.message.args[0] not in CHECK_ENV_IGNORE_WARNINGS:
             raise gym.error.Error(f"Unexpected warning: {warning.message}")

--- a/tests/testing_env.py
+++ b/tests/testing_env.py
@@ -46,11 +46,11 @@ class GenericTestEnv(gym.Env):
         reset_fn: callable = basic_reset_fn,
         step_fn: callable = new_step_fn,
         render_fn: callable = basic_render_fn,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: Dict[str, Any] = {"render_modes": []},
         render_mode: Optional[str] = None,
         spec: EnvSpec = EnvSpec("TestingEnv-v0", "testing-env-no-entry-point"),
     ):
-        self.metadata = {} if metadata is None else metadata
+        self.metadata = metadata
         self.render_mode = render_mode
         self.spec = spec
 


### PR DESCRIPTION
Implements #79 

Some tests are still failing due to incomplete testing environments.

The `_check_render_return` function is very ugly but I don't think there is a much better way. Typically, we would use dicts for something like this, but for rgb_array we need short-circuiting to check the structure of the returned array without raising exceptions if it is unexpected.
