### PR TITLE
Added vector env support to StepAPICompatibility wrapper.

### DIFF
--- a/gymnasium/wrappers/step_api_compatibility.py
+++ b/gymnasium/wrappers/step_api_compatibility.py
@@ -1,10 +1,7 @@
 """Implementation of StepAPICompatibility wrapper class for transforming envs between new and old step API."""
 import gymnasium as gym
 from gymnasium.logger import deprecation
-from gymnasium.utils.step_api_compatibility import (
-    convert_to_done_step_api,
-    convert_to_terminated_truncated_step_api,
-)
+from gymnasium.utils.step_api_compatibility import step_api_compatibility
 
 
 class StepAPICompatibility(gym.Wrapper):
@@ -36,6 +33,7 @@ class StepAPICompatibility(gym.Wrapper):
             output_truncation_bool (bool): Whether the wrapper's step method outputs two booleans (new API) or one boolean (old API)
         """
         super().__init__(env)
+        self.is_vector_env = isinstance(env.unwrapped, gym.vector.VectorEnv)
         self.output_truncation_bool = output_truncation_bool
         if not self.output_truncation_bool:
             deprecation(
@@ -52,7 +50,6 @@ class StepAPICompatibility(gym.Wrapper):
             (observation, reward, terminated, truncated, info) or (observation, reward, done, info)
         """
         step_returns = self.env.step(action)
-        if self.output_truncation_bool:
-            return convert_to_terminated_truncated_step_api(step_returns)
-        else:
-            return convert_to_done_step_api(step_returns)
+        return step_api_compatibility(
+            step_returns, self.output_truncation_bool, self.is_vector_env
+        )

--- a/tests/wrappers/test_step_compatibility.py
+++ b/tests/wrappers/test_step_compatibility.py
@@ -1,7 +1,9 @@
+import numpy as np
 import pytest
 
 import gymnasium as gym
 from gymnasium.spaces import Discrete
+from gymnasium.vector import AsyncVectorEnv, SyncVectorEnv
 from gymnasium.wrappers import StepAPICompatibility
 
 
@@ -52,6 +54,20 @@ def test_step_compatibility_to_old_api(env):
     assert len(step_returns) == 4
     _, _, done, _ = step_returns
     assert isinstance(done, bool)
+
+
+@pytest.mark.parametrize("vector_env", [SyncVectorEnv, AsyncVectorEnv])
+def test_vector_env_step_compatibility_to_old_api(vector_env):
+    num_envs = 2
+    env = vector_env([NewStepEnv for _ in range(num_envs)])
+    old_env = StepAPICompatibility(env, False)
+
+    step_returns = old_env.step([0] * num_envs)
+    assert len(step_returns) == 4
+    _, _, dones, _ = step_returns
+    assert isinstance(dones, np.ndarray)
+    for done in dones:
+        assert isinstance(done, np.bool_)
 
 
 @pytest.mark.parametrize("apply_api_compatibility", [None, True, False])


### PR DESCRIPTION
# Description

This PR adds support for vector environments in StepAPICompatibility wrapper. Previously, the wrapper was incompatible due to not passing proper flag to the underlying `step_api_compatibility` utility function.

Fixes #237 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
