### PR TITLE
Add docstring parser to remove duplicate in Gymnasium website

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,20 @@ napoleon_custom_sections = [("Returns", "params_style")]
 autoclass_content = "both"
 autodoc_preserve_defaults = True
 
+
+# This function removes the content before the parameters in the __init__ function.
+# This content is often not useful for the website documentation as it replicates
+# the class docstring.
+def remove_lines_before_parameters(app, what, name, obj, options, lines):
+    if what == "class":
+        result = [i for i in lines if i.startswith(":param")]
+        lines[:] = result if result else lines
+
+
+def setup(app):
+    app.connect("autodoc-process-docstring", remove_lines_before_parameters)
+
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,8 +72,11 @@ autodoc_preserve_defaults = True
 # the class docstring.
 def remove_lines_before_parameters(app, what, name, obj, options, lines):
     if what == "class":
-        result = [i for i in lines if i.startswith(":param")]
-        lines[:] = result if result else lines
+        # ":" represents args values such as :param: or :raises:
+        idx_to_keep = next(
+            (i for i, line in enumerate(lines) if line.startswith(":")), 0
+        )
+        lines[:] = lines[idx_to_keep:]
 
 
 def setup(app):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,10 +73,10 @@ autodoc_preserve_defaults = True
 def remove_lines_before_parameters(app, what, name, obj, options, lines):
     if what == "class":
         # ":" represents args values such as :param: or :raises:
-        idx_to_keep = next(
+        first_idx_to_keep = next(
             (i for i, line in enumerate(lines) if line.startswith(":")), 0
         )
-        lines[:] = lines[idx_to_keep:]
+        lines[:] = lines[first_idx_to_keep:]
 
 
 def setup(app):

--- a/gymnasium/spaces/dict.py
+++ b/gymnasium/spaces/dict.py
@@ -17,10 +17,10 @@ class Dict(Space[typing.Dict[str, Any]], typing.Mapping[str, Space[Any]]):
     Elements of this space are (ordered) dictionaries of elements from the constituent spaces.
 
     Example:
-        >>> from gymnasium.spaces import Dict, Discrete
-        >>> observation_space = Dict({"position": Discrete(2), "velocity": Discrete(3)}, seed=42)
+        >>> from gymnasium.spaces import Dict, Box, Discrete
+        >>> observation_space = Dict({"position": Box(-1, 1, shape=(2,)), "color": Discrete(3)}, seed=42)
         >>> observation_space.sample()
-        OrderedDict([('position', 0), ('velocity', 2)])
+        OrderedDict([('color', 0), ('position', array([-0.3991573 ,  0.21649833], dtype=float32))])
 
         With a nested dict:
 
@@ -65,15 +65,6 @@ class Dict(Space[typing.Dict[str, Any]], typing.Mapping[str, Space[Any]]):
             spaces: A dictionary of spaces. This specifies the structure of the :class:`Dict` space
             seed: Optionally, you can use this argument to seed the RNGs of the spaces that make up the :class:`Dict` space.
             **spaces_kwargs: If ``spaces`` is ``None``, you need to pass the constituent spaces as keyword arguments, as described above.
-
-        Example:
-            >>> from gymnasium.spaces import Dict, Box, Discrete
-            >>> observation_space = Dict({"position": Box(-1, 1, shape=(2,)), "color": Discrete(3)}, seed=42)
-            >>> observation_space.sample()
-            OrderedDict([('color', 0), ('position', array([-0.3991573 ,  0.21649833], dtype=float32))])
-            >>> observation_space = Dict(position=Box(-1, 1, shape=(2,)), color=Discrete(3), seed=42)
-            >>> observation_space.sample()
-            OrderedDict([('position', array([0.6273108, 0.240238 ], dtype=float32)), ('color', 2)])
         """
         # Convert the spaces into an OrderedDict
         if isinstance(spaces, collections.abc.Mapping) and not isinstance(

--- a/gymnasium/wrappers/step_api_compatibility.py
+++ b/gymnasium/wrappers/step_api_compatibility.py
@@ -11,10 +11,6 @@ class StepAPICompatibility(gym.Wrapper):
     New step API refers to step() method returning (observation, reward, terminated, truncated, info)
     (Refer to docs for details on the API change)
 
-    Args:
-        env (gym.Env): the env to wrap. Can be in old or new API
-        output_truncation_bool (bool): Apply to convert environment to use new step API that returns two bool. (True by default)
-
     Example:
         >>> import gymnasium as gym
         >>> from gymnasium.wrappers import StepAPICompatibility


### PR DESCRIPTION
# Description

As stated in #320, the documentation Gymnasium website contains duplicated content that can be confusing. Both the docstring from the `Class` and the `__init__` are displayed, meaning there is often a sentence repeated twice.

To keep the documentation the same, I just added a parser to the Sphinx `conf.py` to remove any lines that are written before a `Args` in the docstring. 

### Example 
```
class TransformReward(RewardWrapper):
    """Transform the reward via an arbitrary function.

    Warning:
        If the base environment specifies a reward range which is not invariant under :attr:`f`, the :attr:`reward_range` of the wrapped environment will be incorrect.

    Example:
        >>> import gymnasium as gym
        >>> from gymnasium.wrappers import TransformReward
        >>> env = gym.make("CartPole-v1")
        >>> env = TransformReward(env, lambda r: 0.01*r)
        >>> _ = env.reset()
        >>> observation, reward, terminated, truncated, info = env.step(env.action_space.sample())
        >>> reward
        0.01
    """

    def __init__(self, env: gym.Env, f: Callable[[float], float]):
        """Initialize the :class:`TransformReward` wrapper with an environment and reward transform function :attr:`f`.

        Args:
            env: The environment to apply the wrapper
            f: A function that transforms the reward
        """
        super().__init__(env)
        assert callable(f)
        self.f = f
```
Here the parser will remove the lines before `Args`, which are the whitespace and `Initialize the :class:TransformReward wrapper with an environment and reward transform function :attr:f.`.

### Important

The parser targets every docstring that has the tag `class`, which are the `Class` and `__init__` ones. This means that if you place an `Args` section in the `Class` docstring, the lines before it will be removed it too.

I think only one class had this problem, but it should be noted as bad practice for the future.



## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

