### PR TITLE
Move dev_wrappers and functional to experimental

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
         args:
-          - '--per-file-ignores=*/__init__.py:F401 gymnasium/envs/registration.py:E704 docs/tutorials/*.py:E402'
+          - '--per-file-ignores=*/__init__.py:F401 gymnasium/envs/registration.py:E704 docs/tutorials/*.py:E402 gymnasium/experimental/wrappers/__init__.py:E402'
           - --ignore=E203,W503,E741
           - --max-complexity=30
           - --max-line-length=456

--- a/gymnasium/__init__.py
+++ b/gymnasium/__init__.py
@@ -10,10 +10,8 @@ from gymnasium.core import (
 )
 from gymnasium.spaces.space import Space
 from gymnasium.envs.registration import make, spec, register, registry, pprint_registry
-from gymnasium import envs, spaces, utils, vector, wrappers, error, logger
+from gymnasium import envs, spaces, utils, vector, wrappers, error, logger, experimental
 
-import os
-import sys
 
 __all__ = [
     # core classes
@@ -37,6 +35,7 @@ __all__ = [
     "wrappers",
     "error",
     "logger",
+    "experimental",
 ]
 __version__ = "0.26.3"
 
@@ -44,6 +43,9 @@ __version__ = "0.26.3"
 # SDL connecting to alsa frequently create these giant lists of warnings every time you import an environment using
 #   pygame
 # DSP is far more benign (and should probably be the default in SDL anyways)
+
+import os
+import sys
 
 if sys.platform.startswith("linux"):
     os.environ["SDL_AUDIODRIVER"] = "dsp"

--- a/gymnasium/dev_wrappers/__init__.py
+++ b/gymnasium/dev_wrappers/__init__.py
@@ -1,4 +1,0 @@
-"""Root __init__ of the gym dev_wrappers."""
-from typing import TypeVar
-
-ArgType = TypeVar("ArgType")

--- a/gymnasium/experimental/__init__.py
+++ b/gymnasium/experimental/__init__.py
@@ -1,0 +1,12 @@
+"""Root __init__ of the gym dev_wrappers."""
+
+
+from gymnasium.experimental.functional import FuncEnv
+
+__all__ = [
+    # Functional
+    "FuncEnv",
+    "functional",
+    # Wrapper
+    "wrappers",
+]

--- a/gymnasium/experimental/functional.py
+++ b/gymnasium/experimental/functional.py
@@ -1,6 +1,7 @@
 """Base class and definitions for an alternative, functional backend for gym envs, particularly suitable for hardware accelerated and otherwise transformed environments."""
+from __future__ import annotations
 
-from typing import Any, Callable, Dict, Generic, Optional, Tuple, TypeVar
+from typing import Any, Callable, Generic, TypeVar
 
 import numpy as np
 
@@ -35,7 +36,7 @@ class FuncEnv(
     we intend to flesh it out and officially expose it to end users.
     """
 
-    def __init__(self, options: Optional[Dict[str, Any]] = None):
+    def __init__(self, options: dict[str, Any] | None = None):
         """Initialize the environment constants."""
         self.__dict__.update(options or {})
 
@@ -83,7 +84,7 @@ class FuncEnv(
 
     def render_image(
         self, state: StateType, render_state: RenderStateType
-    ) -> Tuple[RenderStateType, np.ndarray]:
+    ) -> tuple[RenderStateType, np.ndarray]:
         """Show the state."""
         raise NotImplementedError
 

--- a/gymnasium/experimental/wrappers/__init__.py
+++ b/gymnasium/experimental/wrappers/__init__.py
@@ -1,0 +1,21 @@
+"""Experimental Wrappers."""
+# isort: skip_file
+
+from typing import TypeVar
+
+ArgType = TypeVar("ArgType")
+
+from gymnasium.experimental.wrappers.lambda_action import LambdaActionV0
+from gymnasium.experimental.wrappers.lambda_observations import LambdaObservationsV0
+from gymnasium.experimental.wrappers.lambda_reward import ClipRewardsV0, LambdaRewardV0
+
+__all__ = [
+    "ArgType",
+    # Lambda Action
+    "LambdaActionV0",
+    # Lambda Observations
+    "LambdaObservationsV0",
+    # Lambda Rewards
+    "LambdaRewardV0",
+    "ClipRewardsV0",
+]

--- a/gymnasium/experimental/wrappers/lambda_action.py
+++ b/gymnasium/experimental/wrappers/lambda_action.py
@@ -4,7 +4,7 @@ from typing import Any, Callable
 
 import gymnasium as gym
 from gymnasium.core import ActType
-from gymnasium.dev_wrappers import ArgType
+from gymnasium.experimental.wrappers import ArgType
 
 
 class LambdaActionV0(gym.ActionWrapper):

--- a/gymnasium/experimental/wrappers/lambda_observations.py
+++ b/gymnasium/experimental/wrappers/lambda_observations.py
@@ -4,7 +4,7 @@ from typing import Any, Callable
 
 import gymnasium as gym
 from gymnasium.core import ObsType
-from gymnasium.dev_wrappers import ArgType
+from gymnasium.experimental.wrappers import ArgType
 
 
 class LambdaObservationsV0(gym.ObservationWrapper):

--- a/gymnasium/experimental/wrappers/lambda_reward.py
+++ b/gymnasium/experimental/wrappers/lambda_reward.py
@@ -5,8 +5,8 @@ from typing import Any, Callable, Optional, Union
 import numpy as np
 
 import gymnasium as gym
-from gymnasium.dev_wrappers import ArgType
 from gymnasium.error import InvalidBound
+from gymnasium.experimental.wrappers import ArgType
 
 
 class LambdaRewardV0(gym.RewardWrapper):
@@ -14,7 +14,7 @@ class LambdaRewardV0(gym.RewardWrapper):
 
     Example:
         >>> import gymnasium as gym
-        >>> from gymnasium.wrappers import LambdaRewardV0
+        >>> from gymnasium.experimental.wrappers import LambdaRewardV0
         >>> env = gym.make("CartPole-v1")
         >>> env = LambdaRewardV0(env, lambda r: 2 * r + 1)
         >>> _ = env.reset()
@@ -52,7 +52,7 @@ class ClipRewardsV0(LambdaRewardV0):
 
     Example with an upper and lower bound:
         >>> import gymnasium as gym
-        >>> from gymnasium.wrappers import ClipRewardsV0
+        >>> from gymnasium.experimental.wrappers import ClipRewardsV0
         >>> env = gym.make("CartPole-v1")
         >>> env = ClipRewardsV0(env, 0, 0.5)
         >>> env.reset()


### PR DESCRIPTION
In v0.27 and v0.28, we are adding new wrappers, vector environments and functional API.

To allow backward compatibility for users, I have created a new experimental folder where all development can happen at the  same time with old code. 