### PR TITLE
Make window in play resizable

### DIFF
--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -59,8 +59,10 @@ class PlayableGame:
 
         self.env = env
         self.relevant_keys = self._get_relevant_keys(keys_to_action)
+        # self.video_size is the size of the video that is being displayed.
+        # The window size may be larger, in that case we will add black bars
         self.video_size = self._get_video_size(zoom)
-        self.screen = pygame.display.set_mode(self.video_size)
+        self.screen = pygame.display.set_mode(self.video_size, pygame.RESIZABLE)
         self.pressed_keys = []
         self.running = True
 
@@ -114,8 +116,12 @@ class PlayableGame:
         elif event.type == pygame.QUIT:
             self.running = False
         elif event.type == VIDEORESIZE:
-            self.video_size = event.size
-            self.screen = pygame.display.set_mode(self.video_size)
+            # Compute the maximum video size that fits into the new window
+            scale_width = event.w / self.video_size[0]
+            scale_height = event.h / self.video_size[1]
+            scale = min(scale_height, scale_width)
+            self.video_size = (scale * self.video_size[0], scale * self.video_size[1])
+            self.screen = pygame.display.set_mode(event.size, pygame.RESIZABLE)
 
 
 def display_arr(
@@ -133,7 +139,12 @@ def display_arr(
     arr = 255.0 * (arr - arr_min) / (arr_max - arr_min)
     pyg_img = pygame.surfarray.make_surface(arr.swapaxes(0, 1) if transpose else arr)
     pyg_img = pygame.transform.scale(pyg_img, video_size)
-    screen.blit(pyg_img, (0, 0))
+    # We might have to add black bars if surface_size is larger than video_size
+    surface_size = screen.get_size()
+    width_offset = (surface_size[0] - video_size[0]) / 2
+    height_offset = (surface_size[1] - video_size[1]) / 2
+    screen.fill((0, 0, 0))
+    screen.blit(pyg_img, (width_offset, height_offset))
 
 
 def play(


### PR DESCRIPTION
- Makes window in play resizable
- Scales content as much as possible while fitting into the window. To preserve the aspect ratio, black bars may be added on top/bottom or left/right (by default the window aspect ratio matches the content aspect ratio, i.e. no black bars)
- The pixel dimensions may become fractional after resizing, but for some reason that doesn't seem to be a problem for pygame, so I'm leaving it like that
- Tested on MacOS, still need to test on Ubuntu