### PR TITLE
chore: remove args references from env.render :fire:

### DIFF
--- a/gymnasium/wrappers/env_checker.py
+++ b/gymnasium/wrappers/env_checker.py
@@ -46,10 +46,10 @@ class PassiveEnvChecker(gym.Wrapper):
         else:
             return self.env.reset(**kwargs)
 
-    def render(self, *args, **kwargs):
+    def render(self):
         """Renders the environment that on the first call will run the `passive_env_render_check`."""
         if self.checked_render is False:
             self.checked_render = True
-            return env_render_passive_checker(self.env, *args, **kwargs)
+            return env_render_passive_checker(self.env)
         else:
-            return self.env.render(*args, **kwargs)
+            return self.env.render()

--- a/gymnasium/wrappers/order_enforcing.py
+++ b/gymnasium/wrappers/order_enforcing.py
@@ -47,14 +47,14 @@ class OrderEnforcing(gym.Wrapper):
         self._has_reset = True
         return self.env.reset(**kwargs)
 
-    def render(self, *args, **kwargs):
+    def render(self):
         """Renders the environment with `kwargs`."""
         if not self._disable_render_order_enforcing and not self._has_reset:
             raise ResetNeeded(
                 "Cannot call `env.render()` before calling `env.reset()`, if this is a intended action, "
                 "set `disable_render_order_enforcing=True` on the OrderEnforcer wrapper."
             )
-        return self.env.render(*args, **kwargs)
+        return self.env.render()
 
     @property
     def has_reset(self):

--- a/gymnasium/wrappers/record_video.py
+++ b/gymnasium/wrappers/record_video.py
@@ -186,10 +186,10 @@ class RecordVideo(gym.Wrapper):
         self.recording = False
         self.recorded_frames = 1
 
-    def render(self, *args, **kwargs):
+    def render(self):
         """Compute the render frames as specified by render_mode attribute during initialization of the environment or as specified in kwargs."""
         if self.video_recorder is None or not self.video_recorder.enabled:
-            return super().render(*args, **kwargs)
+            return super().render()
 
         if len(self.video_recorder.render_history) > 0:
             recorded_frames = [
@@ -199,9 +199,9 @@ class RecordVideo(gym.Wrapper):
             if self.recording:
                 return recorded_frames
             else:
-                return recorded_frames + super().render(*args, **kwargs)
+                return recorded_frames + super().render()
         else:
-            return super().render(*args, **kwargs)
+            return super().render()
 
     def close(self):
         """Closes the wrapper then the video recorder."""

--- a/tests/wrappers/test_pixel_observation.py
+++ b/tests/wrappers/test_pixel_observation.py
@@ -14,6 +14,7 @@ class FakeEnvironment(gym.Env):
         self.action_space = spaces.Box(shape=(1,), low=-1, high=1, dtype=np.float32)
         self.render_mode = render_mode
 
+    # since env.render doesn't accept parameters anymore, this mock should be refactored
     def render(self, mode="human", width=32, height=32):
         image_shape = (height, width, 3)
         return np.zeros(image_shape, dtype=np.uint8)
@@ -47,6 +48,9 @@ class FakeDictObservationEnvironment(FakeEnvironment):
         )
         super().__init__(*args, **kwargs)
 
+    def render(self, mode="human", width=320, height=240):
+        return super().render(mode, width, height)
+
 
 @pytest.mark.parametrize("pixels_only", (True, False))
 def test_dict_observation(pixels_only):
@@ -65,7 +69,6 @@ def test_dict_observation(pixels_only):
         env,
         pixel_keys=(pixel_key,),
         pixels_only=pixels_only,
-        render_kwargs={pixel_key: {"width": width, "height": height}},
     )
 
     assert isinstance(wrapped_env.observation_space, spaces.Dict)


### PR DESCRIPTION
# Description

This commit adds the following changes:
- remove `*args`, `**kwargs` from `env.render` calls
- remove `render_kwargs` from `PixelObservationWrapper`

Fixes #283 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes