### PR TITLE
Added `is_np_flattenable` property to spaces docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,3 +47,16 @@ For classes, code block examples can be provided in the top docstring and not th
 
 To check your docstrings are correct, run `pre-commit run --all-files` or `pydocstyle --source --explain --convention=google`.
 If all docstrings that fail, the source and reason for the failure is provided. 
+
+## Building the docs
+Make sure that you have install the requirements:
+```shell
+cd docs
+pip install -r requirements.txt
+```
+Then run
+```
+python scripts/gen_mds.py 
+make dirhtml
+```
+Now, navigate to `_build/dirhtml` and open `index.html` in your browser.

--- a/docs/api/spaces.md
+++ b/docs/api/spaces.md
@@ -14,19 +14,25 @@ spaces/vector_utils
 ```
 
 ```{eval-rst}
+.. automodule:: gymnasium.spaces
+```
+
+## The Base Class
+```{eval-rst}
 .. autoclass:: gymnasium.spaces.Space
 ```
 
-## Attributes
+### Attributes
 
 ```{eval-rst}
 .. autoproperty:: gymnasium.spaces.space.Space.shape
 .. property:: Space.dtype
 
     Return the data type of this space.
+.. autoproperty:: gymnasium.spaces.space.Space.is_np_flattenable
 ```
 
-## Methods
+### Methods
 
 Each space implements the following functions:
 

--- a/gymnasium/spaces/__init__.py
+++ b/gymnasium/spaces/__init__.py
@@ -7,6 +7,8 @@ are vectors in the two-dimensional unit cube, the environment code may contain t
 
     self.action_space = spaces.Discrete(3)
     self.observation_space = spaces.Box(0, 1, shape=(2,))
+
+All spaces inherit from the :class:`Space` superclass.
 """
 from gymnasium.spaces.box import Box
 from gymnasium.spaces.dict import Dict

--- a/gymnasium/spaces/space.py
+++ b/gymnasium/spaces/space.py
@@ -85,7 +85,7 @@ class Space(Generic[T_cov]):
 
     @property
     def is_np_flattenable(self) -> bool:
-        """Checks whether this space can be flattened to a :class:`spaces.Box`."""
+        """Checks whether this space can be flattened to a :class:`gymnasium.spaces.Box`."""
         raise NotImplementedError
 
     def sample(self, mask: Any | None = None) -> T_cov:


### PR DESCRIPTION
- Updated `CONTRIBUTING.md` to explain how to build the docs (I hope that procedure is still up to date)
- Added auto docs for the module docstring of the spaces module
- Added docs for the `is_np_flattenable` property (previously undocumented)
- Decreased heading level of Attributes, Methods to be smaller than the level of "Fundamental Spaces" etc. (makes more sense to me but idk)