### PR TITLE
Matrix mdp third party

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -98,7 +98,7 @@ Reinforcement learning environments for compiler optimization tasks, such as LLV
 ### [CARL: context adaptive RL](https://github.com/automl/CARL)
 Configurable reinforcement learning environments for testing generalization, e.g. CartPole with variable pole lengths or Brax robots with different ground frictions.
 
-### [matrix-mdp: Easily create discrete MDOs](https://github.com/Paul-543NA/matrix-mdp-gym)
+### [matrix-mdp: Easily create discrete MDPs](https://github.com/Paul-543NA/matrix-mdp-gym)
 An environment to easily implement discrete MDPs as gym environments. Turn a set of matrices (`P_0(s)`, `P(s'| s, a)` and `R(s', s, a)`) into a gym environment that represents the discrete MDP ruled by these dynamics.
 
 ### [mo-gym: Multi-objective Reinforcement Learning environments](https://github.com/LucasAlegre/mo-gym)

--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -98,6 +98,9 @@ Reinforcement learning environments for compiler optimization tasks, such as LLV
 ### [CARL: context adaptive RL](https://github.com/automl/CARL)
 Configurable reinforcement learning environments for testing generalization, e.g. CartPole with variable pole lengths or Brax robots with different ground frictions.
 
+### [matrix-mdp: Easily create discrete MDOs](https://github.com/Paul-543NA/matrix-mdp-gym)
+An environment to easily implement discrete MDPs as gym environments. Turn a set of matrices (`P_0(s)`, `P(s'| s, a)` and `R(s', s, a)`) into a gym environment that represents the discrete MDP ruled by these dynamics.
+
 ### [mo-gym: Multi-objective Reinforcement Learning environments](https://github.com/LucasAlegre/mo-gym)
 Multi-objective RL (MORL) gym environments, where the reward is a NumPy array of different (possibly conflicting) objectives.
 


### PR DESCRIPTION
# Description

I was looking for a gym environment to create an env from the matrices of a discrete MDP (P_0(s), P(s'|s, a), R(s'|s, a)). 
After looking around, I didn't find any, so I created it!

My third-party env is available [on github](https://github.com/Paul-543NA/matrix-mdp-gym) and [Pipy](https://pypi.org/project/matrix-mdp-gym/).

It is pretty common for people to describe discrete MDPs with these matrices and have them available, this environment provides an easy way to turn those into a gym env and get all the benefits of a standard API.

## Type of change

This PR adds the [matrix-mdp](https://github.com/Paul-543NA/matrix-mdp-gym) environment to the `docs/environments/third_party_environments.md` file.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] (irrelevant here) I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
