### PR TITLE
Fix AttributeError in lunar_lander.py

### DIFF
--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -616,7 +616,7 @@ class LunarLander(gym.Env, EzPickle):
             gym.logger.warn(
                 "You are calling render method without specifying any render mode. "
                 "You can specify the render_mode at initialization, "
-                f'e.g. gym.make("{self.spec.id}", render_mode="rgb_array")'
+                'e.g. gym("LunarLander-v2", render_mode="rgb_array")'
             )
             return
 

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -616,7 +616,7 @@ class LunarLander(gym.Env, EzPickle):
             gym.logger.warn(
                 "You are calling render method without specifying any render mode. "
                 "You can specify the render_mode at initialization, "
-                'e.g. gym("LunarLander-v2", render_mode="rgb_array")'
+                f'e.g. gym.make("{self.spec.id}", render_mode="rgb_array")'
             )
             return
 

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -826,4 +826,5 @@ class LunarLanderContinuous:
 
 
 if __name__ == "__main__":
-    demo_heuristic_lander(LunarLander(), render=True)
+    env = gym.make("LunarLander-v2", render_mode="rgb_array")
+    demo_heuristic_lander(env, render=True)


### PR DESCRIPTION
# Description

fix AttributeError of  `lunar_lander.py`

when I run `python gymnasium/envs/box2d/lunar_lander.py`, it raise,

```shell
AttributeError: 'NoneType' object has no attribute 'id'
```
`self.spec` is `None`, so it has no attribute 'id'.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.


| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/44900829/213724047-436d183a-f415-4084-816f-5d35a766f828.png)| ![image](https://user-images.githubusercontent.com/44900829/213724258-1966a2e1-470a-4c77-89a1-923178d7dc8f.png)|

<!--
To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
