### PR TITLE
Minor fixes for the resize observation wrapper

### DIFF
--- a/gymnasium/wrappers/resize_observation.py
+++ b/gymnasium/wrappers/resize_observation.py
@@ -49,10 +49,8 @@ class ResizeObservation(gym.ObservationWrapper):
         ), f"Expected the observation space to be Box, actual type: {type(env.observation_space)}"
         dims = len(env.observation_space.shape)
         assert (
-            2 <= dims <= 3
+            dims == 2 or dims == 3
         ), f"Expected the observation space to have 2 or 3 dimensions, got: {dims}"
-
-        self.shape = tuple(shape)
 
         obs_shape = self.shape + env.observation_space.shape[2:]
         self.observation_space = Box(low=0, high=255, shape=obs_shape, dtype=np.uint8)


### PR DESCRIPTION
See #230

It got merged before I could look at it again, so just fixing two small annoyances:
1. `self.shape` was assigned twice
2. `2 <= dims <= 3` was replaced with `dims == 2 or dims == 3` to make it a bit obvious what the intention is