### PR TITLE
Change `GymV22Compatibility` to `GymV21Compatibility` 

### DIFF
--- a/docs/content/gym_compatibility.md
+++ b/docs/content/gym_compatibility.md
@@ -20,22 +20,34 @@ To perform conversion through a wrapper, the environment itself can be passed to
 An example of this is atari 0.8.0 which does not have a gymnasium implementation.
 ```python
 import gymnasium as gym
+
 env = gym.make("GymV26Environment-v0", env_id="ALE/Pong-v5")
 ```
 
-## Gym v0.22 Environment Compatibility
+## Gym v0.21 Environment Compatibility
 
 ```{eval-rst}
 .. py:currentmodule:: gymnasium
 
 A number of environments have not updated to the recent Gym changes, in particular since v0.21.
 This update is significant for the introduction of ``termination`` and ``truncation`` signatures in favour of the previously used ``done``.
-To allow backward compatibility, Gym and Gymnasium v0.26+ include an ``apply_api_compatibility`` kwarg when calling :meth:`make` that automatically converts a v0.21 API compliant environment one that is compatible with v0.26+.
+To allow backward compatibility, Gym and Gymnasium v0.26+ include an ``apply_api_compatibility`` kwarg when calling :meth:`make` that automatically converts a v0.21 API compliant environment to one that is compatible with v0.26+.
 ```
 
 ```python
 import gym
+
 env = gym.make("OldV21Env-v0", apply_api_compatibility=True)
+```
+
+Additionally, in Gymnasium we provide specialist environments for compatibility that for ``env_id`` will call ``gym.make``.
+```python
+import gymnasium
+
+env = gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1", make_kwargs={"length": 1}, render_mode="human")
+# or
+env = gymnasium.make("GymV21Environment-v0", env=OldV21Env())
+
 ```
 
 ## Step API Compatibility

--- a/gymnasium/envs/__init__.py
+++ b/gymnasium/envs/__init__.py
@@ -1,4 +1,6 @@
 """Registers the internal gym envs then loads the env plugins for module using the entry point."""
