### PR TITLE
New vector API - revert old tests

### DIFF
--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -10,7 +10,7 @@ from gymnasium.error import (
     NoAsyncCallError,
 )
 from gymnasium.spaces import Box, Discrete, MultiDiscrete, Tuple
-from gymnasium.vector import AsyncVectorEnv
+from gymnasium.vector.async_vector_env import AsyncVectorEnv
 from tests.vector.utils import (
     CustomSpace,
     make_custom_space_env,

--- a/tests/vector/test_sync_vector_env.py
+++ b/tests/vector/test_sync_vector_env.py
@@ -3,7 +3,7 @@ import pytest
 
 from gymnasium.envs.registration import EnvSpec
 from gymnasium.spaces import Box, Discrete, MultiDiscrete, Tuple
-from gymnasium.vector import SyncVectorEnv
+from gymnasium.vector.sync_vector_env import SyncVectorEnv
 from tests.envs.utils import all_testing_env_specs
 from tests.vector.utils import (
     CustomSpace,

--- a/tests/vector/test_vector_env.py
+++ b/tests/vector/test_vector_env.py
@@ -3,10 +3,12 @@ from functools import partial
 import numpy as np
 import pytest
 
-from gymnasium.spaces import Discrete
-from gymnasium.vector import AsyncVectorEnv, SyncVectorEnv
+from gymnasium.spaces import Discrete, Tuple
+from gymnasium.vector.async_vector_env import AsyncVectorEnv
+from gymnasium.vector.sync_vector_env import SyncVectorEnv
+from gymnasium.vector.vector_env import VectorEnv
 from tests.testing_env import GenericTestEnv
-from tests.vector.utils import make_env
+from tests.vector.utils import CustomSpace, make_env
 
 
 @pytest.mark.parametrize("shared_memory", [True, False])
@@ -49,6 +51,16 @@ def test_vector_env_equal(shared_memory):
 
     async_env.close()
     sync_env.close()
+
+
+def test_custom_space_vector_env():
+    env = VectorEnv(4, CustomSpace(), CustomSpace())
+
+    assert isinstance(env.single_observation_space, CustomSpace)
+    assert isinstance(env.observation_space, Tuple)
+
+    assert isinstance(env.single_action_space, CustomSpace)
+    assert isinstance(env.action_space, Tuple)
 
 
 @pytest.mark.parametrize(

--- a/tests/vector/test_vector_env_wrapper.py
+++ b/tests/vector/test_vector_env_wrapper.py
@@ -1,22 +1,20 @@
 import numpy as np
 
-import gymnasium as gym
-from gymnasium.vector import VectorEnvWrapper
+from gymnasium.vector import VectorEnvWrapper, make
 
 
 class DummyWrapper(VectorEnvWrapper):
     def __init__(self, env):
-        super().__init__(env)
         self.env = env
         self.counter = 0
 
-    def reset(self, **kwargs):
-        super().reset()
+    def reset_async(self, **kwargs):
+        super().reset_async()
         self.counter += 1
 
 
 def test_vector_env_wrapper_inheritance():
-    env = gym.vector.make("FrozenLake-v1", asynchronous=True)
+    env = make("FrozenLake-v1", asynchronous=False)
     wrapped = DummyWrapper(env)
     wrapped.reset()
     assert wrapped.counter == 1
@@ -24,8 +22,8 @@ def test_vector_env_wrapper_inheritance():
 
 def test_vector_env_wrapper_attributes():
     """Test if `set_attr`, `call` methods for VecEnvWrapper get correctly forwarded to the vector env it is wrapping."""
-    env = gym.vector.make("CartPole-v1", num_envs=3)
-    wrapped = DummyWrapper(gym.vector.make("CartPole-v1", num_envs=3))
+    env = make("CartPole-v1", num_envs=3)
+    wrapped = DummyWrapper(make("CartPole-v1", num_envs=3))
 
     assert np.allclose(wrapped.call("gravity"), env.call("gravity"))
     env.set_attr("gravity", [20.0, 20.0, 20.0])

--- a/tests/vector/test_vector_make.py
+++ b/tests/vector/test_vector_make.py
@@ -3,6 +3,7 @@ import pytest
 import gymnasium as gym
 from gymnasium.vector import AsyncVectorEnv, SyncVectorEnv
 from gymnasium.wrappers import TimeLimit, TransformObservation
+from gymnasium.wrappers.env_checker import PassiveEnvChecker
 from tests.wrappers.utils import has_wrapper
 
 
@@ -50,10 +51,33 @@ def test_vector_make_wrappers():
         "CartPole-v1",
         num_envs=2,
         asynchronous=False,
-        wrappers=[lambda _env: TransformObservation(_env, lambda obs: obs * 2)],
+        wrappers=lambda _env: TransformObservation(_env, lambda obs: obs * 2),
     )
     # As asynchronous environment are inaccessible, synchronous vector must be used
     assert isinstance(env, SyncVectorEnv)
     assert all(has_wrapper(sub_env, TransformObservation) for sub_env in env.envs)
 
+    env.close()
+
+
+def test_vector_make_disable_env_checker():
+    # As asynchronous environment are inaccessible, synchronous vector must be used
+    env = gym.vector.make("CartPole-v1", num_envs=1, asynchronous=False)
+    assert isinstance(env, SyncVectorEnv)
+    assert has_wrapper(env.envs[0], PassiveEnvChecker)
+    env.close()
+
+    env = gym.vector.make("CartPole-v1", num_envs=5, asynchronous=False)
+    assert isinstance(env, SyncVectorEnv)
+    assert has_wrapper(env.envs[0], PassiveEnvChecker)
+    assert all(
+        has_wrapper(env.envs[i], PassiveEnvChecker) is False for i in [1, 2, 3, 4]
+    )
+    env.close()
+
+    env = gym.vector.make(
+        "CartPole-v1", num_envs=3, asynchronous=False, disable_env_checker=True
+    )
+    assert isinstance(env, SyncVectorEnv)
+    assert all(has_wrapper(sub_env, PassiveEnvChecker) is False for sub_env in env.envs)
     env.close()


### PR DESCRIPTION
This should remove all changes to the old vector API tests