### PR TITLE
Allow sequence to accept stacked np arrays if the feature space is Box

### DIFF
--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -8,6 +8,7 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 
+from gymnasium.spaces import Box
 from gymnasium.spaces.space import Space
 
 
@@ -119,9 +120,19 @@ class Sequence(Space[typing.Tuple[Any, ...]]):
 
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""
-        return isinstance(x, collections.abc.Sequence) and all(
+        # check for every other feature_space
+        if not isinstance(x, collections.abc.Sequence) and all(
             self.feature_space.contains(item) for item in x
-        )
+        ):
+            return True
+
+        # check specifically for box spaces to allow for stacked np arrays
+        if not isinstance(x, collections.abc.Iterable):
+            return False
+        if not isinstance(self.feature_space, Box):
+            return False
+        if all(self.feature_space.contains(el) for el in x):
+            return True
 
     def __repr__(self) -> str:
         """Gives a string representation of this space."""

--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -121,7 +121,7 @@ class Sequence(Space[typing.Tuple[Any, ...]]):
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""
         # check for every other feature_space
-        if not isinstance(x, collections.abc.Sequence) and all(
+        if isinstance(x, collections.abc.Sequence) and all(
             self.feature_space.contains(item) for item in x
         ):
             return True
@@ -131,8 +131,11 @@ class Sequence(Space[typing.Tuple[Any, ...]]):
             return False
         if not isinstance(self.feature_space, Box):
             return False
-        if all(self.feature_space.contains(el) for el in x):
-            return True
+        if not all(self.feature_space.contains(el) for el in x):
+            print("here")
+            return False
+
+        return True
 
     def __repr__(self) -> str:
         """Gives a string representation of this space."""

--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -132,7 +132,6 @@ class Sequence(Space[typing.Tuple[Any, ...]]):
         if not isinstance(self.feature_space, Box):
             return False
         if not all(self.feature_space.contains(el) for el in x):
-            print("here")
             return False
 
         return True

--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -120,18 +120,10 @@ class Sequence(Space[typing.Tuple[Any, ...]]):
 
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""
-        # check for every other feature_space
-        if isinstance(x, collections.abc.Sequence) and all(
-            self.feature_space.contains(item) for item in x
-        ):
-            return True
-
-        # check specifically for box spaces to allow for stacked np arrays
+        # by definition, any sequence is an iterable
         if not isinstance(x, collections.abc.Iterable):
             return False
-        if not isinstance(self.feature_space, Box):
-            return False
-        if not all(self.feature_space.contains(el) for el in x):
+        if not all(self.feature_space.contains(item) for item in x):
             return False
 
         return True

--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -120,12 +120,9 @@ class Sequence(Space[typing.Tuple[Any, ...]]):
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""
         # by definition, any sequence is an iterable
-        if not isinstance(x, collections.abc.Iterable):
-            return False
-        if not all(self.feature_space.contains(item) for item in x):
-            return False
-
-        return True
+        return isinstance(x, collections.abc.Iterable) and all(
+            self.feature_space.contains(item) for item in x
+        )
 
     def __repr__(self) -> str:
         """Gives a string representation of this space."""

--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -8,7 +8,6 @@ from typing import Any
 import numpy as np
 import numpy.typing as npt
 
-from gymnasium.spaces import Box
 from gymnasium.spaces.space import Space
 
 

--- a/tests/spaces/test_sequence.py
+++ b/tests/spaces/test_sequence.py
@@ -5,10 +5,11 @@ import pytest
 
 import gymnasium as gym
 
+
 def test_stacked_box():
     """Tests that sequence with a feature space of Box allows stacked np arrays."""
-    space = gym.spaces.Sequence(gym.spaces.Box(0, 1))
-    sample = np.random.rand(5, 1)
+    space = gym.spaces.Sequence(gym.spaces.Box(0, 1, shape=(3,)))
+    sample = np.float32(np.random.rand(5, 3))
     assert space.contains(sample)
 
 

--- a/tests/spaces/test_sequence.py
+++ b/tests/spaces/test_sequence.py
@@ -10,7 +10,9 @@ def test_stacked_box():
     """Tests that sequence with a feature space of Box allows stacked np arrays."""
     space = gym.spaces.Sequence(gym.spaces.Box(0, 1, shape=(3,)))
     sample = np.float32(np.random.rand(5, 3))
-    assert space.contains(sample)
+    assert space.contains(
+        sample
+    ), "Something went wrong, should be able to accept stacked np arrays for Box feature space."
 
 
 def test_sample():

--- a/tests/spaces/test_sequence.py
+++ b/tests/spaces/test_sequence.py
@@ -5,6 +5,12 @@ import pytest
 
 import gymnasium as gym
 
+def test_stacked_box():
+    """Tests that sequence with a feature space of Box allows stacked np arrays."""
+    space = gym.spaces.Sequence(gym.spaces.Box(0, 1))
+    sample = np.random.rand(5, 1)
+    assert space.contains(sample)
+
 
 def test_sample():
     """Tests the sequence sampling works as expects and the errors are correctly raised."""


### PR DESCRIPTION
# Description

This allows the Sequence space to accept numpy arrays of size `[n, *base_size]` if the feature space of the Sequence is `Box(shape=base_size)`.

Fixes # (issue)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update