### PR TITLE
Minor changes + Python 3.11 CI + Mujoco 2.3.1.post1 bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - run: |

--- a/docs/api/experimental.md
+++ b/docs/api/experimental.md
@@ -36,64 +36,34 @@ Gymnasium already contains a large collection of wrappers, but we believe that t
 
     * - Old name
       - New name
-      - Vector version
-      - Tree structure
     * - :class:`wrappers.TransformObservation`
       - :class:`experimental.wrappers.LambdaObservationV0`
-      - VectorLambdaObservation
-      - No
     * - :class:`wrappers.FilterObservation`
       - :class:`experimental.wrappers.FilterObservationV0`
-      - VectorFilterObservation (*)
-      - Yes
     * - :class:`wrappers.FlattenObservation`
       - :class:`experimental.wrappers.FlattenObservationV0`
-      - VectorFlattenObservation (*)
-      - No
     * - :class:`wrappers.GrayScaleObservation`
       - :class:`experimental.wrappers.GrayscaleObservationV0`
-      - VectorGrayscaleObservation (*)
-      - Yes
     * - :class:`wrappers.ResizeObservation`
       - :class:`experimental.wrappers.ResizeObservationV0`
-      - VectorResizeObservation (*)
-      - Yes
     * - `supersuit.reshape_v0`
       - :class:`experimental.wrappers.ReshapeObservationV0`
-      - VectorReshapeObservation (*)
-      - Yes
     * - Not Implemented
       - :class:`experimental.wrappers.RescaleObservationV0`
-      - VectorRescaleObservation (*)
-      - Yes
     * - Not Implemented
       - :class:`experimental.wrappers.DtypeObservationV0`
-      - VectorDtypeObservation (*)
-      - Yes
     * - :class:`wrappers.PixelObservationWrapper`
       - PixelObservation
-      - VectorPixelObservation
-      - No
     * - :class:`wrappers.NormalizeObservation`
       - NormalizeObservation
-      - VectorNormalizeObservation
-      - No
     * - :class:`wrappers.TimeAwareObservation`
       - :class:`experimental.wrappers.TimeAwareObservationV0`
-      - VectorTimeAwareObservation
-      - No
     * - :class:`wrappers.FrameStack`
       - FrameStackObservation
-      - VectorFrameStackObservation
-      - No
     * - `supersuit.dtype_v0`
       - :class:`experimental.wrappers.DelayObservationV0`
-      - VectorDelayObservation
-      - No
     * - :class:`wrappers.AtariPreprocessing`
       - AtariPreprocessing
-      - Not Implemented
-      - No
 ```
 
 ### Action Wrappers
@@ -105,24 +75,14 @@ Gymnasium already contains a large collection of wrappers, but we believe that t
 
     * - Old name
       - New name
-      - Vector version
-      - Tree structure
     * - Not Implemented
       - :class:`experimental.wrappers.LambdaActionV0`
-      - VectorLambdaAction
-      - No
     * - :class:`wrappers.ClipAction`
       - :class:`experimental.wrappers.ClipActionV0`
-      - VectorClipAction (*)
-      - Yes
     * - :class:`wrappers.RescaleAction`
       - :class:`experimental.wrappers.RescaleActionV0`
-      - VectorRescaleAction (*)
-      - Yes
     * - `supersuit.sticky_actions_v0`
       - :class:`experimental.wrappers.StickyActionV0`
-      - VectorStickyAction
-      - No
 ```
 
 ### Reward Wrappers
@@ -134,19 +94,14 @@ Gymnasium already contains a large collection of wrappers, but we believe that t
 
     * - Old name
       - New name
-      - Vector version
     * - :class:`wrappers.TransformReward`
       - :class:`experimental.wrappers.LambdaRewardV0`
-      - VectorLambdaReward
     * - `supersuit.clip_reward_v0`
       - :class:`experimental.wrappers.ClipRewardV0`
-      - VectorClipReward (*)
     * - Not Implemented
       - RescaleReward
-      - VectorRescaleReward (*)
     * - :class:`wrappers.NormalizeReward`
       - NormalizeReward
-      - VectorNormalizeReward
 ```
 
 ### Other Wrappers
@@ -159,34 +114,24 @@ Gymnasium already contains a large collection of wrappers, but we believe that t
 
     * - Old name
       - New name
-      - Vector version
     * - :class:`wrappers.AutoResetWrapper`
       - AutoReset
-      - VectorAutoReset
     * - :class:`wrappers.PassiveEnvChecker`
       - PassiveEnvChecker
-      - VectorPassiveEnvChecker
     * - :class:`wrappers.OrderEnforcing`
       - OrderEnforcing
-      - VectorOrderEnforcing
     * - :class:`wrappers.EnvCompatibility`
       - Moved to `shimmy <https://github.com/Farama-Foundation/Shimmy/blob/main/shimmy/openai_gym_compatibility.py>`_
-      - Not Implemented
     * - :class:`wrappers.RecordEpisodeStatistics`
       - RecordEpisodeStatistics
-      - VectorRecordEpisodeStatistics
     * - :class:`wrappers.RenderCollection`
       - RenderCollection
