### PR TITLE
Revert `make` error when render mode is used without metadata render modes

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -624,7 +624,7 @@ def make(
             _kwargs["render_mode"] = mode[: -len("_list")]
             apply_render_collection = True
         else:
-            raise error.UnsupportedMode(
+            logger.warn(
                 f"The environment is being initialised with render_mode={mode} "
                 f"that is not in the possible render_modes ({render_modes})."
             )

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -625,7 +625,7 @@ def make(
             apply_render_collection = True
         else:
             logger.warn(
-                f"The environment is being initialised with render_mode={mode} "
+                f"The environment is being initialised with render_mode={mode!r} "
                 f"that is not in the possible render_modes ({render_modes})."
             )
 

--- a/tests/envs/test_make.py
+++ b/tests/envs/test_make.py
@@ -40,8 +40,10 @@ def register_make_testing_envs():
         },
     )
 
-    gym.register(id="test/NoRenderModesMetadata-v0",
-                 entry_point="tests.envs.util_envs:NoRenderModesMetadata")
+    gym.register(
+        id="test/NoRenderModesMetadata-v0",
+        entry_point="tests.envs.util_envs:NoRenderModesMetadata",
+    )
 
     gym.register(
         id="test/NoHuman-v0",
@@ -309,7 +311,10 @@ def test_make_render_mode(register_make_testing_envs):
         gym.make("CarRacing-v2", render="human")
 
     # This test checks that a user can create an environment without the metadata including the render mode
-    with pytest.warns(UserWarning, match="The environment is being initialised with render_mode='rgb_list' that is not in the possible render_modes ([])."):
+    with pytest.warns(
+        UserWarning,
+        match="The environment is being initialised with render_mode='rgb_list' that is not in the possible render_modes ([]).",
+    ):
         gym.make("test/NoRenderModesMetadata-v0", render_mode="rgb_array")
 
 

--- a/tests/envs/test_make.py
+++ b/tests/envs/test_make.py
@@ -33,12 +33,15 @@ def register_make_testing_envs():
 
     gym.register(
         id="test.ArgumentEnv-v0",
-        entry_point="tests.envs.utils_envs:ArgumentEnv",
+        entry_point="tests.envs.util_envs:ArgumentEnv",
         kwargs={
             "arg1": "arg1",
             "arg2": "arg2",
         },
     )
+
+    gym.register(id="test/NoRenderModesMetadata-v0",
+                 entry_point="tests.envs.util_envs:NoRenderModesMetadata")
 
     gym.register(
         id="test/NoHuman-v0",
@@ -58,6 +61,7 @@ def register_make_testing_envs():
 
     del gym.envs.registration.registry["RegisterDuringMakeEnv-v0"]
     del gym.envs.registration.registry["test.ArgumentEnv-v0"]
+    del gym.envs.registration.registry["test/NoRenderModesMetadata-v0"]
     del gym.envs.registration.registry["test/NoHuman-v0"]
     del gym.envs.registration.registry["test/NoHumanOldAPI-v0"]
     del gym.envs.registration.registry["test/NoHumanNoRGB-v0"]
@@ -303,6 +307,10 @@ def test_make_render_mode(register_make_testing_envs):
         match=re.escape("got an unexpected keyword argument 'render'"),
     ):
         gym.make("CarRacing-v2", render="human")
+
+    # This test checks that a user can create an environment without the metadata including the render mode
+    with pytest.warns(UserWarning, match="The environment is being initialised with render_mode='rgb_list' that is not in the possible render_modes ([])."):
+        gym.make("test/NoRenderModesMetadata-v0", render_mode="rgb_array")
 
 
 def test_make_kwargs(register_make_testing_envs):

--- a/tests/envs/test_make.py
+++ b/tests/envs/test_make.py
@@ -313,7 +313,9 @@ def test_make_render_mode(register_make_testing_envs):
     # This test checks that a user can create an environment without the metadata including the render mode
     with pytest.warns(
         UserWarning,
-        match=re.escape("\x1b[33mWARN: The environment is being initialised with render_mode=rgb_array that is not in the possible render_modes ([]).\x1b[0m"),
+        match=re.escape(
+            "\x1b[33mWARN: The environment is being initialised with render_mode='rgb_array' that is not in the possible render_modes ([]).\x1b[0m"
+        ),
     ):
         gym.make("test/NoRenderModesMetadata-v0", render_mode="rgb_array")
 

--- a/tests/envs/test_make.py
+++ b/tests/envs/test_make.py
@@ -33,16 +33,11 @@ def register_make_testing_envs():
 
     gym.register(
         id="test.ArgumentEnv-v0",
-        entry_point="tests.envs.util_envs:ArgumentEnv",
+        entry_point="tests.envs.utils_envs:ArgumentEnv",
         kwargs={
             "arg1": "arg1",
             "arg2": "arg2",
         },
-    )
-
-    gym.register(
-        id="test/NoRenderModesMetadata-v0",
-        entry_point="tests.envs.util_envs:NoRenderModesMetadata",
     )
 
     gym.register(
@@ -57,6 +52,11 @@ def register_make_testing_envs():
     gym.register(
         id="test/NoHumanNoRGB-v0",
         entry_point="tests.envs.utils_envs:NoHumanNoRGB",
+    )
+
+    gym.register(
+        id="test/NoRenderModesMetadata-v0",
+        entry_point="tests.envs.utils_envs:NoRenderModesMetadata",
     )
 
     yield
@@ -313,7 +313,7 @@ def test_make_render_mode(register_make_testing_envs):
     # This test checks that a user can create an environment without the metadata including the render mode
     with pytest.warns(
         UserWarning,
-        match="The environment is being initialised with render_mode='rgb_list' that is not in the possible render_modes ([]).",
+        match=re.escape("\x1b[33mWARN: The environment is being initialised with render_mode=rgb_array that is not in the possible render_modes ([]).\x1b[0m"),
     ):
         gym.make("test/NoRenderModesMetadata-v0", render_mode="rgb_array")
 

--- a/tests/envs/utils_envs.py
+++ b/tests/envs/utils_envs.py
@@ -20,18 +20,6 @@ class ArgumentEnv(gym.Env):
 
 
 # Environments to test render_mode
-class NoRenderModesMetadata(gym.Env):
-    """An environment that has rendering but has not updated the metadata."""
-
-    # metadata: dict[str, Any] = {"render_modes": []}
-
-    def __init__(self, render_mode: str):
-        self.render_mode = render_mode
-
-        self.observation_space = gym.spaces.Box(low=0, high=1)
-        self.action_space = gym.spaces.Box(low=0, high=1)
-
-
 class NoHuman(gym.Env):
     """Environment that does not have human-rendering."""
 
@@ -59,3 +47,15 @@ class NoHumanNoRGB(gym.Env):
     def __init__(self, render_mode=None):
         assert render_mode in self.metadata["render_modes"]
         self.render_mode = render_mode
+
+
+class NoRenderModesMetadata(gym.Env):
+    """An environment that has rendering but has not updated the metadata."""
+
+    # metadata: dict[str, Any] = {"render_modes": []}
+
+    def __init__(self, render_mode):
+        self.render_mode = render_mode
+
+        self.observation_space = gym.spaces.Box(low=0, high=1)
+        self.action_space = gym.spaces.Box(low=0, high=1)

--- a/tests/envs/utils_envs.py
+++ b/tests/envs/utils_envs.py
@@ -20,6 +20,18 @@ class ArgumentEnv(gym.Env):
 
 
 # Environments to test render_mode
+class NoRenderModesMetadata(gym.Env):
+    """An environment that has rendering but has not updated the metadata."""
+
+    # metadata: dict[str, Any] = {"render_modes": []}
+
+    def __init__(self, render_mode: str):
+        self.render_mode = render_mode
+
+        self.observation_space = gym.spaces.Box(low=0, high=1)
+        self.action_space = gym.spaces.Box(low=0, high=1)
+
+
 class NoHuman(gym.Env):
     """Environment that does not have human-rendering."""
 


### PR DESCRIPTION
If an environment doesn't have static metadata containing the render modes but a user tries to create an environment then an error will be raised. This error is replaced by a warning.
A test has been added to check this