### PR TITLE
Add explicit error messages when unflatten discrete and multidiscrete fail

### DIFF
--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -275,7 +275,7 @@ def _unflatten_discrete(space: Discrete, x: NDArray[np.int64]) -> np.int64:
     if len(nonzero[0]) == 0:
         raise ValueError(
             f"{x} is not a valid one-hot encoded vector and can not be unflattened to space {space}. "
-            f"Not all valid values in a flattened space can be unflattened."
+            "Not all valid samples in a flattened space can be unflattened."
         )
     return space.start + nonzero[0][0]
 
@@ -290,7 +290,7 @@ def _unflatten_multidiscrete(
     if len(nonzero[0]) == 0:
         raise ValueError(
             f"{x} is not a concatenation of one-hot encoded vectors and can not be unflattened to space {space}. "
-            f"Not all valid values in a flattened space can be unflattened."
+            "Not all valid samples in a flattened space can be unflattened."
         )
     (indices,) = cast(type(offsets[:-1]), nonzero)
     return np.asarray(indices - offsets[:-1], dtype=space.dtype).reshape(space.shape)

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -271,7 +271,13 @@ def _unflatten_box_multibinary(
 
 @unflatten.register(Discrete)
 def _unflatten_discrete(space: Discrete, x: NDArray[np.int64]) -> np.int64:
-    return space.start + np.nonzero(x)[0][0]
+    nonzero = np.nonzero(x)
+    if len(nonzero[0]) == 0:
+        raise ValueError(
+            f"{x} is not a valid one-hot encoded vector and can not be unflattened to space {space}. "
+            f"Not all valid values in a flattened space can be unflattened."
+        )
+    return space.start + nonzero[0][0]
 
 
 @unflatten.register(MultiDiscrete)
@@ -280,8 +286,13 @@ def _unflatten_multidiscrete(
 ) -> NDArray[np.integer[Any]]:
     offsets = np.zeros((space.nvec.size + 1,), dtype=space.dtype)
     offsets[1:] = np.cumsum(space.nvec.flatten())
-
-    (indices,) = cast(type(offsets[:-1]), np.nonzero(x))
+    nonzero = np.nonzero(x)
+    if len(nonzero[0]) == 0:
+        raise ValueError(
+            f"{x} is not a concatenation of one-hot encoded vectors and can not be unflattened to space {space}. "
+            f"Not all valid values in a flattened space can be unflattened."
+        )
+    (indices,) = cast(type(offsets[:-1]), nonzero)
     return np.asarray(indices - offsets[:-1], dtype=space.dtype).reshape(space.shape)
 
 

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -135,3 +135,15 @@ def test_flatten_roundtripping(space):
 
     for original, roundtripped in zip(samples, unflattened_samples):
         assert data_equivalence(original, roundtripped)
+
+
+def test_unflatten_discrete_error():
+    value = np.array([0])
+    with pytest.raises(ValueError):
+        utils._unflatten_discrete(gym.spaces.Discrete(1), value)
+
+
+def test_unflatten_multidiscrete_error():
+    value = np.array([0, 0])
+    with pytest.raises(ValueError):
+        utils._unflatten_multidiscrete(gym.spaces.MultiDiscrete([1, 1]), value)

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -140,10 +140,10 @@ def test_flatten_roundtripping(space):
 def test_unflatten_discrete_error():
     value = np.array([0])
     with pytest.raises(ValueError):
-        utils._unflatten_discrete(gym.spaces.Discrete(1), value)
+        utils.unflatten(gym.spaces.Discrete(1), value)
 
 
 def test_unflatten_multidiscrete_error():
     value = np.array([0, 0])
     with pytest.raises(ValueError):
-        utils._unflatten_multidiscrete(gym.spaces.MultiDiscrete([1, 1]), value)
+        utils.unflatten(gym.spaces.MultiDiscrete([1, 1]), value)


### PR DESCRIPTION
# Description

Provide more explicit error messages for failing unflattening of Discrete and Multidescrete values.

- An error would be raised anyway for the cases that are catch.
- Values mapping itself is not checked, see #102 for the full discussion.
- Error messages try also to contextualize and remind that not all samples from a flattened space can be unflattened (enforcing the state of the flattening feature) in order to help users that may think they are (I did even having quickly walked among doc).

Related to #102 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] NOT RELEVANT - I have commented my code, particularly in hard-to-understand areas
- [ ] NOT RELEVANT - I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
