### PR TITLE
Doc improvement: add comment describing what convolve does

### DIFF
--- a/docs/tutorials/training_agents/blackjack_tutorial.py
+++ b/docs/tutorials/training_agents/blackjack_tutorial.py
@@ -296,15 +296,10 @@ for episode in tqdm(range(n_episodes)):
 # ------------------------------
 #
 
-# Each element of a 1-D convolution output is the dot product
-# between a corresponding portion of the first signal and the
-# entire second signal (array of ones for this context)
-# The size of the corresponding portion of the first signal is
-# the length of the second signal
-
 rolling_length = 500
 fig, axs = plt.subplots(ncols=3, figsize=(12, 5))
 axs[0].set_title("Episode rewards")
+# compute and assign a rolling average of the data to provide a smoother graph
 reward_moving_average = (
     np.convolve(
         np.array(env.return_queue).flatten(), np.ones(rolling_length), mode="valid"

--- a/docs/tutorials/training_agents/blackjack_tutorial.py
+++ b/docs/tutorials/training_agents/blackjack_tutorial.py
@@ -296,6 +296,12 @@ for episode in tqdm(range(n_episodes)):
 # ------------------------------
 #
 
+# Each element of a 1-D convolution output is the dot product
+# between a corresponding portion of the first signal and the
+# entire second signal (array of ones for this context)
+# The size of the corresponding portion of the first signal is
+# the length of the second signal
+
 rolling_length = 500
 fig, axs = plt.subplots(ncols=3, figsize=(12, 5))
 axs[0].set_title("Episode rewards")


### PR DESCRIPTION
# Description
This is a suggestion for doc improvement.
The use of convolution in average calculation (in the blackjack tutorial) doesn't jump out unless you've used the operation in the past. Felt a comment might aid someone else a bit lost as to why  `np.convolve` is used  


## Type of change

- [x] This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
