### PR TITLE
Update docker_entrypoint

### DIFF
--- a/bin/docker_entrypoint
+++ b/bin/docker_entrypoint
@@ -1,26 +1,40 @@
 #!/bin/bash
-# This script is the entrypoint for our Docker image.
 
 set -ex
 
 # Set up display; otherwise rendering will fail
 Xvfb -screen 0 1024x768x24 &
+disp_pid=$!
 export DISPLAY=:0
 
 # Wait for the file to come up
-display=0
-file="/tmp/.X11-unix/X$display"
-for i in $(seq 1 10); do
-    if [ -e "$file" ]; then
-	break
-    fi
+file="/tmp/.X11-unix/X0"
+for i in {1..10}; do
+if [ -e "$file" ]; then
+break
+fi
 
-    echo "Waiting for $file to be created (try $i/10)"
-    sleep "$i"
+# Copy code
+echo "Waiting for $file to be created (try $i/10)"
+sleep "$i"
 done
+
 if ! [ -e "$file" ]; then
-    echo "Timing out: $file was not created"
-    exit 1
+echo "Timing out: $file was not created"
+kill $disp_pid
+exit 1
 fi
 
 exec "$@"
+
+# Add trap to cleanup and exit when script is interrupted
+trap "kill $disp_pid; exit" INT TERM
+
+# Wait for background process to finish
+wait $disp_pid
+
+# Exit with the exit code of the last executed command
+exit $?
+
+
+


### PR DESCRIPTION
I added a variable, disp_pid, to store the process ID of the Xvfb process, so that it can be killed if the script exits before the Xvfb process completes. I replaced the for loop with a {1..10} range loop, which is more concise and easier to read. I added a trap statement at the end of the script that will clean up and exit when the script is interrupted by a INT or TERM signal. I added a wait command at the end of the script, which will wait for the background Xvfb process to finish before exiting the script. I added the exit command at the end of the script, which will exit the script with the exit code of the last executed command.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
