### PR TITLE
FIX: return type of AsyncVectorEnv.reset

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -216,7 +216,7 @@ class AsyncVectorEnv(VectorEnv):
         timeout: Optional[Union[int, float]] = None,
         seed: Optional[int] = None,
         options: Optional[dict] = None,
-    ) -> Union[ObsType, Tuple[ObsType, List[dict]]]:
+    ) -> Union[ObsType, Tuple[ObsType, dict]]:
         """Waits for the calls triggered by :meth:`reset_async` to finish and returns the results.
 
         Args:


### PR DESCRIPTION
The type of info returned by `AsyncVectorEnv.reset` should be `dict` and not `List[dict]`
