### PR TITLE
Fixed render bug in RecordVideo wrapper

### DIFF
--- a/gymnasium/wrappers/monitoring/video_recorder.py
+++ b/gymnasium/wrappers/monitoring/video_recorder.py
@@ -54,7 +54,6 @@ class VideoRecorder:
         self._closed = False
 
         self.render_history = []
-        self.last_frame = None
         self.env = env
 
         self.render_mode = env.render_mode
@@ -116,7 +115,6 @@ class VideoRecorder:
         if isinstance(frame, List):
             self.render_history += frame
             frame = frame[-1]
-        self.last_frame = frame
 
         if not self.functional:
             return

--- a/gymnasium/wrappers/monitoring/video_recorder.py
+++ b/gymnasium/wrappers/monitoring/video_recorder.py
@@ -59,10 +59,7 @@ class VideoRecorder:
 
         self.render_mode = env.render_mode
 
-        if (
-            "rgb_array_list" != self.render_mode
-            and "rgb_array" != self.render_mode
-        ):
+        if "rgb_array_list" != self.render_mode and "rgb_array" != self.render_mode:
             logger.warn(
                 f"Disabling video recorder because environment {env} was not initialized with any compatible video "
                 "mode between `rgb_array` and `rgb_array_list`"
@@ -75,9 +72,7 @@ class VideoRecorder:
             return
 
         if path is not None and base_path is not None:
-            raise error.Error(
-                "You can pass at most one of `path` or `base_path`."
-            )
+            raise error.Error("You can pass at most one of `path` or `base_path`.")
 
         required_ext = ".mp4"
         if path is None:
@@ -157,17 +152,13 @@ class VideoRecorder:
         # Close the encoder
         if len(self.recorded_frames) > 0:
             try:
-                from moviepy.video.io.ImageSequenceClip import (
-                    ImageSequenceClip,
-                )
+                from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
             except ImportError:
                 raise error.DependencyNotInstalled(
                     "MoviePy is not installed, run `pip install moviepy`"
                 )
 
-            clip = ImageSequenceClip(
-                self.recorded_frames, fps=self.frames_per_sec
-            )
+            clip = ImageSequenceClip(self.recorded_frames, fps=self.frames_per_sec)
             moviepy_logger = None if self.disable_logger else "bar"
             clip.write_videofile(self.path, logger=moviepy_logger)
         else:

--- a/gymnasium/wrappers/monitoring/video_recorder.py
+++ b/gymnasium/wrappers/monitoring/video_recorder.py
@@ -54,11 +54,15 @@ class VideoRecorder:
         self._closed = False
 
         self.render_history = []
+        self.last_frame = None
         self.env = env
 
         self.render_mode = env.render_mode
 
-        if "rgb_array_list" != self.render_mode and "rgb_array" != self.render_mode:
+        if (
+            "rgb_array_list" != self.render_mode
+            and "rgb_array" != self.render_mode
+        ):
             logger.warn(
                 f"Disabling video recorder because environment {env} was not initialized with any compatible video "
                 "mode between `rgb_array` and `rgb_array_list`"
@@ -71,7 +75,9 @@ class VideoRecorder:
             return
 
         if path is not None and base_path is not None:
-            raise error.Error("You can pass at most one of `path` or `base_path`.")
+            raise error.Error(
+                "You can pass at most one of `path` or `base_path`."
+            )
 
         required_ext = ".mp4"
         if path is None:
@@ -115,6 +121,7 @@ class VideoRecorder:
         if isinstance(frame, List):
             self.render_history += frame
             frame = frame[-1]
+        self.last_frame = frame
 
         if not self.functional:
             return
@@ -150,13 +157,17 @@ class VideoRecorder:
         # Close the encoder
         if len(self.recorded_frames) > 0:
             try:
-                from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
+                from moviepy.video.io.ImageSequenceClip import (
+                    ImageSequenceClip,
+                )
             except ImportError:
                 raise error.DependencyNotInstalled(
                     "MoviePy is not installed, run `pip install moviepy`"
                 )
 
-            clip = ImageSequenceClip(self.recorded_frames, fps=self.frames_per_sec)
+            clip = ImageSequenceClip(
+                self.recorded_frames, fps=self.frames_per_sec
+            )
             moviepy_logger = None if self.disable_logger else "bar"
             clip.write_videofile(self.path, logger=moviepy_logger)
         else:

--- a/gymnasium/wrappers/record_video.py
+++ b/gymnasium/wrappers/record_video.py
@@ -201,10 +201,7 @@ class RecordVideo(gym.Wrapper):
             else:
                 return recorded_frames + super().render(*args, **kwargs)
         else:
-            if self.recording:
-                return self.video_recorder.last_frame
-            else:
-                return super().render(*args, **kwargs)
+            return super().render(*args, **kwargs)
 
     def close(self):
         """Closes the wrapper then the video recorder."""


### PR DESCRIPTION
# Description

Fixed a bug where the `RecordVideo` wrapper was trying to retrieve the non-existing attribute `last_frame` from `VideoRecorder` causing recordings to fail. This pull request reintroduces the `last_frame` attribute resolving the issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
