### PR TITLE
Ignore GymV21Environment when building environments docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,6 +68,7 @@ environments/third_party_environments
 :caption: Tutorials
 
 tutorials/**/index
+Comet Tutorial <https://www.comet.com/docs/v2/integrations/ml-frameworks/gymnasium/>
 ```
 
 ```{toctree}

--- a/docs/scripts/utils.py
+++ b/docs/scripts/utils.py
@@ -41,4 +41,5 @@ kill_strs = [
     "oulette",
     "DomainRandom",
     "RacingDiscrete",
+    "GymV21Environment",
 ]


### PR DESCRIPTION
# Description

Ignore `GymV21Environment` when building environments docs. Fixes failing workflow