### PR TITLE
Properly handle different kwargs in the new vector API

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -698,7 +698,7 @@ def make_vec(
 ) -> gym.experimental.VectorEnv:
     """Create a vector environment according to the given ID.
 
-    Note: 
+    Note:
         This feature is experimental, and is likely to change in future releases.
 
     To find all available environments use `gymnasium.envs.registry.keys()` for all valid ids.

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -698,7 +698,8 @@ def make_vec(
 ) -> gym.experimental.VectorEnv:
     """Create a vector environment according to the given ID.
 
-    Note that this functionality is experimental, and is likely to change in future releases.
+    Note: 
+        This feature is experimental, and is likely to change in future releases.
 
     To find all available environments use `gymnasium.envs.registry.keys()` for all valid ids.
 

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -696,7 +696,9 @@ def make_vec(
     wrappers: Sequence[Callable[[Env], Wrapper]] | None = None,
     **kwargs,
 ) -> gym.experimental.VectorEnv:
-    """Create an environment according to the given ID.
+    """Create a vector environment according to the given ID.
+
+    Note that this functionality is experimental, and is likely to change in future releases.
 
     To find all available environments use `gymnasium.envs.registry.keys()` for all valid ids.
 
@@ -787,8 +789,8 @@ def make_vec(
     elif vectorization_mode == "custom":
         if len(wrappers) > 0:
             raise error.Error("Cannot use custom vectorization mode with wrappers.")
-        _kwargs["max_episode_steps"] = spec_.max_episode_steps
-        env = env_creator(num_envs=num_envs, **_kwargs)
+        vector_kwargs["max_episode_steps"] = spec_.max_episode_steps
+        env = env_creator(num_envs=num_envs, **vector_kwargs)
     else:
         raise error.Error(f"Invalid vectorization mode: {vectorization_mode}")
 


### PR DESCRIPTION
`**kwargs` and `vector_kwargs` were mixed up between the different vectorization modes, now they are not.