### PR TITLE
Switch flake8 from gitlab to github

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: codespell
         args:
           - --ignore-words-list=nd,reacher,thist,ths, ure, referenc,wile
-  - repo: https://gitlab.com/PyCQA/flake8
+  - repo: https://gitlab.com/PyCQA/flake8 
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: codespell
         args:
           - --ignore-words-list=nd,reacher,thist,ths, ure, referenc,wile
-  - repo: https://gitlab.com/PyCQA/flake8 
+  - repo: https://gitlab.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: codespell
         args:
           - --ignore-words-list=nd,reacher,thist,ths, ure, referenc,wile
-  - repo: https://gitlab.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8


### PR DESCRIPTION
Context: https://github.com/PyCQA/flake8/issues/1605 https://github.com/PyCQA/flake8/issues/1736

tl;dr flake8 moved from gitlab to github, so we need to change all the pre-commits in Farama projects to use that instead.

Otherwise, all pre-commits will start failing