### PR TITLE
Fix `__all__` in root `__init__.py`

### DIFF
--- a/gymnasium/__init__.py
+++ b/gymnasium/__init__.py
@@ -10,7 +10,8 @@ from gymnasium.core import (
 )
 from gymnasium.spaces.space import Space
 from gymnasium.envs.registration import make, spec, register, registry
-from gymnasium import logger, vector, wrappers, error
+from gymnasium import envs, spaces, utils, vector, wrappers, error, logger
+
 import os
 import sys
 
@@ -28,10 +29,13 @@ __all__ = [
     "register",
     "registry",
     # root files
-    "error",
-    "logger",
+    "envs",
+    "spaces",
+    "utils",
     "vector",
     "wrappers",
+    "error",
+    "logger",
 ]
 __version__ = "0.26.3"
 

--- a/gymnasium/__init__.py
+++ b/gymnasium/__init__.py
@@ -1,24 +1,38 @@
-"""Root __init__ of the gymnasium module setting the __all__ of gymnasium modules."""
-# isort: skip_file
+"""Root `__init__` of the gymnasium module setting the `__all__` of gymnasium modules."""
 
-from gymnasium import error
-
-from gymnasium.core import (
-    Env,
-    Wrapper,
-    ObservationWrapper,
-    ActionWrapper,
-    RewardWrapper,
-)
-from gymnasium.spaces import Space
-from gymnasium.envs import make, spec, register
-from gymnasium import logger
-from gymnasium import vector
-from gymnasium import wrappers
 import os
 import sys
 
-__all__ = ["Env", "Space", "Wrapper", "make", "spec", "register"]
+from gymnasium import error, logger, vector, wrappers
+from gymnasium.core import (
+    ActionWrapper,
+    Env,
+    ObservationWrapper,
+    RewardWrapper,
+    Wrapper,
+)
+from gymnasium.envs.registration import make, register, registry, spec
+from gymnasium.spaces.space import Space
+
+__all__ = [
+    # core classes
+    "Env",
+    "Wrapper",
+    "ObservationWrapper",
+    "ActionWrapper",
+    "RewardWrapper",
+    "Space",
+    # registration
+    "make",
+    "spec",
+    "register",
+    "registry",
+    # root files
+    "error",
+    "logger",
+    "vector",
+    "wrappers",
+]
 __version__ = "0.26.3"
 
 # Initializing pygame initializes audio connections through SDL. SDL uses alsa by default on all Linux systems
@@ -38,6 +52,5 @@ try:
     notice = notices.notices.get(__version__)
     if notice:
         print(notice, file=sys.stderr)
-
 except Exception:  # nosec
     pass

--- a/gymnasium/__init__.py
+++ b/gymnasium/__init__.py
@@ -1,18 +1,18 @@
 """Root `__init__` of the gymnasium module setting the `__all__` of gymnasium modules."""
+# isort: skip_file
 
+from gymnasium.core import (
+    Env,
+    Wrapper,
+    ObservationWrapper,
+    ActionWrapper,
+    RewardWrapper,
+)
+from gymnasium.spaces.space import Space
+from gymnasium.envs.registration import make, spec, register, registry
+from gymnasium import logger, vector, wrappers, error
 import os
 import sys
-
-from gymnasium import error, logger, vector, wrappers
-from gymnasium.core import (
-    ActionWrapper,
-    Env,
-    ObservationWrapper,
-    RewardWrapper,
-    Wrapper,
-)
-from gymnasium.envs.registration import make, register, registry, spec
-from gymnasium.spaces.space import Space
 
 __all__ = [
     # core classes

--- a/gymnasium/spaces/__init__.py
+++ b/gymnasium/spaces/__init__.py
@@ -21,17 +21,21 @@ from gymnasium.spaces.tuple import Tuple
 from gymnasium.spaces.utils import flatdim, flatten, flatten_space, unflatten
 
 __all__ = [
+    # base space
     "Space",
+    # fundamental spaces
     "Box",
     "Discrete",
     "Text",
-    "Graph",
-    "GraphInstance",
     "MultiDiscrete",
     "MultiBinary",
+    # composite spaces
+    "Graph",
+    "GraphInstance",
     "Tuple",
     "Sequence",
     "Dict",
+    # util functions (there are more utility functions in vector/utils/spaces.py)
     "flatdim",
     "flatten_space",
     "flatten",


### PR DESCRIPTION
Pyright complains that `gym.wrappers` is a private import, the reason for this is that `wrappers` is not included in the root `__init__.py`'s `__all__`.
In this PR, I have updated the `__all__` to include all of the imported items in the `__init__.py`

In addition, this PR adds the registry to the `__all__` like `make`, `register` and `spec`. We might want to think about making it a property to avoid users writing over environment specs 