### PR TITLE
Add back long description to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,19 @@ def get_version():
     raise RuntimeError("bad version data in __init__.py")
 
 
-setup(name="gymnasium", version=get_version())
+def get_description():
+    """Gets the description from the readme."""
+    with open("README.md") as fh:
+        long_description = ""
+        header_count = 0
+        for line in fh:
+            if line.startswith("##"):
+                header_count += 1
+            if header_count < 2:
+                long_description += line
+            else:
+                break
+    return long_description
+
+
+setup(name="gymnasium", version=get_version(), long_description=get_description())


### PR DESCRIPTION
# Description

Long description was removed from the setup.py to toml change earlier, this PR adds it back.
