### PR TITLE
Update vector_envs_tutorial.py 

### DIFF
--- a/docs/tutorials/gymnasium_basics/vector_envs_tutorial.py
+++ b/docs/tutorials/gymnasium_basics/vector_envs_tutorial.py
@@ -7,11 +7,10 @@ Training A2C with Vector Envs and Domain Randomization
 # Notice
 # ------
 #
-# If you encounter an RuntimeError like the following comment raised on multiprocessing/spawn.py, wrap up the code from ```gym.vector.make`=``` or ```gym.vector.AsyncVectorEnv``` to the end of the code by ```if__name__ == '__main__'```.
+# If you encounter an RuntimeError like the following comment raised on multiprocessing/spawn.py, wrap up the code from ``gym.vector.make=`` or ``gym.vector.AsyncVectorEnv`` to the end of the code by ``if__name__ == '__main__'``.
 #
-# ```An attempt has been made to start a new process before the current process has finished its bootstrapping phase.```
+# ``An attempt has been made to start a new process before the current process has finished its bootstrapping phase.``
 #
-
 
 # %%
 #

--- a/docs/tutorials/gymnasium_basics/vector_envs_tutorial.py
+++ b/docs/tutorials/gymnasium_basics/vector_envs_tutorial.py
@@ -3,6 +3,20 @@ Training A2C with Vector Envs and Domain Randomization
 ======================================================
 
 """
+# %%
+# Notice
+# ------
+#
+# If you encounter an RuntimeError like the following comment raised on multiprocessing/spawn.py, wrap up the code from ```gym.vector.make`=``` or ```gym.vector.AsyncVectorEnv``` to the end of the code by ```if__name__ == '__main__'```.
+#
+# ```An attempt has been made to start a new process before the current process has finished its bootstrapping phase.```
+#
+
+
+# %%
+#
+# ------------------------------
+#
 
 
 # %%


### PR DESCRIPTION
# Description

Running vector_env_tutorial.py on jupyter notebook doesn't trigger the following error. 
But on the .py file, it caused. I confused jupyter and interactive mode on vscode. At first, I thought they are identical.

But maybe it isn't. 
.ipynb  file ran succesfully but .py file on interactive 


Therefore I add the notice on the head of the vector_env_tutorial.py.
The content is that adding `if name == "main"` from gym.vector to the end to avoid error on multiprocessing
(Fixes https://github.com/Farama-Foundation/Gymnasium/issues/309)

The issue was triggered at gym.vector.make and gym.vector.AsyncVectorEnv

I ran on Python 3.10 and my computer is 21.5.0 Darwin Kernel Version 21.5.0: Tue Apr 26 21:08:22 PDT 2022; root:xnu-8020.121.3~4/RELEASE_X86_64 x86_64

## Type of change

- [X] This change requires a documentation update

### Screenshots


Case 1: Just running .py file
![sssss](https://user-images.githubusercontent.com/79500842/221462190-e54ee257-ea1b-4311-8e44-0943071bc734.jpeg)

Case 2: Running .py file on the interative mode on vscode  
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/79500842/221462011-a6189352-ac2d-4eb4-841f-4ca62ee93c9e.png">



# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

