### PR TITLE
Switch references of the MultiBinary and MultiDiscrete classes in documentation

### DIFF
--- a/docs/api/spaces.md
+++ b/docs/api/spaces.md
@@ -53,8 +53,8 @@ Gymnasium has a number of fundamental spaces that are used as building boxes for
 
 * :py:class:`Box` - Supports continuous (and discrete) vectors or matrices, used for vector observations, images, etc
 * :py:class:`Discrete` - Supports a single discrete number of values with an optional start for the values
-* :py:class:`MultiDiscrete` - Supports single or matrices of binary values, used for holding down a button or if an agent has an object
-* :py:class:`MultiBinary` - Supports multiple discrete values with multiple axes, used for controller actions
+* :py:class:`MultiBinary` - Supports single or matrices of binary values, used for holding down a button or if an agent has an object
+* :py:class:`MultiDiscrete` - Supports multiple discrete values with multiple axes, used for controller actions
 * :py:class:`Text` - Supports strings, used for passing agent messages, mission details, etc
 ```
 


### PR DESCRIPTION
# Description

Switch references of the `MultiBinary` and `MultiDiscrete` classes in list of fundamental spaces to match their corresponding description.

Fixes #275 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
