### PR TITLE
Remove shimmy as a core dependency 

### DIFF
--- a/gymnasium/envs/__init__.py
+++ b/gymnasium/envs/__init__.py
@@ -348,5 +348,17 @@ register(
 )
 
 
+# --- For shimmy compatibility
+def _raise_shimmy_error():
+    raise ImportError(
+        "To use the gym compatibility environments, run `pip install shimmy[gym]`"
+    )
+
+
+# When installed, shimmy will re-register these environments with the correct entry_point
+register(id="GymV22Environment-v0", entry_point=_raise_shimmy_error)
+register(id="GymV26Environment-v0", entry_point=_raise_shimmy_error)
+
+
 # Hook to load plugins from entry points
 load_env_plugins()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "importlib-metadata >=4.8.0; python_version < '3.10'",
     "typing-extensions >=4.3.0",
     "gymnasium-notices >=0.0.1",
-    "shimmy >=0.1.0,<1.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
As both shimmy and gymnasium have each other as core dependencies then issues can occur when building the projects
https://github.com/Farama-Foundation/Shimmy/issues/23

Therefore, we are removing shimmy as a core dependency of gymnasium.
To ensure backward compatibility, we register the gym compatibility environments, such that shimmy will re-register the environment if installed