-      - VectorRenderCollection
     * - :class:`wrappers.HumanRendering`
       - HumanRendering
-      - Not Implemented
     * - Not Implemented
       - :class:`experimental.wrappers.JaxToNumpyV0`
-      - VectorJaxToNumpy (*)
     * - Not Implemented
       - :class:`experimental.wrappers.JaxToTorchV0`
-      - VectorJaxToTorch (*)
 ```
 
 ### Vector Only Wrappers

--- a/docs/api/experimental.md
+++ b/docs/api/experimental.md
@@ -58,7 +58,7 @@ Gymnasium already contains a large collection of wrappers, but we believe that t
       - :class:`experimental.wrappers.ResizeObservationV0`
       - VectorResizeObservation (*)
       - Yes
-    * - Not Implemented
+    * - `supersuit.reshape_v0`
       - :class:`experimental.wrappers.ReshapeObservationV0`
       - VectorReshapeObservation (*)
       - Yes
@@ -86,7 +86,7 @@ Gymnasium already contains a large collection of wrappers, but we believe that t
       - FrameStackObservation
       - VectorFrameStackObservation
       - No
-    * - Not Implemented
+    * - `supersuit.dtype_v0`
       - :class:`experimental.wrappers.DelayObservationV0`
       - VectorDelayObservation
       - No
@@ -119,7 +119,7 @@ Gymnasium already contains a large collection of wrappers, but we believe that t
       - :class:`experimental.wrappers.RescaleActionV0`
       - VectorRescaleAction (*)
       - Yes
-    * - Not Implemented
+    * - `supersuit.sticky_actions_v0`
       - :class:`experimental.wrappers.StickyActionV0`
       - VectorStickyAction
       - No
@@ -138,7 +138,7 @@ Gymnasium already contains a large collection of wrappers, but we believe that t
     * - :class:`wrappers.TransformReward`
       - :class:`experimental.wrappers.LambdaRewardV0`
       - VectorLambdaReward
-    * - Not Implemented
+    * - `supersuit.clip_reward_v0`
       - :class:`experimental.wrappers.ClipRewardV0`
       - VectorClipReward (*)
     * - Not Implemented
@@ -149,7 +149,7 @@ Gymnasium already contains a large collection of wrappers, but we believe that t
       - VectorNormalizeReward
 ```
 
-### Common Wrappers
+### Other Wrappers
 
 ```{eval-rst}
 .. py:currentmodule:: gymnasium

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ other = [
     "opencv-python >=3.0",
     "matplotlib >=3.0",
     "moviepy >=1.0.0",
-    "tensorflow >=2.1.0",
     "torch >=1.0.0",
 ]
 all = [
@@ -82,7 +81,6 @@ all = [
     "opencv-python >=3.0",
     "matplotlib >=3.0",
     "moviepy >=1.0.0",
-    "tensorflow >=2.1.0",
     "torch >=1.0.0",
 ]
 testing = ["pytest ==7.1.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ mujoco_py = ["mujoco-py >=2.1,<2.2"]  # kept for backward compatibility
 mujoco = ["mujoco ==2.3.1.post1", "imageio >=2.14.1"]
 toy-text = ["pygame ==2.1.3.dev8"]
 toy_text = ["pygame ==2.1.3.dev8"]         # kept for backward compatibility
-jax = ["jax ==0.3.20", "jaxlib ==0.3.20"]
+jax = ["jax >=0.3.24", "jaxlib >=0.3.24"]
 other = [
     "lz4 >=3.1.0",
     "opencv-python >=3.0",
@@ -75,8 +75,8 @@ all = [
     # toy-text
     "pygame ==2.1.3.dev8",
     # jax
-    "jax ==0.3.20",
-    "jaxlib ==0.3.20",
+    "jax >=0.3.24",
+    "jaxlib >=0.3.24",
     # other
     "lz4 >=3.1.0",
     "opencv-python >=3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classic-control = ["pygame ==2.1.3.dev8"]
 classic_control = ["pygame ==2.1.3.dev8"]  # kept for backward compatibility
 mujoco-py = ["mujoco-py >=2.1,<2.2"]
 mujoco_py = ["mujoco-py >=2.1,<2.2"]  # kept for backward compatibility
-mujoco = ["mujoco >=2.3.0", "imageio >=2.14.1"]
+mujoco = ["mujoco ==2.3.1.post1", "imageio >=2.14.1"]
 toy-text = ["pygame ==2.1.3.dev8"]
 toy_text = ["pygame ==2.1.3.dev8"]         # kept for backward compatibility
 jax = ["jax ==0.3.20", "jaxlib ==0.3.20"]
@@ -70,7 +70,7 @@ all = [
     # mujoco-py
     "mujoco-py >=2.1,<2.2",
     # mujoco
-    "mujoco >=2.3.0",
+    "mujoco ==2.3.1.post1",
     "imageio >=2.14.1",
     # toy-text
     "pygame ==2.1.3.dev8",


### PR DESCRIPTION
* Minor documentation review by Jordan
* Add Python 3.11 to CI due to missing mujoco support previous
* Bump Mujoco to 2.3.1.post1 (https://github.com/deepmind/mujoco/releases/tag/2.3.1)