### PR TITLE
docs(tutorials): fixed environment creation link

### DIFF
--- a/docs/tutorials/environment_creation.py
+++ b/docs/tutorials/environment_creation.py
@@ -20,7 +20,7 @@ Subclassing gymnasium.Env
 -------------------------
 
 Before learning how to create your own environment you should check out
-`the documentation of Gymnasium’s API </api/core>`__.
+`the documentation of Gymnasium’s API </api/env>`__.
 
 We will be concerned with a subset of gym-examples that looks like this:
 


### PR DESCRIPTION
# Description
The link at https://github.com/Farama-Foundation/Gymnasium/blob/8f0baf62aa13c69c77dc00bed0060e09d700890a/docs/tutorials/environment_creation.py#L23 was redirecting to 404.

I changed it to redirect to https://gymnasium.farama.org/api/env/

Fixes #231 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
