### PR TITLE
Improve the warning when error is raised from plugin

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -310,7 +310,7 @@ def load_env_plugins(entry_point: str = "gymnasium.envs") -> None:
             try:
                 fn()
             except Exception as e:
-                logger.warn(str(e))
+                logger.warn(f'plugin: {plugin.value} raised {e}')
 
 
 # fmt: off

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -8,6 +8,7 @@ import importlib
 import importlib.util
 import re
 import sys
+import traceback
 import warnings
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -309,8 +310,8 @@ def load_env_plugins(entry_point: str = "gymnasium.envs") -> None:
             fn = plugin.load()
             try:
                 fn()
-            except Exception as e:
-                logger.warn(f'plugin: {plugin.value} raised {e}')
+            except Exception:
+                logger.warn(f'plugin: {plugin.value} raised {traceback.format_exc()}')
 
 
 # fmt: off


### PR DESCRIPTION
Within the plugin system, it is possible that the plugin raises an error, this is logged as a warning however does not give context on the plugin that caused the error.
