### PR TITLE
Fix `play` assertion error

### DIFF
--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -51,7 +51,7 @@ class PlayableGame:
             zoom: If to zoom in on the environment render
         """
         if env.render_mode not in {"rgb_array", "rgb_array_list"}:
-            logger.error(
+            raise ValueError(
                 "PlayableGame wrapper works only with rgb_array and rgb_array_list render modes, "
                 f"but your environment render_mode = {env.render_mode}."
             )

--- a/tests/utils/test_play.py
+++ b/tests/utils/test_play.py
@@ -206,4 +206,12 @@ def test_play_loop_real_env():
 
 def test_play_no_keys():
     with pytest.raises(MissingKeysToAction):
-        play(gym.make("CartPole-v1"))
+        play(gym.make("CartPole-v1", render_mode="rgb_array"))
+
+
+def test_wrong_render_mode():
+    with pytest.raises(
+        ValueError,
+        match=r"PlayableGame wrapper works only with rgb_array and rgb_array_list render modes",
+    ):
+        play(gym.make("CartPole-v1"), keys_to_action={})


### PR DESCRIPTION
This PR addresses https://github.com/Farama-Foundation/Gymnasium/issues/126
I just replaced the error message with an actual exception.
I guess `logger.error` can be a somewhat confusing name for a function that only does logging. Searching through the repo, https://github.com/Farama-Foundation/Gymnasium/blob/5674a52d4c4d7cca9f169db561622b8d3e49bd65/gymnasium/utils/save_video.py#L86 seems to have the same problem.