+from typing import Any
+
 from gymnasium.envs.registration import (
     load_env_plugins,
     make,
@@ -349,14 +351,14 @@ register(
 
 
 # --- For shimmy compatibility
-def _raise_shimmy_error():
+def _raise_shimmy_error(*args: Any, **kwargs: Any):
     raise ImportError(
         "To use the gym compatibility environments, run `pip install shimmy[gym]`"
     )
 
 
 # When installed, shimmy will re-register these environments with the correct entry_point
-register(id="GymV22Environment-v0", entry_point=_raise_shimmy_error)
+register(id="GymV21Environment-v0", entry_point=_raise_shimmy_error)
 register(id="GymV26Environment-v0", entry_point=_raise_shimmy_error)
 
 

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -158,6 +158,11 @@ class EnvSpec:
         return make(self, **kwargs)
 
 
+# Global registry of environments. Meant to be accessed through `register` and `make`
+registry: dict[str, EnvSpec] = {}
+current_namespace: str | None = None
+
+
 def _check_namespace_exists(ns: str | None):
     """Check if a namespace exists. If it doesn't, print a helpful error message."""
     if ns is None:
@@ -374,11 +379,6 @@ def make(id: Literal[
     "Humanoid-v2", "Humanoid-v3", "Humanoid-v4",
 ], **kwargs) -> Env[np.ndarray, np.ndarray]: ...
 # fmt: on
-
-
-# Global registry of environments. Meant to be accessed through `register` and `make`
-registry: dict[str, EnvSpec] = {}
-current_namespace: str | None = None
 
 
 def _check_spec_register(spec: EnvSpec):

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -158,11 +158,6 @@ class EnvSpec:
         return make(self, **kwargs)
 
 
-# Global registry of environments. Meant to be accessed through `register` and `make`
-registry: dict[str, EnvSpec] = {}
-current_namespace: str | None = None
-
-
 def _check_namespace_exists(ns: str | None):
     """Check if a namespace exists. If it doesn't, print a helpful error message."""
     if ns is None:
@@ -379,6 +374,11 @@ def make(id: Literal[
     "Humanoid-v2", "Humanoid-v3", "Humanoid-v4",
 ], **kwargs) -> Env[np.ndarray, np.ndarray]: ...
 # fmt: on
+
+
+# Global registry of environments. Meant to be accessed through `register` and `make`
+registry: dict[str, EnvSpec] = {}
+current_namespace: str | None = None
 
 
 def _check_spec_register(spec: EnvSpec):

--- a/gymnasium/wrappers/compatibility.py
+++ b/gymnasium/wrappers/compatibility.py
@@ -65,8 +65,8 @@ class EnvCompatibility(gym.Env):
             render_mode (str): the render mode to use when rendering the environment, passed automatically to env.render
         """
         logger.warn(
-            "The `gymnasium.make(..., apply_api_compatibility=...)` parameter is deprecated and will be removed in v0.28. "
-            "Instead use `gym.make('GymV22Environment-v0', env_name=...)` or `from shimmy import GymV22CompatibilityV0`"
+            "The `gymnasium.make(..., apply_api_compatibility=...)` parameter is deprecated and will be removed in v0.29. "
+            "Instead use `gym.make('GymV21Environment-v0', env_name=...)` or `from shimmy import GymV21CompatibilityV0`"
         )
         self.metadata = getattr(old_env, "metadata", {"render_modes": []})
         self.render_mode = render_mode

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -143,7 +143,7 @@ def test_make_compatibility_in_make():
 
 
 def test_shimmy_gym_compatibility():
-    assert gymnasium.spec("GymV22Environment-v0") is not None
+    assert gymnasium.spec("GymV21Environment-v0") is not None
     assert gymnasium.spec("GymV26Environment-v0") is not None
 
     if shimmy is None:
@@ -153,7 +153,7 @@ def test_shimmy_gym_compatibility():
                 "To use the gym compatibility environments, run `pip install shimmy[gym]`"
             ),
         ):
-            gymnasium.make("GymV22Environment-v0")
+            gymnasium.make("GymV21Environment-v0")
         with pytest.raises(
             ImportError,
             match=re.escape(
@@ -168,7 +168,7 @@ def test_shimmy_gym_compatibility():
                 "No module named 'gym' (Hint: You need to install gym with `pip install gym` to use gym environments"
             ),
         ):
-            gymnasium.make("GymV22Environment-v0", env_id="CartPole-v1")
+            gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1")
         with pytest.raises(
             DependencyNotInstalled,
             match=re.escape(
@@ -177,5 +177,5 @@ def test_shimmy_gym_compatibility():
         ):
             gymnasium.make("GymV26Environment-v0", env_id="CartPole-v1")
     else:
-        gymnasium.make("GymV22Environment-v0", env_id="CartPole-v1")
+        gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1")
         gymnasium.make("GymV26Environment-v0", env_id="CartPole-v1")

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -153,14 +153,14 @@ def test_shimmy_gym_compatibility():
                 "To use the gym compatibility environments, run `pip install shimmy[gym]`"
             ),
         ):
-            gymnasium.make("GymV21Environment-v0")
+            gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1")
         with pytest.raises(
             ImportError,
             match=re.escape(
                 "To use the gym compatibility environments, run `pip install shimmy[gym]`"
             ),
         ):
-            gymnasium.make("GymV26Environment-v0")
+            gymnasium.make("GymV26Environment-v0", env_id="CartPole-v1")
     elif gym is None:
         with pytest.raises(
             DependencyNotInstalled,
@@ -177,5 +177,6 @@ def test_shimmy_gym_compatibility():
         ):
             gymnasium.make("GymV26Environment-v0", env_id="CartPole-v1")
     else:
-        gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1")
+        # todo - update when shimmy is updated to v0.28
+        gymnasium.make("GymV22Environment-v0", env_id="CartPole-v1")
         gymnasium.make("GymV26Environment-v0", env_id="CartPole-v1")

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -168,7 +168,8 @@ def test_shimmy_gym_compatibility():
                 "No module named 'gym' (Hint: You need to install gym with `pip install gym` to use gym environments"
             ),
         ):
-            gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1")
+            # todo - update when shimmy is updated to v0.28
+            gymnasium.make("GymV22Environment-v0", env_id="CartPole-v1")
         with pytest.raises(
             DependencyNotInstalled,
             match=re.escape(


### PR DESCRIPTION
In order to de-couple shimmy and gymnasium, such that they are not core dependencies of both.
For backward compatibility, we register dummy / fake gym compatibility environments.

However, it was founded in shimmy that the v22 compatibility is actually for v21. 
Therefore, shimmy is updating to use `GymV21Compatibility` rather than `GymV22Compatibility`.

As the shimmy is not updated yet, we need to keep use the shimmy V0.22 environments but as soon as this is released then we can update shimmy and then need to fix this issue  