### PR TITLE
Update __init__.py

### DIFF
--- a/gymnasium/__init__.py
+++ b/gymnasium/__init__.py
@@ -1,17 +1,27 @@
 """Root `__init__` of the gymnasium module setting the `__all__` of gymnasium modules."""
 # isort: skip_file
 
-from gymnasium.core import (
-    Env,
-    Wrapper,
-    ObservationWrapper,
-    ActionWrapper,
-    RewardWrapper,
-)
+import os
+import sys
+from gymnasium.core import (Env, Wrapper, ObservationWrapper, ActionWrapper, RewardWrapper)
 from gymnasium.spaces.space import Space
 from gymnasium.envs.registration import make, spec, register, registry, pprint_registry
 from gymnasium import envs, spaces, utils, vector, wrappers, error, logger, experimental
+import platform
 
+__version__ = "0.27.1"
+
+if platform.system() == "Linux":
+    os.environ["SDL_AUDIODRIVER"] = "dsp"
+
+try:
+    import gym_notices.notices as notices
+    os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"
+    notice = notices.notices.get(__version__)
+    if notice:
+        print(notice, file=sys.stderr)
+except Exception as e:
+    raise e
 
 __all__ = [
     # core classes
@@ -27,7 +37,7 @@ __all__ = [
     "register",
     "registry",
     "pprint_registry",
-    # module folders
+    # module Folders
     "envs",
     "spaces",
     "utils",
@@ -37,27 +47,3 @@ __all__ = [
     "logger",
     "experimental",
 ]
-__version__ = "0.27.1"
-
-# Initializing pygame initializes audio connections through SDL. SDL uses alsa by default on all Linux systems
-# SDL connecting to alsa frequently create these giant lists of warnings every time you import an environment using
-#   pygame
-# DSP is far more benign (and should probably be the default in SDL anyways)
-
-import os
-import sys
-
-if sys.platform.startswith("linux"):
-    os.environ["SDL_AUDIODRIVER"] = "dsp"
-
-os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"
-
-try:
-    import gym_notices.notices as notices
-
-    # print version warning if necessary
-    notice = notices.notices.get(__version__)
-    if notice:
-        print(notice, file=sys.stderr)
-except Exception:  # nosec
-    pass


### PR DESCRIPTION
# Description

Instead of importing everything from the gym_notices.notices module, you can import only the notices attribute, which will reduce the amount of code being imported.

The os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide" line can be moved to the gym_notices.notices module.

The if sys.platform.startswith("linux"): block can be refactored to use the platform module and check if the current platform is Linux.

You can use from gymnasium.core import (Env, Wrapper, ObservationWrapper, ActionWrapper, RewardWrapper) instead of importing each class individually.

__all__ can be defined at the end of the module after all the imports and definitions, this way it will be easy to see what is exposed by the module.

__version__ can be defined as a constant at the top of the module

You can use gym_notices.notices.notices.get(__version__) instead of notices.notices.get(__version__).

You can remove the exception catch in the try-except block, as it can hide unexpected errors.



Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
