### PR TITLE
ENH: clean make function

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -422,7 +422,9 @@ def _check_spec_register(spec: EnvSpec):
 
 def _check_metadata(metadata_: dict):
     if not isinstance(metadata_, dict):
-        raise error.InvalidMetadata(f"Expect the environment metadata to be dict, actual type: {type(metadata)}")
+        raise error.InvalidMetadata(
+            f"Expect the environment metadata to be dict, actual type: {type(metadata)}"
+        )
 
     render_modes = metadata_.get("render_modes")
     if render_modes is None:

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from typing import (
     Callable,
     Dict,
+    Iterable,
     List,
     Optional,
     Sequence,
@@ -431,9 +432,9 @@ def _check_metadata(metadata_: dict):
         logger.warn(
             f"The environment creator metadata doesn't include `render_modes`, contains: {list(metadata_.keys())}"
         )
-    elif not isinstance(render_modes, Sequence):
+    elif not isinstance(render_modes, Iterable):
         logger.warn(
-            f"Expects the environment metadata render_modes to be a Sequence, actual type: {type(render_modes)}"
+            f"Expects the environment metadata render_modes to be a Iterable, actual type: {type(render_modes)}"
         )
 
 

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -601,7 +601,7 @@ def make(
     render_modes = None
     if hasattr(env_creator, "metadata"):
         _check_metadata(env_creator.metadata)
-        render_modes = env_creator.get("render_modes")
+        render_modes = env_creator.metadata.get("render_modes")
     mode = _kwargs.get("render_mode")
     apply_human_rendering = False
     apply_render_collection = False

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -608,14 +608,13 @@ def make(
 
     if mode is not None and render_modes is not None and mode not in render_modes:
         # Apply the `HumanRendering` wrapper, if the mode=="human" but "human" not in render_modes
-        displayable_mode = render_modes.get("rgb_array_list")
-        displayable_mode = render_modes.get("rgb_array", displayable_mode)
-        if mode == "human" and displayable_mode is not None:
+        displayable_modes = {"rgb_array", "rgb_array_list"}.intersection(render_modes)
+        if mode == "human" and len(displayable_modes) > 0:
             logger.warn(
                 "You are trying to use 'human' rendering for an environment that doesn't natively support it. "
                 "The HumanRendering wrapper is being applied to your environment."
             )
-            _kwargs["render_mode"] = displayable_mode
+            _kwargs["render_mode"] = displayable_modes.pop()
             apply_human_rendering = True
         elif mode.endswith("_list") and mode[: -len("_list")] in render_modes:
             _kwargs["render_mode"] = mode[: -len("_list")]

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -606,8 +606,8 @@ def make(
     apply_human_rendering = False
     apply_render_collection = False
 
+    # If mode is not valid, try applying HumanRendering/RenderCollection wrappers
     if mode is not None and render_modes is not None and mode not in render_modes:
-        # Apply the `HumanRendering` wrapper, if the mode=="human" but "human" not in render_modes
         displayable_modes = {"rgb_array", "rgb_array_list"}.intersection(render_modes)
         if mode == "human" and len(displayable_modes) > 0:
             logger.warn(

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -420,6 +420,21 @@ def _check_spec_register(spec: EnvSpec):
         )
 
 
+def _check_metadata(metadata_: dict):
+    if not isinstance(metadata_, dict):
+        raise error.InvalidMetadata(f"Expect the environment metadata to be dict, actual type: {type(metadata)}")
+
+    render_modes = metadata_.get("render_modes")
+    if render_modes is None:
+        logger.warn(
+            f"The environment creator metadata doesn't include `render_modes`, contains: {list(metadata_.keys())}"
+        )
+    elif not isinstance(render_modes, Sequence):
+        logger.warn(
+            f"Expects the environment metadata render_modes to be a Sequence, actual type: {type(render_modes)}"
+        )
+
+
 # Public API
 
 
@@ -581,52 +596,32 @@ def make(
         # Assume it's a string
         env_creator = load(spec_.entry_point)
 
+    render_modes = None
+    if hasattr(env_creator, "metadata"):
+        _check_metadata(env_creator.metadata)
+        render_modes = env_creator.get("render_modes")
     mode = _kwargs.get("render_mode")
     apply_human_rendering = False
     apply_render_collection = False
 
-    # If we have access to metadata we check that "render_mode" is valid and see if the HumanRendering wrapper needs to be applied
-    if mode is not None and hasattr(env_creator, "metadata"):
-        assert isinstance(
-            env_creator.metadata, dict
-        ), f"Expect the environment creator ({env_creator}) metadata to be dict, actual type: {type(env_creator.metadata)}"
-
-        if "render_modes" in env_creator.metadata:
-            render_modes = env_creator.metadata["render_modes"]
-            if not isinstance(render_modes, Sequence):
-                logger.warn(
-                    f"Expects the environment metadata render_modes to be a Sequence (tuple or list), actual type: {type(render_modes)}"
-                )
-
-            # Apply the `HumanRendering` wrapper, if the mode=="human" but "human" not in render_modes
-            if (
-                mode == "human"
-                and "human" not in render_modes
-                and ("rgb_array" in render_modes or "rgb_array_list" in render_modes)
-            ):
-                logger.warn(
-                    "You are trying to use 'human' rendering for an environment that doesn't natively support it. "
-                    "The HumanRendering wrapper is being applied to your environment."
-                )
-                apply_human_rendering = True
-                if "rgb_array" in render_modes:
-                    _kwargs["render_mode"] = "rgb_array"
-                else:
-                    _kwargs["render_mode"] = "rgb_array_list"
-            elif (
-                mode not in render_modes
-                and mode.endswith("_list")
-                and mode[: -len("_list")] in render_modes
-            ):
-                _kwargs["render_mode"] = mode[: -len("_list")]
-                apply_render_collection = True
-            elif mode not in render_modes:
-                logger.warn(
-                    f"The environment is being initialised with mode ({mode}) that is not in the possible render_modes ({render_modes})."
-                )
-        else:
+    if mode is not None and render_modes is not None and mode not in render_modes:
+        # Apply the `HumanRendering` wrapper, if the mode=="human" but "human" not in render_modes
+        displayable_mode = render_modes.get("rgb_array_list")
+        displayable_mode = render_modes.get("rgb_array", displayable_mode)
+        if mode == "human" and displayable_mode is not None:
             logger.warn(
-                f"The environment creator metadata doesn't include `render_modes`, contains: {list(env_creator.metadata.keys())}"
+                "You are trying to use 'human' rendering for an environment that doesn't natively support it. "
+                "The HumanRendering wrapper is being applied to your environment."
+            )
+            _kwargs["render_mode"] = displayable_mode
+            apply_human_rendering = True
+        elif mode.endswith("_list") and mode[: -len("_list")] in render_modes:
+            _kwargs["render_mode"] = mode[: -len("_list")]
+            apply_render_collection = True
+        else:
+            raise error.UnsupportedMode(
+                f"The environment is being initialised with render_mode={mode} "
+                f"that is not in the possible render_modes ({render_modes})."
             )
 
     if apply_api_compatibility is True or (

--- a/gymnasium/error.py
+++ b/gymnasium/error.py
@@ -53,6 +53,10 @@ class UnsupportedMode(Error):
     """Raised when the user requests a rendering mode not supported by the environment."""
 
 
+class InvalidMetadata(Error):
+    """Raised when the metadata of an environment is not valid."""
+
+
 class ResetNeeded(Error):
     """When the order enforcing is violated, i.e. step or render is called before reset."""
 


### PR DESCRIPTION
Addressing https://github.com/Farama-Foundation/Gymnasium/issues/92
This also introduces a change: now `UnsupportedMode` is raised if 'render_mode` is invalid (previously we showed only a warning). 


Side question: are the make `overloading` useful? It seems they introduce a bit of noise in the file just for having a more specific typing; a general return type `Env` works fine too