### PR TITLE
`MuJoCo.Ant` v4 changelog

### DIFF
--- a/gymnasium/envs/mujoco/ant_v4.py
+++ b/gymnasium/envs/mujoco/ant_v4.py
@@ -169,7 +169,7 @@ class AntEnv(MujocoEnv, utils.EzPickle):
     | `exclude_current_positions_from_observation`| **bool** | `True`| Whether or not to omit the x- and y-coordinates from observations. Excluding the position can serve as an inductive bias to induce position-agnostic behavior in policies |
 
     ## Version History
-    * v4: All MuJoCo environments now use the MuJoCo bindings in mujoco >= 2.1.3
+    * v4: All MuJoCo environments now use the MuJoCo bindings in mujoco >= 2.1.3, also removed contact forces from the default observation space (new variable `use_contact_forces=True` can restore them)
     * v3: Support for `gymnasium.make` kwargs such as `xml_file`, `ctrl_cost_weight`, `reset_noise_scale`, etc. rgb rendering comes from tracking camera (so agent does not run away from screen)
     * v2: All continuous control environments now use mujoco-py >= 1.50
     * v1: max_time_steps raised to 1000 for robot based tasks. Added reward_threshold to environments.


### PR DESCRIPTION


# Description
Now indicated the change of the default observation space in the `## Version History`

Note: this is not needed for any of the other `MuJoCo` Environments
## Type of change

Please delete options that are not relevant.

- [x] Doc fix (Does not change code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [NO] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [YES] I have commented my code, particularly in hard-to-understand areas
- [YES] I have made corresponding changes to the documentation
- [PROBABLY] My changes generate no new warnings
- [NO] I have added tests that prove my fix is effective or that my feature works
- [DID NOT YEST] New and existing unit tests pass locally with my changes
+[YES] Have used a spell checker for new doc

