### PR TITLE
ResizeObservation: fix silent bug on 2-dimensional observations.

### DIFF
--- a/gymnasium/wrappers/resize_observation.py
+++ b/gymnasium/wrappers/resize_observation.py
@@ -25,23 +25,29 @@ class ResizeObservation(gym.ObservationWrapper):
         (64, 64, 3)
     """
 
-    def __init__(self, env: gym.Env, shape: Union[tuple, int]):
+    def __init__(self, env: gym.Env, shape: Union[tuple[int, int], int]) -> None:
         """Resizes image observations to shape given by :attr:`shape`.
 
         Args:
             env: The environment to apply the wrapper
             shape: The shape of the resized observations
         """
-        super().__init__(env)
-        if isinstance(shape, int):
-            shape = (shape, shape)
-        assert all(x > 0 for x in shape), shape
+        if not isinstance(env.observation_space, Box):
+            raise ValueError(f"Expected the observation space to be Box, actual type: {type(env.observation_space)}")
+        dims = len(env.observation_space.shape)
+        if not 2 <= dims <= 3:
+            raise ValueError(f"Expected the observation space to have 2 or 3 dimensions, got: {dims}")
 
+        try:
+            shape = tuple(shape)
+        except TypeError:
+            shape = (shape, shape)
+        if len(shape) != 2 or not all(isinstance(x, int) and x > 0 for x in shape):
+            raise ValueError(f"Expected shape to be a 2-tuple of positive integers, got: {shape}")
+
+        super().__init__(env)
         self.shape = tuple(shape)
 
-        assert isinstance(
-            env.observation_space, Box
-        ), f"Expected the observation space to be Box, actual type: {type(env.observation_space)}"
         obs_shape = self.shape + env.observation_space.shape[2:]
         self.observation_space = Box(low=0, high=255, shape=obs_shape, dtype=np.uint8)
 
@@ -67,6 +73,4 @@ class ResizeObservation(gym.ObservationWrapper):
         observation = cv2.resize(
             observation, self.shape[::-1], interpolation=cv2.INTER_AREA
         )
-        if observation.ndim == 2:
-            observation = np.expand_dims(observation, -1)
-        return observation
+        return observation.reshape(self.observation_space.shape)

--- a/gymnasium/wrappers/resize_observation.py
+++ b/gymnasium/wrappers/resize_observation.py
@@ -1,8 +1,6 @@
 """Wrapper for resizing observations."""
 from __future__ import annotations
 
-from typing import Union
-
 import numpy as np
 
 import gymnasium as gym
@@ -30,7 +28,7 @@ class ResizeObservation(gym.ObservationWrapper):
         (64, 64, 3)
     """
 
-    def __init__(self, env: gym.Env, shape: Union[tuple[int, int], int]) -> None:
+    def __init__(self, env: gym.Env, shape: tuple[int, int] | int) -> None:
         """Resizes image observations to shape given by :attr:`shape`.
 
         Args:

--- a/tests/wrappers/test_resize_observation.py
+++ b/tests/wrappers/test_resize_observation.py
@@ -2,14 +2,14 @@ import pytest
 
 import gymnasium as gym
 from gymnasium import spaces
-from gymnasium.wrappers import ResizeObservation
+from gymnasium.wrappers import GrayScaleObservation, ResizeObservation
 
 
 @pytest.mark.parametrize("env_id", ["CarRacing-v2"])
 @pytest.mark.parametrize("shape", [16, 32, (8, 5), [10, 7]])
 def test_resize_observation(env_id, shape):
-    env = gym.make(env_id, disable_env_checker=True)
-    env = ResizeObservation(env, shape)
+    base_env = gym.make(env_id, disable_env_checker=True)
+    env = ResizeObservation(base_env, shape)
 
     assert isinstance(env.observation_space, spaces.Box)
     assert env.observation_space.shape[-1] == 3
@@ -20,3 +20,28 @@ def test_resize_observation(env_id, shape):
     else:
         assert env.observation_space.shape[:2] == tuple(shape)
         assert obs.shape == tuple(shape) + (3,)
+
+    # test two-dimensional input by grayscaling the observation
+    gray_env = GrayScaleObservation(base_env, keep_dim=False)
+    env = ResizeObservation(gray_env, shape)
+    obs, _ = env.reset()
+    if isinstance(shape, int):
+        assert env.observation_space.shape == obs.shape == (shape, shape)
+    else:
+        assert env.observation_space.shape == obs.shape == tuple(shape)
+
+
+def test_invalid_input():
+    env = gym.make("CarRacing-v2", disable_env_checker=True)
+    with pytest.raises(AssertionError):
+        ResizeObservation(env, ())
+    with pytest.raises(AssertionError):
+        ResizeObservation(env, (1,))
+    with pytest.raises(AssertionError):
+        ResizeObservation(env, (1, 1, 1, 1))
+    with pytest.raises(AssertionError):
+        ResizeObservation(env, -1)
+    with pytest.raises(AssertionError):
+        ResizeObservation(gym.make("CartPole-v1", disable_env_checker=True), 1)
+    with pytest.raises(AssertionError):
+        ResizeObservation(gym.make("Blackjack-v1", disable_env_checker=True), 1)


### PR DESCRIPTION
# Description

The `ResizeObservation` wrapper silently becomes buggy when passed an environment that produces two-dimensional observations, such as the output of `GrayscaleObservation` with `keep_dim=False` (the default), since it sets the `observation_space` to be two-dimensional (WxH), but actually produces three-dimensional output (WxHx1).

I changed the `observation` method to keep the shape, whether it be two- or three-dimensional. I also added extra checks in the constructor to make sure that the input is either two- or three-dimensional, since `cv2.resize` does not work otherwise.

Here is some code that demonstrates the bug:
```python
import gymnasium as gym
from gymnasium.wrappers import GrayScaleObservation, ResizeObservation


def assert_space_is_consistent(env):
    obs_shape = env.reset()[0].shape
    expected_shape = env.observation_space.shape
    if obs_shape != expected_shape:
        raise ValueError(f'Expected {expected_shape}, got {obs_shape}')


env = gym.make('CarRacing-v2', render_mode='rgb_array')

# Sanity check: works when keeping the dimension, i.e. WxHx1
gray_env = GrayScaleObservation(env, keep_dim=True)
resized_env = ResizeObservation(gray_env, 100)
assert_space_is_consistent(resized_env)  # this always passes

# Fails when discarding the dimension (the default behaviour), i.e. WxH
gray_env_flattened = GrayScaleObservation(env, keep_dim=False)
resized_env_flattened = ResizeObservation(gray_env_flattened, 100)
assert_space_is_consistent(resized_env_flattened)
```

In the current main branch, the last assert fails with the error:
```
ValueError: Expected (100, 100), got (100, 100, 1)
```
but passes with this fix applied.

Let me know if this change is desirable, and then I will go through the checklist before asking for a review. :)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
