### PR TITLE
`MuJoCo/Ant` clarify the lack of `use_contact_forces` on  v3 (and older)

### DIFF
--- a/gymnasium/envs/mujoco/ant_v4.py
+++ b/gymnasium/envs/mujoco/ant_v4.py
@@ -84,7 +84,7 @@ class AntEnv(MujocoEnv, utils.EzPickle):
     | 26  |angular velocity of the angle between back right links        | -Inf   | Inf    | ankle_4 (right_back_leg)               | hinge | angle (rad)              |
 
 
-    If `use_contact_forces` is `True` then the observation space is extended by 14*6 = 84 elements, which are contact forces
+    If version < `v4` or `use_contact_forces` is `True` then the observation space is extended by 14*6 = 84 elements, which are contact forces
     (external forces - force x, y, z and torque x, y, z) applied to the
     center of mass of each of the links. The 14 links are: the ground link,
     the torso link, and 3 links for each leg (1 + 1 + 12) with the 6 external forces.
@@ -116,7 +116,7 @@ class AntEnv(MujocoEnv, utils.EzPickle):
 
     The total reward returned is ***reward*** *=* *healthy_reward + forward_reward - ctrl_cost*.
 
-    But if `use_contact_forces=True`
+    But if `use_contact_forces=True` or version < `v4`
     The total reward returned is ***reward*** *=* *healthy_reward + forward_reward - ctrl_cost - contact_cost*.
 
     In either case `info` will also contain the individual reward terms.


### PR DESCRIPTION
# Description

clarifies the fact that `use_contact_forces` does not exist on previous versions

Downside: it increases the complexity of the DOC for people not interested in v3 or older

Fixes # (issue)

## Type of change

- [X] DOC CHANGE

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [DOES NOT APPLY] I have commented my code, particularly in hard-to-understand areas
- [DOES NOT APPLY] I have made corresponding changes to the documentation
- [[DOES NOT APPLY] My changes generate no new warnings
- [[DOES NOT APPLY] I have added tests that prove my fix is effective or that my feature works
- [DOES NOT APPLY] New and existing unit tests pass locally with my changes