### PR TITLE
Add all atari environments and remove pip install atari from documentation

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,7 +21,7 @@ jobs:
         run: pip install -r docs/requirements.txt
 
       - name: Install Gymnasium
-        run: pip install mujoco && pip install .[atari,accept-rom-license,box2d]
+        run: pip install mujoco && pip install .[box2d]
 
       - name: Build Envs Docs
         run: python docs/scripts/gen_mds.py && python docs/scripts/gen_envs_display.py

--- a/docs/environments/atari.md
+++ b/docs/environments/atari.md
@@ -17,39 +17,69 @@ atari/assault
 atari/asterix
 atari/asteroids
 atari/atlantis
+atari/atlantis2
+atari/backgammon
 atari/bank_heist
+atari/basic_math
 atari/battle_zone
 atari/beam_rider
 atari/berzerk
+atari/blackjack
 atari/bowling
 atari/boxing
 atari/breakout
 atari/carnival
+atari/casino
 atari/centipede
 atari/chopper_command
 atari/crazy_climber
+atari/crossbow
+atari/darkchambers
 atari/defender
 atari/demon_attack
+atari/donkey_kong
 atari/double_dunk
+atari/earthworld
 atari/elevator_action
 atari/enduro
+atari/entombed
+atari/et
 atari/fishing_derby
+atari/flag_capture
 atari/freeway
+atari/frogger
 atari/frostbite
+atari/galaxian
 atari/gopher
 atari/gravitar
+atari/hangman
+atari/haunted_house
 atari/hero
+atari/human_cannonball
 atari/ice_hockey
 atari/jamesbond
 atari/journey_escape
+atari/kaboom
 atari/kangaroo
+atari/keystone_kapers
+atari/king_kong
+atari/klax
+atari/koolaid
 atari/krull
 atari/kung_fu_master
+atari/laser_gates
+atari/lost_luggage
+atari/mario_bros
+atari/miniature_golf
 atari/montezuma_revenge
+atari/mr_do
 atari/ms_pacman
 atari/name_this_game
+atari/othello
+atari/pacman
 atari/phoenix
 atari/pitfall
+atari/pitfall2
 atari/pong
 atari/pooyan
 atari/private_eye
@@ -58,17 +88,29 @@ atari/riverraid
 atari/road_runner
 atari/robotank
 atari/seaquest
+atari/sir_lancelot
 atari/skiing
 atari/solaris
 atari/space_invaders
+atari/space_war
 atari/star_gunner
+atari/superman
+atari/surround
 atari/tennis
+atari/tetris
+atari/tic_tac_toe_3d
 atari/time_pilot
+atari/trondead
+atari/turmoil
 atari/tutankham
 atari/up_n_down
 atari/venture
+atari/video_checkers
+atari/video_chess
+atari/video_cube
 atari/video_pinball
 atari/wizard_of_wor
+atari/word_zapper
 atari/yars_revenge
 atari/zaxxon
 ```
@@ -212,109 +254,112 @@ game dynamics and (if a reduced action space is used) different action spaces. W
 refer to the combination of difficulty level and game mode as a flavor of a game. The following table shows
 the available modes and difficulty levels for different Atari games:
 
-| Environment      | Possible Modes                                |   Default Mode | Possible Difficulties   |   Default Difficulty |
-|------------------|-----------------------------------------------|----------------|-------------------------|----------------------|
-| Adventure        | [0, 1, 2]                                     |              0 | [0, 1, 2, 3]            |                    0 |
-| AirRaid          | [1, ..., 8]                                   |              1 | [0]                     |                    0 |
-| Alien            | [0, 1, 2, 3]                                  |              0 | [0, 1, 2, 3]            |                    0 |
-| Amidar           | [0]                                           |              0 | [0, 3]                  |                    0 |
-| Assault          | [0]                                           |              0 | [0]                     |                    0 |
-| Asterix          | [0]                                           |              0 | [0]                     |                    0 |
-| Asteroids        | [0, ..., 31, 128]                             |              0 | [0, 3]                  |                    0 |
-| Atlantis         | [0, 1, 2, 3]                                  |              0 | [0]                     |                    0 |
-| Atlantis2        | [0]                                           |              0 | [0]                     |                    0 |
-| Backgammon       | [0]                                           |              0 | [3]                     |                    0 |
-| BankHeist        | [0, 4, 8, 12, 16, 20, 24, 28]                 |              0 | [0, 1, 2, 3]            |                    0 |
-| BasicMath        | [5, 6, 7, 8]                                  |              5 | [0, 2, 3]               |                    0 |
-| BattleZone       | [1, 2, 3]                                     |              1 | [0]                     |                    0 |
-| BeamRider        | [0]                                           |              0 | [0, 1]                  |                    0 |
-| Berzerk          | [1, ..., 9, 16, 17, 18]                       |              1 | [0]                     |                    0 |
-| Blackjack        | [0]                                           |              0 | [0, 1, 2, 3]            |                    0 |
-| Bowling          | [0, 2, 4]                                     |              0 | [0, 1]                  |                    0 |
-| Boxing           | [0]                                           |              0 | [0, 1, 2, 3]            |                    0 |
-| Breakout         | [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44] |              0 | [0, 1]                  |                    0 |
-| Carnival         | [0]                                           |              0 | [0]                     |                    0 |
-| Casino           | [0, 2, 3]                                     |              0 | [0, 1, 2, 3]            |                    0 |
-| Centipede        | [22, 86]                                      |             22 | [0]                     |                    0 |
-| ChopperCommand   | [0, 2]                                        |              0 | [0, 1]                  |                    0 |
-| CrazyClimber     | [0, 1, 2, 3]                                  |              0 | [0, 1]                  |                    0 |
-| Crossbow         | [0, 2, 4, 6]                                  |              0 | [0, 1]                  |                    0 |
-| Darkchambers     | [0]                                           |              0 | [0]                     |                    0 |
-| Defender         | [1, ..., 9, 16]                               |              1 | [0, 1]                  |                    0 |
-| DemonAttack      | [1, 3, 5, 7]                                  |              1 | [0, 1]                  |                    0 |
-| DonkeyKong       | [0]                                           |              0 | [0]                     |                    0 |
-| DoubleDunk       | [0, ..., 15]                                  |              0 | [0]                     |                    0 |
-| Earthworld       | [0]                                           |              0 | [0]                     |                    0 |
-| ElevatorAction   | [0]                                           |              0 | [0]                     |                    0 |
-| Enduro           | [0]                                           |              0 | [0]                     |                    0 |
-| Entombed         | [0]                                           |              0 | [0, 2]                  |                    0 |
-| Et               | [0, 1, 2]                                     |              0 | [0, 1, 2, 3]            |                    0 |
-| FishingDerby     | [0]                                           |              0 | [0, 1, 2, 3]            |                    0 |
-| FlagCapture      | [8, 9, 10]                                    |              8 | [0]                     |                    0 |
-| Freeway          | [0, ..., 7]                                   |              0 | [0, 1]                  |                    0 |
-| Frogger          | [0, 1, 2]                                     |              0 | [0, 1]                  |                    0 |
-| Frostbite        | [0, 2]                                        |              0 | [0]                     |                    0 |
-| Galaxian         | [1, ..., 9]                                   |              1 | [0, 1]                  |                    0 |
-| Gopher           | [0, 2]                                        |              0 | [0, 1]                  |                    0 |
-| Gravitar         | [0, 1, 2, 3, 4]                               |              0 | [0]                     |                    0 |
-| Hangman          | [0, 1, 2, 3]                                  |              0 | [0, 1]                  |                    0 |
-| HauntedHouse     | [0, ..., 8]                                   |              0 | [0, 1]                  |                    0 |
-| Hero             | [0, 1, 2, 3, 4]                               |              0 | [0]                     |                    0 |
-| HumanCannonball  | [0, ..., 7]                                   |              0 | [0, 1]                  |                    0 |
-| IceHockey        | [0, 2]                                        |              0 | [0, 1, 2, 3]            |                    0 |
-| Jamesbond        | [0, 1]                                        |              0 | [0]                     |                    0 |
-| JourneyEscape    | [0]                                           |              0 | [0, 1]                  |                    0 |
-| Kaboom           | [0]                                           |              0 | [0]                     |                    0 |
-| Kangaroo         | [0, 1]                                        |              0 | [0]                     |                    0 |
-| KeystoneKapers   | [0]                                           |              0 | [0]                     |                    0 |
-| KingKong         | [0, 1, 2, 3]                                  |              0 | [0]                     |                    0 |
-| Klax             | [0, 1, 2]                                     |              0 | [0]                     |                    0 |
-| Koolaid          | [0]                                           |              0 | [0]                     |                    0 |
-| Krull            | [0]                                           |              0 | [0]                     |                    0 |
-| KungFuMaster     | [0]                                           |              0 | [0]                     |                    0 |
-| LaserGates       | [0]                                           |              0 | [0]                     |                    0 |
-| LostLuggage      | [0, 1]                                        |              0 | [0, 1]                  |                    0 |
-| MarioBros        | [0, 2, 4, 6]                                  |              0 | [0]                     |                    0 |
-| MiniatureGolf    | [0]                                           |              0 | [0, 1]                  |                    0 |
-| MontezumaRevenge | [0]                                           |              0 | [0]                     |                    0 |
-| MrDo             | [0, 1, 2, 3]                                  |              0 | [0]                     |                    0 |
-| MsPacman         | [0, 1, 2, 3]                                  |              0 | [0]                     |                    0 |
-| NameThisGame     | [8, 24, 40]                                   |              8 | [0, 1]                  |                    0 |
-| Othello          | [0, 1, 2]                                     |              0 | [0, 2]                  |                    0 |
-| Pacman           | [0, ..., 7]                                   |              0 | [0, 1]                  |                    0 |
-| Phoenix          | [0]                                           |              0 | [0]                     |                    0 |
-| Pitfall          | [0]                                           |              0 | [0]                     |                    0 |
-| Pitfall2         | [0]                                           |              0 | [0]                     |                    0 |
-| Pong             | [0, 1]                                        |              0 | [0, 1, 2, 3]            |                    0 |
-| Pooyan           | [10, 30, 50, 70]                              |             10 | [0]                     |                    0 |
-| PrivateEye       | [0, 1, 2, 3, 4]                               |              0 | [0, 1, 2, 3]            |                    0 |
-| Qbert            | [0]                                           |              0 | [0, 1]                  |                    0 |
-| Riverraid        | [0]                                           |              0 | [0, 1]                  |                    0 |
-| RoadRunner       | [0]                                           |              0 | [0]                     |                    0 |
-| Robotank         | [0]                                           |              0 | [0]                     |                    0 |
-| Seaquest         | [0]                                           |              0 | [0, 1]                  |                    0 |
-| SirLancelot      | [0]                                           |              0 | [0]                     |                    0 |
-| Skiing           | [0]                                           |              0 | [0]                     |                    0 |
-| Solaris          | [0]                                           |              0 | [0]                     |                    0 |
-| SpaceInvaders    | [0, ..., 15]                                  |              0 | [0, 1]                  |                    0 |
-| SpaceWar         | [6, ..., 17]                                  |              6 | [0]                     |                    0 |
-| StarGunner       | [0, 1, 2, 3]                                  |              0 | [0]                     |                    0 |
-| Superman         | [0]                                           |              0 | [0, 1, 2, 3]            |                    0 |
-| Surround         | [0, 2]                                        |              0 | [0, 1, 2, 3]            |                    0 |
-| Tennis           | [0, 2]                                        |              0 | [0, 1, 2, 3]            |                    0 |
-| Tetris           | [0]                                           |              0 | [0]                     |                    0 |
-| TimePilot        | [0]                                           |              0 | [0, 1, 2]               |                    0 |
-| Trondead         | [0]                                           |              0 | [0, 1]                  |                    0 |
-| Turmoil          | [0, ..., 8]                                   |              0 | [0]                     |                    0 |
-| Tutankham        | [0, 4, 8, 12]                                 |              0 | [0]                     |                    0 |
-| UpNDown          | [0]                                           |              0 | [0, 1, 2, 3]            |                    0 |
-| Venture          | [0]                                           |              0 | [0, 1, 2, 3]            |                    0 |
-| VideoCheckers    | [1, ..., 9, 11, ..., 19]                      |              1 | [0]                     |                    0 |
-| VideoPinball     | [0, 2]                                        |              0 | [0, 1]                  |                    0 |
-| WizardOfWor      | [0]                                           |              0 | [0, 1]                  |                    0 |
-| WordZapper       | [0, ..., 23]                                  |              0 | [0, 1, 2, 3]            |                    0 |
-| YarsRevenge      | [0, 32, 64, 96]                               |              0 | [0, 1]                  |                    0 |
-| Zaxxon           | [0, 8, 16, 24]                                |              0 | [0]                     |                    0 |
+| Environment      | Possible Modes                                  |   Default Mode | Possible Difficulties   |   Default Difficulty |
+|------------------|-------------------------------------------------|----------------|-------------------------|----------------------|
+| Adventure        | [0, 1, 2]                                       |              0 | [0, 1, 2, 3]            |                    0 |
+| AirRaid          | [1, ..., 8]                                     |              1 | [0]                     |                    0 |
+| Alien            | [0, 1, 2, 3]                                    |              0 | [0, 1, 2, 3]            |                    0 |
+| Amidar           | [0]                                             |              0 | [0, 3]                  |                    0 |
+| Assault          | [0]                                             |              0 | [0]                     |                    0 |
+| Asterix          | [0]                                             |              0 | [0]                     |                    0 |
+| Asteroids        | [0, ..., 31, 128]                               |              0 | [0, 3]                  |                    0 |
+| Atlantis         | [0, 1, 2, 3]                                    |              0 | [0]                     |                    0 |
+| Atlantis2        | [0]                                             |              0 | [0]                     |                    0 |
+| Backgammon       | [0]                                             |              0 | [3]                     |                    0 |
+| BankHeist        | [0, 4, 8, 12, 16, 20, 24, 28]                   |              0 | [0, 1, 2, 3]            |                    0 |
+| BasicMath        | [5, 6, 7, 8]                                    |              5 | [0, 2, 3]               |                    0 |
+| BattleZone       | [1, 2, 3]                                       |              1 | [0]                     |                    0 |
+| BeamRider        | [0]                                             |              0 | [0, 1]                  |                    0 |
+| Berzerk          | [1, ..., 9, 16, 17, 18]                         |              1 | [0]                     |                    0 |
+| Blackjack        | [0]                                             |              0 | [0, 1, 2, 3]            |                    0 |
+| Bowling          | [0, 2, 4]                                       |              0 | [0, 1]                  |                    0 |
+| Boxing           | [0]                                             |              0 | [0, 1, 2, 3]            |                    0 |
+| Breakout         | [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44]   |              0 | [0, 1]                  |                    0 |
+| Carnival         | [0]                                             |              0 | [0]                     |                    0 |
+| Casino           | [0, 2, 3]                                       |              0 | [0, 1, 2, 3]            |                    0 |
+| Centipede        | [22, 86]                                        |             22 | [0]                     |                    0 |
+| ChopperCommand   | [0, 2]                                          |              0 | [0, 1]                  |                    0 |
+| CrazyClimber     | [0, 1, 2, 3]                                    |              0 | [0, 1]                  |                    0 |
+| Crossbow         | [0, 2, 4, 6]                                    |              0 | [0, 1]                  |                    0 |
+| Darkchambers     | [0]                                             |              0 | [0]                     |                    0 |
+| Defender         | [1, ..., 9, 16]                                 |              1 | [0, 1]                  |                    0 |
+| DemonAttack      | [1, 3, 5, 7]                                    |              1 | [0, 1]                  |                    0 |
+| DonkeyKong       | [0]                                             |              0 | [0]                     |                    0 |
+| DoubleDunk       | [0, ..., 15]                                    |              0 | [0]                     |                    0 |
+| Earthworld       | [0]                                             |              0 | [0]                     |                    0 |
+| ElevatorAction   | [0]                                             |              0 | [0]                     |                    0 |
+| Enduro           | [0]                                             |              0 | [0]                     |                    0 |
+| Entombed         | [0]                                             |              0 | [0, 2]                  |                    0 |
+| Et               | [0, 1, 2]                                       |              0 | [0, 1, 2, 3]            |                    0 |
+| FishingDerby     | [0]                                             |              0 | [0, 1, 2, 3]            |                    0 |
+| FlagCapture      | [8, 9, 10]                                      |              8 | [0]                     |                    0 |
+| Freeway          | [0, ..., 7]                                     |              0 | [0, 1]                  |                    0 |
+| Frogger          | [0, 1, 2]                                       |              0 | [0, 1]                  |                    0 |
+| Frostbite        | [0, 2]                                          |              0 | [0]                     |                    0 |
+| Galaxian         | [1, ..., 9]                                     |              1 | [0, 1]                  |                    0 |
+| Gopher           | [0, 2]                                          |              0 | [0, 1]                  |                    0 |
+| Gravitar         | [0, 1, 2, 3, 4]                                 |              0 | [0]                     |                    0 |
+| Hangman          | [0, 1, 2, 3]                                    |              0 | [0, 1]                  |                    0 |
+| HauntedHouse     | [0, ..., 8]                                     |              0 | [0, 1]                  |                    0 |
+| Hero             | [0, 1, 2, 3, 4]                                 |              0 | [0]                     |                    0 |
+| HumanCannonball  | [0, ..., 7]                                     |              0 | [0, 1]                  |                    0 |
+| IceHockey        | [0, 2]                                          |              0 | [0, 1, 2, 3]            |                    0 |
+| Jamesbond        | [0, 1]                                          |              0 | [0]                     |                    0 |
+| JourneyEscape    | [0]                                             |              0 | [0, 1]                  |                    0 |
+| Kaboom           | [0]                                             |              0 | [0]                     |                    0 |
+| Kangaroo         | [0, 1]                                          |              0 | [0]                     |                    0 |
+| KeystoneKapers   | [0]                                             |              0 | [0]                     |                    0 |
+| KingKong         | [0, 1, 2, 3]                                    |              0 | [0]                     |                    0 |
+| Klax             | [0, 1, 2]                                       |              0 | [0]                     |                    0 |
+| Koolaid          | [0]                                             |              0 | [0]                     |                    0 |
+| Krull            | [0]                                             |              0 | [0]                     |                    0 |
+| KungFuMaster     | [0]                                             |              0 | [0]                     |                    0 |
+| LaserGates       | [0]                                             |              0 | [0]                     |                    0 |
+| LostLuggage      | [0, 1]                                          |              0 | [0, 1]                  |                    0 |
+| MarioBros        | [0, 2, 4, 6]                                    |              0 | [0]                     |                    0 |
+| MiniatureGolf    | [0]                                             |              0 | [0, 1]                  |                    0 |
+| MontezumaRevenge | [0]                                             |              0 | [0]                     |                    0 |
+| MrDo             | [0, 1, 2, 3]                                    |              0 | [0]                     |                    0 |
+| MsPacman         | [0, 1, 2, 3]                                    |              0 | [0]                     |                    0 |
+| NameThisGame     | [8, 24, 40]                                     |              8 | [0, 1]                  |                    0 |
+| Othello          | [0, 1, 2]                                       |              0 | [0, 2]                  |                    0 |
+| Pacman           | [0, ..., 7]                                     |              0 | [0, 1]                  |                    0 |
+| Phoenix          | [0]                                             |              0 | [0]                     |                    0 |
+| Pitfall          | [0]                                             |              0 | [0]                     |                    0 |
+| Pitfall2         | [0]                                             |              0 | [0]                     |                    0 |
+| Pong             | [0, 1]                                          |              0 | [0, 1, 2, 3]            |                    0 |
+| Pooyan           | [10, 30, 50, 70]                                |             10 | [0]                     |                    0 |
+| PrivateEye       | [0, 1, 2, 3, 4]                                 |              0 | [0, 1, 2, 3]            |                    0 |
+| Qbert            | [0]                                             |              0 | [0, 1]                  |                    0 |
+| Riverraid        | [0]                                             |              0 | [0, 1]                  |                    0 |
+| RoadRunner       | [0]                                             |              0 | [0]                     |                    0 |
+| Robotank         | [0]                                             |              0 | [0]                     |                    0 |
+| Seaquest         | [0]                                             |              0 | [0, 1]                  |                    0 |
+| SirLancelot      | [0]                                             |              0 | [0]                     |                    0 |
+| Skiing           | [0]                                             |              0 | [0]                     |                    0 |
+| Solaris          | [0]                                             |              0 | [0]                     |                    0 |
+| SpaceInvaders    | [0, ..., 15]                                    |              0 | [0, 1]                  |                    0 |
+| SpaceWar         | [6, ..., 17]                                    |              6 | [0]                     |                    0 |
+| StarGunner       | [0, 1, 2, 3]                                    |              0 | [0]                     |                    0 |
+| Superman         | [0]                                             |              0 | [0, 1, 2, 3]            |                    0 |
+| Surround         | [0, 2]                                          |              0 | [0, 1, 2, 3]            |                    0 |
+| Tennis           | [0, 2]                                          |              0 | [0, 1, 2, 3]            |                    0 |
+| Tetris           | [0]                                             |              0 | [0]                     |                    0 |
+| TicTacToe3D      | [0, ..., 8]                                     |              0 | [0, 2]                  |                    0 |
+| TimePilot        | [0]                                             |              0 | [0, 1, 2]               |                    0 |
+| Trondead         | [0]                                             |              0 | [0, 1]                  |                    0 |
+| Turmoil          | [0, ..., 8]                                     |              0 | [0]                     |                    0 |
+| Tutankham        | [0, 4, 8, 12]                                   |              0 | [0]                     |                    0 |
+| UpNDown          | [0]                                             |              0 | [0, 1, 2, 3]            |                    0 |
+| Venture          | [0]                                             |              0 | [0, 1, 2, 3]            |                    0 |
+| VideoCheckers    | [1, ..., 9, 11, ..., 19]                        |              1 | [0]                     |                    0 |
+| VideoChess       | [0, 1, 2, 3, 4]                                 |              0 | [0]                     |                    0 |
+| VideoCube        | [0, 1, 2, 100, 101, 102, ..., 5000, 5001, 5002] |              0 | [0, 1]                  |                    0 |
+| VideoPinball     | [0, 2]                                          |              0 | [0, 1]                  |                    0 |
+| WizardOfWor      | [0]                                             |              0 | [0, 1]                  |                    0 |
+| WordZapper       | [0, ..., 23]                                    |              0 | [0, 1, 2, 3]            |                    0 |
+| YarsRevenge      | [0, 32, 64, 96]                                 |              0 | [0, 1]                  |                    0 |
+| Zaxxon           | [0, 8, 16, 24]                                  |              0 | [0]                     |                    0 |
 
 ## References
 

--- a/docs/environments/atari/adventure.md
+++ b/docs/environments/atari/adventure.md
@@ -11,11 +11,21 @@ title: Adventure
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (250, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Adventure-v5")` |
+
+For more Adventure variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You must find the enchanted chalice and return it to the golden castle. You can pick up various objects (keys, a sword,a bridge, or a magnet) and have to fight or outmanoeuvre dragons.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=1)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=1)
 
 ## Actions
 

--- a/docs/environments/atari/air_raid.md
+++ b/docs/environments/atari/air_raid.md
@@ -11,6 +11,16 @@ title: AirRaid
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (250, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/AirRaid-v5")` |
+
+For more AirRaid variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control a ship that can move sideways. You must protect two buildings (one on the right and one on the left side of the screen) from flying saucers that are trying to drop bombs on them.

--- a/docs/environments/atari/alien.md
+++ b/docs/environments/atari/alien.md
@@ -11,11 +11,21 @@ title: Alien
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Alien-v5")` |
+
+For more Alien variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are stuck in a maze-like space ship with three aliens. You goal is to destroy their eggs that are scattered all over the ship while simultaneously avoiding the aliens (they are trying to kill you). You have a flamethrower that can help you turn them away in tricky situations. Moreover, you can occasionally collect a power-up (pulsar) that gives you the temporary ability to kill aliens.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=815)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=815)
 
 ## Actions
 

--- a/docs/environments/atari/amidar.md
+++ b/docs/environments/atari/amidar.md
@@ -11,11 +11,21 @@ title: Amidar
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(10) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Amidar-v5")` |
+
+For more Amidar variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 This game is similar to Pac-Man: You are trying to visit all places on a 2-dimensional grid while simultaneously avoiding your enemies. You can turn the tables at one point in the game: Your enemies turn into chickens and you can catch them.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=817)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=817)
 
 ## Actions
 

--- a/docs/environments/atari/assault.md
+++ b/docs/environments/atari/assault.md
@@ -11,11 +11,21 @@ title: Assault
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(7) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Assault-v5")` |
+
+For more Assault variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control a vehicle that can move sideways. A big mother ship circles overhead and continually deploys smaller drones.You must destroy these enemies and dodge their attacks.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=827)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=827)
 
 ## Actions
 

--- a/docs/environments/atari/asterix.md
+++ b/docs/environments/atari/asterix.md
@@ -11,11 +11,21 @@ title: Asterix
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(9) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Asterix-v5")` |
+
+For more Asterix variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are Asterix and can move horizontally (continuously) and vertically (discretely). Objects move horizontally across the screen: lyres and other (more useful) objects. Your goal is to guideAsterix in such a way as to avoid lyres and collect as many other objects as possible. You score points by collecting objects and lose a life whenever you collect a lyre. You have three lives available at the beginning. If you score sufficiently many points, you will be awarded additional points.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=3325)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=3325)
 
 ## Actions
 

--- a/docs/environments/atari/asteroids.md
+++ b/docs/environments/atari/asteroids.md
@@ -11,11 +11,21 @@ title: Asteroids
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(14) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Asteroids-v5")` |
+
+For more Asteroids variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 This is a well-known arcade game: You control a spaceship in an asteroid field and must break up asteroids by shooting them. Once all asteroids are destroyed, you enter a new level and new asteroids will appear. You will occasionally be attacked by a flying saucer.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=828)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=828)
 
 ## Actions
 

--- a/docs/environments/atari/atlantis.md
+++ b/docs/environments/atari/atlantis.md
@@ -11,11 +11,21 @@ title: Atlantis
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(4) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Atlantis-v5")` |
+
+For more Atlantis variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your job is to defend the submerged city of Atlantis. Your enemies slowly descend towards the city and you must destroy them before they reach striking distance. To this end, you control three defense posts.You lose if your enemies manage to destroy all seven of Atlantis' installations. You may rebuild installations after you have fought of a wave of enemies and scored a sufficient number of points.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=835)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=835)
 
 ## Actions
 

--- a/docs/environments/atari/atlantis2.md
+++ b/docs/environments/atari/atlantis2.md
@@ -1,0 +1,78 @@
+---
+title: Atlantis2
+---
+
+# Atlantis2
+
+```{figure} ../../_static/videos/atari/atlantis2.gif
+:width: 120px
+:name: Atlantis2
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(4) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Atlantis2-v5")` |
+
+For more Atlantis2 variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Atlantis2 is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Atlantis2 has the action space `Discrete(4)` with the table below lists the meaning of each action's meanings.
+As Atlantis2 uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning     |
+|---------|-------------|
+| `0`     | `NOOP`      |
+| `1`     | `FIRE`      |
+| `2`     | `RIGHTFIRE` |
+| `3`     | `LEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Atlantis2 has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id               | obs_type=   | frameskip=   | repeat_action_probability=   |
+|----------------------|-------------|--------------|------------------------------|
+| ALE/Atlantis2-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Atlantis2-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/backgammon.md
+++ b/docs/environments/atari/backgammon.md
@@ -1,0 +1,77 @@
+---
+title: Backgammon
+---
+
+# Backgammon
+
+```{figure} ../../_static/videos/atari/backgammon.gif
+:width: 120px
+:name: Backgammon
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(3) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Backgammon-v5")` |
+
+For more Backgammon variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Backgammon is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Backgammon has the action space `Discrete(3)` with the table below lists the meaning of each action's meanings.
+As Backgammon uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning   |
+|---------|-----------|
+| `0`     | `FIRE`    |
+| `1`     | `RIGHT`   |
+| `2`     | `LEFT`    |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Backgammon has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-----------------------|-------------|--------------|------------------------------|
+| ALE/Backgammon-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Backgammon-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[3]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/bank_heist.md
+++ b/docs/environments/atari/bank_heist.md
@@ -11,11 +11,21 @@ title: BankHeist
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/BankHeist-v5")` |
+
+For more BankHeist variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are a bank robber and (naturally) want to rob as many banks as possible. You control your getaway car and must navigate maze-like cities. The police chases you and will appear whenever you rob a bank. You may destroy police cars by dropping sticks of dynamite. You can fill up your gas tank by entering a new city.At the beginning of the game you have four lives. Lives are lost if you run out of gas, are caught by the police,or run over the dynamite you have previously dropped.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=1008)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=1008)
 
 ## Actions
 

--- a/docs/environments/atari/basic_math.md
+++ b/docs/environments/atari/basic_math.md
@@ -1,0 +1,80 @@
+---
+title: BasicMath
+---
+
+# BasicMath
+
+```{figure} ../../_static/videos/atari/basic_math.gif
+:width: 120px
+:name: BasicMath
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/BasicMath-v5")` |
+
+For more BasicMath variants with different observation and action spaces, see the variants section.
+
+## Description
+
+BasicMath is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+BasicMath has the action space `Discrete(6)` with the table below lists the meaning of each action's meanings.
+As BasicMath uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning   |
+|---------|-----------|
+| `0`     | `NOOP`    |
+| `1`     | `FIRE`    |
+| `2`     | `UP`      |
+| `3`     | `RIGHT`   |
+| `4`     | `LEFT`    |
+| `5`     | `DOWN`    |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+BasicMath has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id               | obs_type=   | frameskip=   | repeat_action_probability=   |
+|----------------------|-------------|--------------|------------------------------|
+| ALE/BasicMath-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/BasicMath-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[5, 6, 7, 8]`    | `5`            | `[0, 2, 3]`              | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/battle_zone.md
+++ b/docs/environments/atari/battle_zone.md
@@ -11,11 +11,21 @@ title: BattleZone
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/BattleZone-v5")` |
+
+For more BattleZone variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control a tank and must destroy enemy vehicles. This game is played in a first-person perspective and creates a 3D illusion. A radar screen shows enemies around you. You start with 5 lives and gain up to 2 extra lives if you reach a sufficient score.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=859)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=859)
 
 ## Actions
 

--- a/docs/environments/atari/beam_rider.md
+++ b/docs/environments/atari/beam_rider.md
@@ -11,11 +11,21 @@ title: BeamRider
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(9) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/BeamRider-v5")` |
+
+For more BeamRider variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control a space-ship that travels forward at a constant speed. You can only steer it sideways between discrete positions. Your goal is to destroy enemy ships, avoid their attacks and dodge space debris.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareID=860)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareID=860)
 
 ## Actions
 

--- a/docs/environments/atari/berzerk.md
+++ b/docs/environments/atari/berzerk.md
@@ -11,11 +11,21 @@ title: Berzerk
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Berzerk-v5")` |
+
+For more Berzerk variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are stuck in a maze with evil robots. You must destroy them and avoid touching the walls of the maze, as this will kill you. You may be awarded extra lives after scoring a sufficient number of points, depending on the game mode.You may also be chased by an undefeatable enemy, Evil Otto, that you must avoid. Evil Otto does not appear in the default mode.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=866)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=866)
 
 ## Actions
 

--- a/docs/environments/atari/blackjack.md
+++ b/docs/environments/atari/blackjack.md
@@ -1,0 +1,78 @@
+---
+title: Blackjack
+---
+
+# Blackjack
+
+```{figure} ../../_static/videos/atari/blackjack.gif
+:width: 120px
+:name: Blackjack
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(4) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Blackjack-v5")` |
+
+For more Blackjack variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Blackjack is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Blackjack has the action space `Discrete(4)` with the table below lists the meaning of each action's meanings.
+As Blackjack uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning   |
+|---------|-----------|
+| `0`     | `NOOP`    |
+| `1`     | `FIRE`    |
+| `2`     | `UP`      |
+| `3`     | `DOWN`    |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Blackjack has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id               | obs_type=   | frameskip=   | repeat_action_probability=   |
+|----------------------|-------------|--------------|------------------------------|
+| ALE/Blackjack-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Blackjack-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0, 1, 2, 3]`           | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/bowling.md
+++ b/docs/environments/atari/bowling.md
@@ -11,11 +11,21 @@ title: Bowling
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Bowling-v5")` |
+
+For more Bowling variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your goal is to score as many points as possible in the game of Bowling. A game consists of 10 frames and you have two tries per frame. Knocking down all pins on the first try is called a "strike". Knocking down all pins on the second roll is called a "spar". Otherwise, the frame is called "open".
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=879)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=879)
 
 ## Actions
 

--- a/docs/environments/atari/boxing.md
+++ b/docs/environments/atari/boxing.md
@@ -11,11 +11,21 @@ title: Boxing
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Boxing-v5")` |
+
+For more Boxing variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You fight an opponent in a boxing ring. You score points for hitting the opponent. If you score 100 points, your opponent is knocked out.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=882)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=882)
 
 ## Actions
 

--- a/docs/environments/atari/breakout.md
+++ b/docs/environments/atari/breakout.md
@@ -11,11 +11,21 @@ title: Breakout
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(4) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Breakout-v5")` |
+
+For more Breakout variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Another famous Atari game. The dynamics are similar to pong: You move a paddle and hit the ball in a brick wall at the top of the screen. Your goal is to destroy the brick wall. You can try to break through the wall and let the ball wreak havoc on the other side, all on its own! You have five lives.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=889)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=889)
 
 ## Actions
 

--- a/docs/environments/atari/carnival.md
+++ b/docs/environments/atari/carnival.md
@@ -11,11 +11,21 @@ title: Carnival
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (214, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Carnival-v5")` |
+
+For more Carnival variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 This is a "shoot 'em up" game. Targets move horizontally across the screen and you must shoot them. You are in control of a gun that can be moved horizontally. The supply of ammunition is limited and chickens may steal some bullets from you if you don't hit them in time.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=908)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=908)
 
 ## Actions
 

--- a/docs/environments/atari/casino.md
+++ b/docs/environments/atari/casino.md
@@ -1,0 +1,78 @@
+---
+title: Casino
+---
+
+# Casino
+
+```{figure} ../../_static/videos/atari/casino.gif
+:width: 120px
+:name: Casino
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(4) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Casino-v5")` |
+
+For more Casino variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Casino is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Casino has the action space `Discrete(4)` with the table below lists the meaning of each action's meanings.
+As Casino uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning   |
+|---------|-----------|
+| `0`     | `NOOP`    |
+| `1`     | `FIRE`    |
+| `2`     | `UP`      |
+| `3`     | `DOWN`    |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Casino has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id            | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-------------------|-------------|--------------|------------------------------|
+| ALE/Casino-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Casino-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 2, 3]`       | `0`            | `[0, 1, 2, 3]`           | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/centipede.md
+++ b/docs/environments/atari/centipede.md
@@ -11,11 +11,21 @@ title: Centipede
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Centipede-v5")` |
+
+For more Centipede variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are an elf and must use your magic wands to fend off spiders, fleas and centipedes. Your goal is to protect mushrooms in an enchanted forest. If you are bitten by a spider, flea or centipede, you will be temporally paralyzed and you will lose a magic wand. The game ends once you have lost all wands. You may receive additional wands after scoring a sufficient number of points.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=911)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=911)
 
 ## Actions
 

--- a/docs/environments/atari/chopper_command.md
+++ b/docs/environments/atari/chopper_command.md
@@ -11,11 +11,21 @@ title: ChopperCommand
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/ChopperCommand-v5")` |
+
+For more ChopperCommand variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control a helicopter and must protect truck convoys. To that end, you need to shoot down enemy aircraft.A mini-map is displayed at the bottom of the screen.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=921)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=921)
 
 ## Actions
 

--- a/docs/environments/atari/crazy_climber.md
+++ b/docs/environments/atari/crazy_climber.md
@@ -11,11 +11,21 @@ title: CrazyClimber
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(9) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/CrazyClimber-v5")` |
+
+For more CrazyClimber variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are a climber trying to reach the top of four buildings, while avoiding obstacles like closing windows and falling objects. When you receive damage (windows closing or objects) you will fall and lose one life; you have a total of 5 lives before the end games. At the top of each building, there's a helicopter which you need to catch to get to the next building. The goal is to climb as fast as possible while receiving the least amount of damage.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=113)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=113)
 
 ## Actions
 

--- a/docs/environments/atari/crossbow.md
+++ b/docs/environments/atari/crossbow.md
@@ -1,0 +1,90 @@
+---
+title: Crossbow
+---
+
+# Crossbow
+
+```{figure} ../../_static/videos/atari/crossbow.gif
+:width: 120px
+:name: Crossbow
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Crossbow-v5")` |
+
+For more Crossbow variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Crossbow is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Crossbow has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As Crossbow uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Crossbow has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id              | obs_type=   | frameskip=   | repeat_action_probability=   |
+|---------------------|-------------|--------------|------------------------------|
+| ALE/Crossbow-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Crossbow-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 2, 4, 6]`    | `0`            | `[0, 1]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/darkchambers.md
+++ b/docs/environments/atari/darkchambers.md
@@ -1,0 +1,90 @@
+---
+title: Darkchambers
+---
+
+# Darkchambers
+
+```{figure} ../../_static/videos/atari/darkchambers.gif
+:width: 120px
+:name: Darkchambers
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Darkchambers-v5")` |
+
+For more Darkchambers variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Darkchambers is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Darkchambers has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As Darkchambers uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Darkchambers has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                  | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-------------------------|-------------|--------------|------------------------------|
+| ALE/Darkchambers-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Darkchambers-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/defender.md
+++ b/docs/environments/atari/defender.md
@@ -11,11 +11,21 @@ title: Defender
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Defender-v5")` |
+
+For more Defender variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Aliens attack the earth. You control a spaceship and must defend humanity by destroying alien ships and rescuing humanoids.You have three lives and three smart bombs. You lose a live when you are shot down by an alien spaceship.Points are scored by destroying enemies and retrieving humans that are being abducted. You have an unlimited number of laser missiles.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=128)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=128)
 
 ## Actions
 

--- a/docs/environments/atari/demon_attack.md
+++ b/docs/environments/atari/demon_attack.md
@@ -11,11 +11,21 @@ title: DemonAttack
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/DemonAttack-v5")` |
+
+For more DemonAttack variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are facing waves of demons in the ice planet of Krybor. Points are accumulated by destroying demons. You begin with 3 reserve bunkers, and can increase its number (up to 6) by avoiding enemy attacks. Each attack wave you survive without any hits, grants you a new bunker. Every time an enemy hits you, a bunker is destroyed. When the last bunker falls, the next enemy hit will destroy you and the game ends.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=135)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=135)
 
 ## Actions
 

--- a/docs/environments/atari/donkey_kong.md
+++ b/docs/environments/atari/donkey_kong.md
@@ -1,0 +1,90 @@
+---
+title: DonkeyKong
+---
+
+# DonkeyKong
+
+```{figure} ../../_static/videos/atari/donkey_kong.gif
+:width: 120px
+:name: DonkeyKong
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/DonkeyKong-v5")` |
+
+For more DonkeyKong variants with different observation and action spaces, see the variants section.
+
+## Description
+
+DonkeyKong is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+DonkeyKong has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As DonkeyKong uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+DonkeyKong has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-----------------------|-------------|--------------|------------------------------|
+| ALE/DonkeyKong-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/DonkeyKong-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/double_dunk.md
+++ b/docs/environments/atari/double_dunk.md
@@ -11,11 +11,21 @@ title: DoubleDunk
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/DoubleDunk-v5")` |
+
+For more DoubleDunk variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are playing a 2v2 game of basketball. At the start of each possession, you select between a set of different plays and then execute them to either score or prevent your rivals from scoring.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=153)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=153)
 
 ## Actions
 

--- a/docs/environments/atari/earthworld.md
+++ b/docs/environments/atari/earthworld.md
@@ -1,0 +1,90 @@
+---
+title: Earthworld
+---
+
+# Earthworld
+
+```{figure} ../../_static/videos/atari/earthworld.gif
+:width: 120px
+:name: Earthworld
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Earthworld-v5")` |
+
+For more Earthworld variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Earthworld is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Earthworld has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As Earthworld uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Earthworld has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-----------------------|-------------|--------------|------------------------------|
+| ALE/Earthworld-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Earthworld-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/elevator_action.md
+++ b/docs/environments/atari/elevator_action.md
@@ -11,11 +11,21 @@ title: ElevatorAction
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/ElevatorAction-v5")` |
+
+For more ElevatorAction variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are a secret agent that must retrieve some secret documents and reach the ground level of a building by going down an elevator/stairs. Once you reach the ground level, you are picked up and taken to the next level. You are equipped with a gun to defend yourself against enemy agents waiting for you in each floor. You gather points by shooting down enemy agents and visiting apartments marked with a red door, which contain the secret documents.This is an unreleased prototype based on the arcade game.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=1131)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=1131)
 
 ## Actions
 

--- a/docs/environments/atari/enduro.md
+++ b/docs/environments/atari/enduro.md
@@ -11,11 +11,21 @@ title: Enduro
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(9) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Enduro-v5")` |
+
+For more Enduro variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are a racer in the National Enduro, a long-distance endurance race. You must overtake a certain amount of cars each day to stay on the race. The first day you need to pass 200 cars, and 300 foreach following day. The game ends if you do not meet your overtake quota for the day.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=163)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=163)
 
 ## Actions
 

--- a/docs/environments/atari/entombed.md
+++ b/docs/environments/atari/entombed.md
@@ -1,0 +1,90 @@
+---
+title: Entombed
+---
+
+# Entombed
+
+```{figure} ../../_static/videos/atari/entombed.gif
+:width: 120px
+:name: Entombed
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Entombed-v5")` |
+
+For more Entombed variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Entombed is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Entombed has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As Entombed uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Entombed has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id              | obs_type=   | frameskip=   | repeat_action_probability=   |
+|---------------------|-------------|--------------|------------------------------|
+| ALE/Entombed-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Entombed-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0, 2]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/et.md
+++ b/docs/environments/atari/et.md
@@ -1,0 +1,90 @@
+---
+title: Et
+---
+
+# Et
+
+```{figure} ../../_static/videos/atari/et.gif
+:width: 120px
+:name: Et
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Et-v5")` |
+
+For more Et variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Et is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Et has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As Et uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Et has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id        | obs_type=   | frameskip=   | repeat_action_probability=   |
+|---------------|-------------|--------------|------------------------------|
+| ALE/Et-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Et-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 1, 2]`       | `0`            | `[0, 1, 2, 3]`           | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/fishing_derby.md
+++ b/docs/environments/atari/fishing_derby.md
@@ -11,11 +11,21 @@ title: FishingDerby
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/FishingDerby-v5")` |
+
+For more FishingDerby variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 your objective is to catch more sunfish than your opponent.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=182)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=182)
 
 ## Actions
 

--- a/docs/environments/atari/flag_capture.md
+++ b/docs/environments/atari/flag_capture.md
@@ -1,0 +1,90 @@
+---
+title: FlagCapture
+---
+
+# FlagCapture
+
+```{figure} ../../_static/videos/atari/flag_capture.gif
+:width: 120px
+:name: FlagCapture
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/FlagCapture-v5")` |
+
+For more FlagCapture variants with different observation and action spaces, see the variants section.
+
+## Description
+
+FlagCapture is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+FlagCapture has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As FlagCapture uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+FlagCapture has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                 | obs_type=   | frameskip=   | repeat_action_probability=   |
+|------------------------|-------------|--------------|------------------------------|
+| ALE/FlagCapture-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/FlagCapture-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[8, 9, 10]`      | `8`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/freeway.md
+++ b/docs/environments/atari/freeway.md
@@ -11,11 +11,21 @@ title: Freeway
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(3) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Freeway-v5")` |
+
+For more Freeway variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 your objective is to guide your chicken across lane after lane of busy rush hour traffic. You receive a point for every chicken that makes it to the top of the screen after crossing all the lanes of traffic.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=192)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=192)
 
 ## Actions
 

--- a/docs/environments/atari/frogger.md
+++ b/docs/environments/atari/frogger.md
@@ -1,0 +1,79 @@
+---
+title: Frogger
+---
+
+# Frogger
+
+```{figure} ../../_static/videos/atari/frogger.gif
+:width: 120px
+:name: Frogger
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(5) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Frogger-v5")` |
+
+For more Frogger variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Frogger is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Frogger has the action space `Discrete(5)` with the table below lists the meaning of each action's meanings.
+As Frogger uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning   |
+|---------|-----------|
+| `0`     | `NOOP`    |
+| `1`     | `UP`      |
+| `2`     | `RIGHT`   |
+| `3`     | `LEFT`    |
+| `4`     | `DOWN`    |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Frogger has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id             | obs_type=   | frameskip=   | repeat_action_probability=   |
+|--------------------|-------------|--------------|------------------------------|
+| ALE/Frogger-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Frogger-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 1, 2]`       | `0`            | `[0, 1]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/frostbite.md
+++ b/docs/environments/atari/frostbite.md
@@ -11,11 +11,21 @@ title: Frostbite
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Frostbite-v5")` |
+
+For more Frostbite variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 In Frostbite, the player controls "Frostbite Bailey" who hops back and forth across across an Arctic river, changing the color of the ice blocks from white to blue. Each time he does so, a block is added to his igloo.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=199)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=199)
 
 ## Actions
 

--- a/docs/environments/atari/galaxian.md
+++ b/docs/environments/atari/galaxian.md
@@ -1,0 +1,80 @@
+---
+title: Galaxian
+---
+
+# Galaxian
+
+```{figure} ../../_static/videos/atari/galaxian.gif
+:width: 120px
+:name: Galaxian
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Galaxian-v5")` |
+
+For more Galaxian variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Galaxian is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Galaxian has the action space `Discrete(6)` with the table below lists the meaning of each action's meanings.
+As Galaxian uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning     |
+|---------|-------------|
+| `0`     | `NOOP`      |
+| `1`     | `FIRE`      |
+| `2`     | `RIGHT`     |
+| `3`     | `LEFT`      |
+| `4`     | `RIGHTFIRE` |
+| `5`     | `LEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Galaxian has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id              | obs_type=   | frameskip=   | repeat_action_probability=   |
+|---------------------|-------------|--------------|------------------------------|
+| ALE/Galaxian-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Galaxian-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[1, ..., 9]`     | `1`            | `[0, 1]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/gopher.md
+++ b/docs/environments/atari/gopher.md
@@ -11,11 +11,21 @@ title: Gopher
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(8) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Gopher-v5")` |
+
+For more Gopher variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 The player controls a shovel-wielding farmer who protects a crop of three carrots from a gopher.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=218)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=218)
 
 ## Actions
 

--- a/docs/environments/atari/gravitar.md
+++ b/docs/environments/atari/gravitar.md
@@ -11,11 +11,21 @@ title: Gravitar
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Gravitar-v5")` |
+
+For more Gravitar variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 The player controls a small blue spacecraft. The game starts in a fictional solar system with several planets to explore. If the player moves his ship into a planet, he will be taken to a side-view landscape.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=223)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=223)
 
 ## Actions
 

--- a/docs/environments/atari/hangman.md
+++ b/docs/environments/atari/hangman.md
@@ -1,0 +1,90 @@
+---
+title: Hangman
+---
+
+# Hangman
+
+```{figure} ../../_static/videos/atari/hangman.gif
+:width: 120px
+:name: Hangman
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Hangman-v5")` |
+
+For more Hangman variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Hangman is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Hangman has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As Hangman uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Hangman has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id             | obs_type=   | frameskip=   | repeat_action_probability=   |
+|--------------------|-------------|--------------|------------------------------|
+| ALE/Hangman-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Hangman-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 1, 2, 3]`    | `0`            | `[0, 1]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/haunted_house.md
+++ b/docs/environments/atari/haunted_house.md
@@ -1,0 +1,90 @@
+---
+title: HauntedHouse
+---
+
+# HauntedHouse
+
+```{figure} ../../_static/videos/atari/haunted_house.gif
+:width: 120px
+:name: HauntedHouse
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/HauntedHouse-v5")` |
+
+For more HauntedHouse variants with different observation and action spaces, see the variants section.
+
+## Description
+
+HauntedHouse is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+HauntedHouse has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As HauntedHouse uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+HauntedHouse has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                  | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-------------------------|-------------|--------------|------------------------------|
+| ALE/HauntedHouse-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/HauntedHouse-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, ..., 8]`     | `0`            | `[0, 1]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/hero.md
+++ b/docs/environments/atari/hero.md
@@ -11,11 +11,21 @@ title: Hero
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Hero-v5")` |
+
+For more Hero variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You need to rescue miners that are stuck in a mine shaft. You have access to various tools: A propeller backpack that allows you to fly wherever you want, sticks of dynamite that can be used to blast through walls, a laser beam to kill vermin, and a raft to float across stretches of lava.You have a limited amount of power. Once you run out, you lose a live.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=228)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=228)
 
 ## Actions
 

--- a/docs/environments/atari/human_cannonball.md
+++ b/docs/environments/atari/human_cannonball.md
@@ -1,0 +1,90 @@
+---
+title: HumanCannonball
+---
+
+# HumanCannonball
+
+```{figure} ../../_static/videos/atari/human_cannonball.gif
+:width: 120px
+:name: HumanCannonball
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/HumanCannonball-v5")` |
+
+For more HumanCannonball variants with different observation and action spaces, see the variants section.
+
+## Description
+
+HumanCannonball is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+HumanCannonball has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As HumanCannonball uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+HumanCannonball has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                     | obs_type=   | frameskip=   | repeat_action_probability=   |
+|----------------------------|-------------|--------------|------------------------------|
+| ALE/HumanCannonball-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/HumanCannonball-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, ..., 7]`     | `0`            | `[0, 1]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/ice_hockey.md
+++ b/docs/environments/atari/ice_hockey.md
@@ -11,11 +11,21 @@ title: IceHockey
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/IceHockey-v5")` |
+
+For more IceHockey variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your goal is to score as many points as possible in a standard game of Ice Hockey over a 3-minute time period. The ball is usually called "the puck".There are 32 shot angles ranging from the extreme left to the extreme right. The angles can only aim towards the opponent's goal.Just as in real hockey, you can pass the puck by shooting it off the sides of the rink. This can be really key when you're in position to score a goal.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=241)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=241)
 
 ## Actions
 

--- a/docs/environments/atari/jamesbond.md
+++ b/docs/environments/atari/jamesbond.md
@@ -11,11 +11,21 @@ title: Jamesbond
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Jamesbond-v5")` |
+
+For more Jamesbond variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your mission is to control Mr. Bond's specially designed multipurpose craft to complete a variety of missions.The craft moves forward with a right motion and slightly back with a left motion.An up or down motion causes the craft to jump or dive.You can also fire by either lobbing a bomb to the bottom of the screen or firing a fixed angle shot to the top of the screen.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=250)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=250)
 
 ## Actions
 

--- a/docs/environments/atari/journey_escape.md
+++ b/docs/environments/atari/journey_escape.md
@@ -11,11 +11,21 @@ title: JourneyEscape
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(16) |
+| Observation Shape | (230, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/JourneyEscape-v5")` |
+
+For more JourneyEscape variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You must lead all 5 members of JOURNEY through waves of pesky characters and backstage obstacles to the Scarab Escape Vehicle before time runs out.You must also protect $50,000 in concert cash from grasping groupies, photographers, and promoters.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=252)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=252)
 
 ## Actions
 

--- a/docs/environments/atari/kaboom.md
+++ b/docs/environments/atari/kaboom.md
@@ -1,0 +1,78 @@
+---
+title: Kaboom
+---
+
+# Kaboom
+
+```{figure} ../../_static/videos/atari/kaboom.gif
+:width: 120px
+:name: Kaboom
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(4) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Kaboom-v5")` |
+
+For more Kaboom variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Kaboom is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Kaboom has the action space `Discrete(4)` with the table below lists the meaning of each action's meanings.
+As Kaboom uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning   |
+|---------|-----------|
+| `0`     | `NOOP`    |
+| `1`     | `FIRE`    |
+| `2`     | `RIGHT`   |
+| `3`     | `LEFT`    |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Kaboom has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id            | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-------------------|-------------|--------------|------------------------------|
+| ALE/Kaboom-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Kaboom-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/kangaroo.md
+++ b/docs/environments/atari/kangaroo.md
@@ -11,11 +11,21 @@ title: Kangaroo
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Kangaroo-v5")` |
+
+For more Kangaroo variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 The object of the game is to score as many points as you can while controlling Mother Kangaroo to rescue her precious baby. You start the game with three lives.During this rescue mission, Mother Kangaroo encounters many obstacles. You need to help her climb ladders, pick bonus fruit, and throw punches at monkeys.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=923)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=923)
 
 ## Actions
 

--- a/docs/environments/atari/keystone_kapers.md
+++ b/docs/environments/atari/keystone_kapers.md
@@ -1,0 +1,88 @@
+---
+title: KeystoneKapers
+---
+
+# KeystoneKapers
+
+```{figure} ../../_static/videos/atari/keystone_kapers.gif
+:width: 120px
+:name: KeystoneKapers
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(14) |
+| Observation Shape | (250, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/KeystoneKapers-v5")` |
+
+For more KeystoneKapers variants with different observation and action spaces, see the variants section.
+
+## Description
+
+KeystoneKapers is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+KeystoneKapers has the action space `Discrete(14)` with the table below lists the meaning of each action's meanings.
+As KeystoneKapers uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning     |
+|---------|-------------|
+| `0`     | `NOOP`      |
+| `1`     | `FIRE`      |
+| `2`     | `UP`        |
+| `3`     | `RIGHT`     |
+| `4`     | `LEFT`      |
+| `5`     | `DOWN`      |
+| `6`     | `UPRIGHT`   |
+| `7`     | `UPLEFT`    |
+| `8`     | `DOWNRIGHT` |
+| `9`     | `DOWNLEFT`  |
+| `10`    | `UPFIRE`    |
+| `11`    | `RIGHTFIRE` |
+| `12`    | `LEFTFIRE`  |
+| `13`    | `DOWNFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+KeystoneKapers has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                    | obs_type=   | frameskip=   | repeat_action_probability=   |
+|---------------------------|-------------|--------------|------------------------------|
+| ALE/KeystoneKapers-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/KeystoneKapers-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/king_kong.md
+++ b/docs/environments/atari/king_kong.md
@@ -1,0 +1,80 @@
+---
+title: KingKong
+---
+
+# KingKong
+
+```{figure} ../../_static/videos/atari/king_kong.gif
+:width: 120px
+:name: KingKong
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (250, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/KingKong-v5")` |
+
+For more KingKong variants with different observation and action spaces, see the variants section.
+
+## Description
+
+KingKong is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+KingKong has the action space `Discrete(6)` with the table below lists the meaning of each action's meanings.
+As KingKong uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning   |
+|---------|-----------|
+| `0`     | `NOOP`    |
+| `1`     | `FIRE`    |
+| `2`     | `UP`      |
+| `3`     | `RIGHT`   |
+| `4`     | `LEFT`    |
+| `5`     | `DOWN`    |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+KingKong has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id              | obs_type=   | frameskip=   | repeat_action_probability=   |
+|---------------------|-------------|--------------|------------------------------|
+| ALE/KingKong-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/KingKong-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 1, 2, 3]`    | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/klax.md
+++ b/docs/environments/atari/klax.md
@@ -1,0 +1,90 @@
+---
+title: Klax
+---
+
+# Klax
+
+```{figure} ../../_static/videos/atari/klax.gif
+:width: 120px
+:name: Klax
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (250, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Klax-v5")` |
+
+For more Klax variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Klax is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Klax has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As Klax uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Klax has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id          | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-----------------|-------------|--------------|------------------------------|
+| ALE/Klax-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Klax-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 1, 2]`       | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/koolaid.md
+++ b/docs/environments/atari/koolaid.md
@@ -1,0 +1,83 @@
+---
+title: Koolaid
+---
+
+# Koolaid
+
+```{figure} ../../_static/videos/atari/koolaid.gif
+:width: 120px
+:name: Koolaid
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(9) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Koolaid-v5")` |
+
+For more Koolaid variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Koolaid is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Koolaid has the action space `Discrete(9)` with the table below lists the meaning of each action's meanings.
+As Koolaid uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning     |
+|---------|-------------|
+| `0`     | `NOOP`      |
+| `1`     | `UP`        |
+| `2`     | `RIGHT`     |
+| `3`     | `LEFT`      |
+| `4`     | `DOWN`      |
+| `5`     | `UPRIGHT`   |
+| `6`     | `UPLEFT`    |
+| `7`     | `DOWNRIGHT` |
+| `8`     | `DOWNLEFT`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Koolaid has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id             | obs_type=   | frameskip=   | repeat_action_probability=   |
+|--------------------|-------------|--------------|------------------------------|
+| ALE/Koolaid-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Koolaid-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/krull.md
+++ b/docs/environments/atari/krull.md
@@ -11,11 +11,21 @@ title: Krull
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Krull-v5")` |
+
+For more Krull variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your mission is to find and enter the Beast's Black Fortress, rescue Princess Lyssa, and destroy the Beast.The task is not an easy one, for the location of the Black Fortress changes with each sunrise on Krull.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=267)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=267)
 
 ## Actions
 

--- a/docs/environments/atari/kung_fu_master.md
+++ b/docs/environments/atari/kung_fu_master.md
@@ -11,11 +11,21 @@ title: KungFuMaster
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(14) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/KungFuMaster-v5")` |
+
+For more KungFuMaster variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are a Kung-Fu Master fighting your way through the Evil Wizard's temple. Your goal is to rescue Princess Victoria, defeating various enemies along the way.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=268)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=268)
 
 ## Actions
 

--- a/docs/environments/atari/laser_gates.md
+++ b/docs/environments/atari/laser_gates.md
@@ -1,0 +1,90 @@
+---
+title: LaserGates
+---
+
+# LaserGates
+
+```{figure} ../../_static/videos/atari/laser_gates.gif
+:width: 120px
+:name: LaserGates
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (250, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/LaserGates-v5")` |
+
+For more LaserGates variants with different observation and action spaces, see the variants section.
+
+## Description
+
+LaserGates is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+LaserGates has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As LaserGates uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+LaserGates has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-----------------------|-------------|--------------|------------------------------|
+| ALE/LaserGates-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/LaserGates-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/lost_luggage.md
+++ b/docs/environments/atari/lost_luggage.md
@@ -1,0 +1,83 @@
+---
+title: LostLuggage
+---
+
+# LostLuggage
+
+```{figure} ../../_static/videos/atari/lost_luggage.gif
+:width: 120px
+:name: LostLuggage
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(9) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/LostLuggage-v5")` |
+
+For more LostLuggage variants with different observation and action spaces, see the variants section.
+
+## Description
+
+LostLuggage is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+LostLuggage has the action space `Discrete(9)` with the table below lists the meaning of each action's meanings.
+As LostLuggage uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning     |
+|---------|-------------|
+| `0`     | `NOOP`      |
+| `1`     | `UP`        |
+| `2`     | `RIGHT`     |
+| `3`     | `LEFT`      |
+| `4`     | `DOWN`      |
+| `5`     | `UPRIGHT`   |
+| `6`     | `UPLEFT`    |
+| `7`     | `DOWNRIGHT` |
+| `8`     | `DOWNLEFT`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+LostLuggage has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                 | obs_type=   | frameskip=   | repeat_action_probability=   |
+|------------------------|-------------|--------------|------------------------------|
+| ALE/LostLuggage-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/LostLuggage-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 1]`          | `0`            | `[0, 1]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/mario_bros.md
+++ b/docs/environments/atari/mario_bros.md
@@ -1,0 +1,90 @@
+---
+title: MarioBros
+---
+
+# MarioBros
+
+```{figure} ../../_static/videos/atari/mario_bros.gif
+:width: 120px
+:name: MarioBros
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/MarioBros-v5")` |
+
+For more MarioBros variants with different observation and action spaces, see the variants section.
+
+## Description
+
+MarioBros is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+MarioBros has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As MarioBros uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+MarioBros has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id               | obs_type=   | frameskip=   | repeat_action_probability=   |
+|----------------------|-------------|--------------|------------------------------|
+| ALE/MarioBros-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/MarioBros-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 2, 4, 6]`    | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/miniature_golf.md
+++ b/docs/environments/atari/miniature_golf.md
@@ -1,0 +1,90 @@
+---
+title: MiniatureGolf
+---
+
+# MiniatureGolf
+
+```{figure} ../../_static/videos/atari/miniature_golf.gif
+:width: 120px
+:name: MiniatureGolf
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/MiniatureGolf-v5")` |
+
+For more MiniatureGolf variants with different observation and action spaces, see the variants section.
+
+## Description
+
+MiniatureGolf is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+MiniatureGolf has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As MiniatureGolf uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+MiniatureGolf has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                   | obs_type=   | frameskip=   | repeat_action_probability=   |
+|--------------------------|-------------|--------------|------------------------------|
+| ALE/MiniatureGolf-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/MiniatureGolf-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0, 1]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/montezuma_revenge.md
+++ b/docs/environments/atari/montezuma_revenge.md
@@ -11,11 +11,21 @@ title: MontezumaRevenge
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/MontezumaRevenge-v5")` |
+
+For more MontezumaRevenge variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your goal is to acquire Montezuma's treasure by making your way through a maze of chambers within the emperor's fortress. You must avoid deadly creatures while collecting valuables and tools which can help you escape with the treasure.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=310)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=310)
 
 ## Actions
 

--- a/docs/environments/atari/mr_do.md
+++ b/docs/environments/atari/mr_do.md
@@ -1,0 +1,84 @@
+---
+title: MrDo
+---
+
+# MrDo
+
+```{figure} ../../_static/videos/atari/mr_do.gif
+:width: 120px
+:name: MrDo
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(10) |
+| Observation Shape | (250, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/MrDo-v5")` |
+
+For more MrDo variants with different observation and action spaces, see the variants section.
+
+## Description
+
+MrDo is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+MrDo has the action space `Discrete(10)` with the table below lists the meaning of each action's meanings.
+As MrDo uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning     |
+|---------|-------------|
+| `0`     | `NOOP`      |
+| `1`     | `FIRE`      |
+| `2`     | `UP`        |
+| `3`     | `RIGHT`     |
+| `4`     | `LEFT`      |
+| `5`     | `DOWN`      |
+| `6`     | `UPFIRE`    |
+| `7`     | `RIGHTFIRE` |
+| `8`     | `LEFTFIRE`  |
+| `9`     | `DOWNFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+MrDo has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id          | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-----------------|-------------|--------------|------------------------------|
+| ALE/MrDo-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/MrDo-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 1, 2, 3]`    | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/ms_pacman.md
+++ b/docs/environments/atari/ms_pacman.md
@@ -11,11 +11,21 @@ title: MsPacman
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(9) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/MsPacman-v5")` |
+
+For more MsPacman variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your goal is to collect all of the pellets on the screen while avoiding the ghosts.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_page.php?SoftwareLabelID=924)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_page.php?SoftwareLabelID=924)
 
 ## Actions
 

--- a/docs/environments/atari/name_this_game.md
+++ b/docs/environments/atari/name_this_game.md
@@ -11,11 +11,21 @@ title: NameThisGame
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/NameThisGame-v5")` |
+
+For more NameThisGame variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your goal is to defend the treasure that you have discovered. You must fight off a shark and an octopus while keeping an eye on your oxygen supply.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=323)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=323)
 
 ## Actions
 

--- a/docs/environments/atari/othello.md
+++ b/docs/environments/atari/othello.md
@@ -1,0 +1,84 @@
+---
+title: Othello
+---
+
+# Othello
+
+```{figure} ../../_static/videos/atari/othello.gif
+:width: 120px
+:name: Othello
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(10) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Othello-v5")` |
+
+For more Othello variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Othello is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Othello has the action space `Discrete(10)` with the table below lists the meaning of each action's meanings.
+As Othello uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning     |
+|---------|-------------|
+| `0`     | `NOOP`      |
+| `1`     | `FIRE`      |
+| `2`     | `UP`        |
+| `3`     | `RIGHT`     |
+| `4`     | `LEFT`      |
+| `5`     | `DOWN`      |
+| `6`     | `UPRIGHT`   |
+| `7`     | `UPLEFT`    |
+| `8`     | `DOWNRIGHT` |
+| `9`     | `DOWNLEFT`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Othello has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id             | obs_type=   | frameskip=   | repeat_action_probability=   |
+|--------------------|-------------|--------------|------------------------------|
+| ALE/Othello-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Othello-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 1, 2]`       | `0`            | `[0, 2]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/pacman.md
+++ b/docs/environments/atari/pacman.md
@@ -1,0 +1,93 @@
+---
+title: Pacman
+---
+
+# Pacman
+
+```{figure} ../../_static/videos/atari/pacman.gif
+:width: 120px
+:name: Pacman
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(5) |
+| Observation Shape | (250, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Pacman-v5")` |
+
+For more Pacman variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Pacman is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Pacman has the action space `Discrete(5)` with the table below lists the meaning of each action's meanings.
+As Pacman uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning   |
+|---------|-----------|
+| `0`     | `NOOP`    |
+| `1`     | `UP`      |
+| `2`     | `RIGHT`   |
+| `3`     | `LEFT`    |
+| `4`     | `DOWN`    |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Pacman has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                       | obs_type=   | frameskip=   | repeat_action_probability=   |
+|------------------------------|-------------|--------------|------------------------------|
+| MsPacman-v0                  | `"rgb"`     | `(2, 5)`     | `0.25`                       |
+| MsPacman-ram-v0              | `"ram"`     | `(2, 5)`     | `0.25`                       |
+| MsPacman-ramDeterministic-v0 | `"ram"`     | `4`          | `0.25`                       |
+| MsPacman-ramNoFrameskip-v0   | `"ram"`     | `1`          | `0.25`                       |
+| MsPacmanDeterministic-v0     | `"rgb"`     | `4`          | `0.25`                       |
+| MsPacmanNoFrameskip-v0       | `"rgb"`     | `1`          | `0.25`                       |
+| MsPacman-v4                  | `"rgb"`     | `(2, 5)`     | `0.0`                        |
+| MsPacman-ram-v4              | `"ram"`     | `(2, 5)`     | `0.0`                        |
+| MsPacman-ramDeterministic-v4 | `"ram"`     | `4`          | `0.0`                        |
+| MsPacman-ramNoFrameskip-v4   | `"ram"`     | `1`          | `0.0`                        |
+| MsPacmanDeterministic-v4     | `"rgb"`     | `4`          | `0.0`                        |
+| MsPacmanNoFrameskip-v4       | `"rgb"`     | `1`          | `0.0`                        |
+| ALE/MsPacman-v5              | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/MsPacman-ram-v5          | `"ram"`     | `4`          | `0.25`                       |
+| ALE/Pacman-v5                | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Pacman-ram-v5            | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, ..., 7]`     | `0`            | `[0, 1]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/phoenix.md
+++ b/docs/environments/atari/phoenix.md
@@ -11,11 +11,21 @@ title: Phoenix
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(8) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Phoenix-v5")` |
+
+For more Phoenix variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your goal is to reach and shoot the alien pilot. On your way there, you must eliminate waves of war birds while avoiding their bombs.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=355)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=355)
 
 ## Actions
 

--- a/docs/environments/atari/pitfall.md
+++ b/docs/environments/atari/pitfall.md
@@ -11,11 +11,21 @@ title: Pitfall
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Pitfall-v5")` |
+
+For more Pitfall variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control Pitfall Harry and are tasked with collecting all the treasures in a jungle within 20 minutes. You have three lives. The game is over if you collect all the treasures or if you die or if the time runs out.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=360)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=360)
 
 ## Actions
 

--- a/docs/environments/atari/pitfall2.md
+++ b/docs/environments/atari/pitfall2.md
@@ -1,0 +1,90 @@
+---
+title: Pitfall2
+---
+
+# Pitfall2
+
+```{figure} ../../_static/videos/atari/pitfall2.gif
+:width: 120px
+:name: Pitfall2
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Pitfall2-v5")` |
+
+For more Pitfall2 variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Pitfall2 is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Pitfall2 has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As Pitfall2 uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Pitfall2 has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id              | obs_type=   | frameskip=   | repeat_action_probability=   |
+|---------------------|-------------|--------------|------------------------------|
+| ALE/Pitfall2-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Pitfall2-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/pong.md
+++ b/docs/environments/atari/pong.md
@@ -11,11 +11,21 @@ title: Pong
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Pong-v5")` |
+
+For more Pong variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control the right paddle, you compete against the left paddle controlled by the computer. You each try to keep deflecting the ball away from your goal and into your opponent's goal.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=587)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=587)
 
 ## Actions
 

--- a/docs/environments/atari/pooyan.md
+++ b/docs/environments/atari/pooyan.md
@@ -11,11 +11,21 @@ title: Pooyan
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (220, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Pooyan-v5")` |
+
+For more Pooyan variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are a mother pig protecting her piglets (Pooyans) from wolves. In the first scene, you can move up and down a rope. Try to shoot the worker's balloons, while guarding yourself from attacks. If the wolves reach the ground safely they will get behind and try to eat you. In the second scene, the wolves try to float up. You have to try and stop them using arrows and bait. You die if a wolf eats you, or a stone or rock hits you.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=372)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=372)
 
 ## Actions
 

--- a/docs/environments/atari/private_eye.md
+++ b/docs/environments/atari/private_eye.md
@@ -11,11 +11,21 @@ title: PrivateEye
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/PrivateEye-v5")` |
+
+For more PrivateEye variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control the French Private Eye Pierre Touche. Navigate the city streets, parks, secret passages, dead-ends and one-ways in search of the ringleader, Henri Le Fiend and his gang. You also need to find evidence and stolen goods that are scattered about. There are five cases, complete each case before its statute of limitations expires.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=376)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=376)
 
 ## Actions
 

--- a/docs/environments/atari/qbert.md
+++ b/docs/environments/atari/qbert.md
@@ -11,11 +11,21 @@ title: Qbert
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Qbert-v5")` |
+
+For more Qbert variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You are Q*bert. Your goal is to change the color of all the cubes on the pyramid to the pyramid's 'destination' color. To do this, you must hop on each cube on the pyramid one at a time while avoiding nasty creatures that lurk there.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=1224)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=1224)
 
 ## Actions
 

--- a/docs/environments/atari/riverraid.md
+++ b/docs/environments/atari/riverraid.md
@@ -11,11 +11,21 @@ title: Riverraid
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Riverraid-v5")` |
+
+For more Riverraid variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control a jet that flies over a river: you can move it sideways and fire missiles to destroy enemy objects. Each time an enemy object is destroyed you score points (i.e. rewards).You lose a jet when you run out of fuel: fly over a fuel depot when you begin to run low.You lose a jet even when it collides with the river bank or one of the enemy objects (except fuel depots).The game begins with a squadron of three jets in reserve and you're given an additional jet (up to 9) for each 10,000 points you score.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=409)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=409)
 
 ## Actions
 

--- a/docs/environments/atari/road_runner.md
+++ b/docs/environments/atari/road_runner.md
@@ -11,11 +11,21 @@ title: RoadRunner
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/RoadRunner-v5")` |
+
+For more RoadRunner variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control the Road Runner(TM) in a race; you can control the direction to run in and times to jumps.The goal is to outrun Wile E. Coyote(TM) while avoiding the hazards of the desert.The game begins with three lives.  You lose a life when the coyote catches you, picks you up in a rocket, or shoots you with a cannon.  You also lose a life when a truck hits you, you hit a land mine, you fall off a cliff,or you get hit by a falling rock.You score points (i.e. rewards) by eating seeds along the road, eating steel shot, and destroying the coyote.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=412)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=412)
 
 ## Actions
 

--- a/docs/environments/atari/robotank.md
+++ b/docs/environments/atari/robotank.md
@@ -11,11 +11,21 @@ title: Robotank
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Robotank-v5")` |
+
+For more Robotank variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control your Robot Tanks to destroy enemies and avoid enemy fire.Game ends when all of your Robot Tanks are destroyed or all 12 enemy squadrons are destroyed.The game begins with one active Robot Tank and three reserves.Your Robot Tank may get lost when it is hit by enemy    rocket fire - your video scrambles with static interference when this    happens - or just become damaged - sensors report the damage by flashing on your control panel (look at V/C/R/T squares).You earn one bonus Robot Tank for every enemy squadron destroyed. The maximum number of bonus Robot Tanks allowed at any one time is 12.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=416)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=416)
 
 ## Actions
 

--- a/docs/environments/atari/seaquest.md
+++ b/docs/environments/atari/seaquest.md
@@ -11,11 +11,21 @@ title: Seaquest
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Seaquest-v5")` |
+
+For more Seaquest variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control a sub able to move in all directions and fire torpedoes.The goal is to retrieve as many divers as you can, while dodging and blasting enemy subs and killer sharks; points will be awarded accordingly.The game begins with one sub and three waiting on the horizon. Each time you increase your score by 10,000 points, an extra sub will be delivered to yourbase.  You can only have six reserve subs on the screen at one time.Your sub will explode if it collides with anything except your own divers.The sub has a limited amount of oxygen that decreases at a constant rate during the game. When the oxygen tank is almost empty, you need to surface and if you don't do it in time, your sub will blow up and you'll lose one diver.  Each time you're forced to surface, with less than six divers, you lose one diver as well.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=424)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=424)
 
 ## Actions
 

--- a/docs/environments/atari/sir_lancelot.md
+++ b/docs/environments/atari/sir_lancelot.md
@@ -1,0 +1,80 @@
+---
+title: SirLancelot
+---
+
+# SirLancelot
+
+```{figure} ../../_static/videos/atari/sir_lancelot.gif
+:width: 120px
+:name: SirLancelot
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (250, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/SirLancelot-v5")` |
+
+For more SirLancelot variants with different observation and action spaces, see the variants section.
+
+## Description
+
+SirLancelot is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+SirLancelot has the action space `Discrete(6)` with the table below lists the meaning of each action's meanings.
+As SirLancelot uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning     |
+|---------|-------------|
+| `0`     | `NOOP`      |
+| `1`     | `FIRE`      |
+| `2`     | `RIGHT`     |
+| `3`     | `LEFT`      |
+| `4`     | `RIGHTFIRE` |
+| `5`     | `LEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+SirLancelot has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                 | obs_type=   | frameskip=   | repeat_action_probability=   |
+|------------------------|-------------|--------------|------------------------------|
+| ALE/SirLancelot-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/SirLancelot-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/skiing.md
+++ b/docs/environments/atari/skiing.md
@@ -11,11 +11,21 @@ title: Skiing
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(3) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Skiing-v5")` |
+
+For more Skiing variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control a skier who can move sideways.The goal is to run through all gates (between the poles) in the fastest time.You are penalized five seconds for each gate you miss.If you hit a gate or a tree, your skier will jump back up and keep going.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=434)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=434)
 
 ## Actions
 

--- a/docs/environments/atari/solaris.md
+++ b/docs/environments/atari/solaris.md
@@ -11,11 +11,21 @@ title: Solaris
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Solaris-v5")` |
+
+For more Solaris variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control a spaceship. Blast enemies before they can blast you. You can warp to different sectors. You have to defend Federation planets, and destroy Zylon forces. Keep track of your fuel, if you run out you lose a life. Warp to a Federation planet to refuel. The game ends if all your ships are destroyed or if you reach the Solaris planet.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=450)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=450)
 
 ## Actions
 

--- a/docs/environments/atari/space_invaders.md
+++ b/docs/environments/atari/space_invaders.md
@@ -11,11 +11,21 @@ title: SpaceInvaders
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/SpaceInvaders-v5")` |
+
+For more SpaceInvaders variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your objective is to destroy the space invaders by shooting your laser cannon at them before they reach the Earth. The game ends when all your lives are lost after taking enemy fire, or when they reach the earth.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=460)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=460)
 
 ## Actions
 

--- a/docs/environments/atari/space_war.md
+++ b/docs/environments/atari/space_war.md
@@ -1,0 +1,90 @@
+---
+title: SpaceWar
+---
+
+# SpaceWar
+
+```{figure} ../../_static/videos/atari/space_war.gif
+:width: 120px
+:name: SpaceWar
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (250, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/SpaceWar-v5")` |
+
+For more SpaceWar variants with different observation and action spaces, see the variants section.
+
+## Description
+
+SpaceWar is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+SpaceWar has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As SpaceWar uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+SpaceWar has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id              | obs_type=   | frameskip=   | repeat_action_probability=   |
+|---------------------|-------------|--------------|------------------------------|
+| ALE/SpaceWar-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/SpaceWar-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[6, ..., 17]`    | `6`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/star_gunner.md
+++ b/docs/environments/atari/star_gunner.md
@@ -11,11 +11,21 @@ title: StarGunner
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/StarGunner-v5")` |
+
+For more StarGunner variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Stop the alien invasion by shooting down alien saucers and creatures while avoiding bombs.
 
-For a more detailed documentation, see [the AtariAge page](http://www.atarimania.com/game-atari-2600-vcs-stargunner_16921.html)
+    For a more detailed documentation, see [the AtariAge page](http://www.atarimania.com/game-atari-2600-vcs-stargunner_16921.html)
 
 ## Actions
 

--- a/docs/environments/atari/superman.md
+++ b/docs/environments/atari/superman.md
@@ -1,0 +1,90 @@
+---
+title: Superman
+---
+
+# Superman
+
+```{figure} ../../_static/videos/atari/superman.gif
+:width: 120px
+:name: Superman
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Superman-v5")` |
+
+For more Superman variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Superman is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Superman has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As Superman uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Superman has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id              | obs_type=   | frameskip=   | repeat_action_probability=   |
+|---------------------|-------------|--------------|------------------------------|
+| ALE/Superman-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Superman-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0, 1, 2, 3]`           | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/surround.md
+++ b/docs/environments/atari/surround.md
@@ -1,0 +1,79 @@
+---
+title: Surround
+---
+
+# Surround
+
+```{figure} ../../_static/videos/atari/surround.gif
+:width: 120px
+:name: Surround
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(5) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Surround-v5")` |
+
+For more Surround variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Surround is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Surround has the action space `Discrete(5)` with the table below lists the meaning of each action's meanings.
+As Surround uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning   |
+|---------|-----------|
+| `0`     | `NOOP`    |
+| `1`     | `UP`      |
+| `2`     | `RIGHT`   |
+| `3`     | `LEFT`    |
+| `4`     | `DOWN`    |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Surround has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id              | obs_type=   | frameskip=   | repeat_action_probability=   |
+|---------------------|-------------|--------------|------------------------------|
+| ALE/Surround-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Surround-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 2]`          | `0`            | `[0, 1, 2, 3]`           | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/tennis.md
+++ b/docs/environments/atari/tennis.md
@@ -11,11 +11,21 @@ title: Tennis
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Tennis-v5")` |
+
+For more Tennis variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control the orange player playing against a computer-controlled blue player. The game follows the rules of tennis.The first player to win at least 6 games with a margin of at least two games wins the match. If the score is tied at 6-6, the first player to go 2 games up wins the match.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=555)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=555)
 
 ## Actions
 

--- a/docs/environments/atari/tetris.md
+++ b/docs/environments/atari/tetris.md
@@ -1,0 +1,79 @@
+---
+title: Tetris
+---
+
+# Tetris
+
+```{figure} ../../_static/videos/atari/tetris.gif
+:width: 120px
+:name: Tetris
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(5) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Tetris-v5")` |
+
+For more Tetris variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Tetris is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Tetris has the action space `Discrete(5)` with the table below lists the meaning of each action's meanings.
+As Tetris uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning   |
+|---------|-----------|
+| `0`     | `NOOP`    |
+| `1`     | `FIRE`    |
+| `2`     | `RIGHT`   |
+| `3`     | `LEFT`    |
+| `4`     | `DOWN`    |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Tetris has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id            | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-------------------|-------------|--------------|------------------------------|
+| ALE/Tetris-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Tetris-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/tic_tac_toe_3d.md
+++ b/docs/environments/atari/tic_tac_toe_3d.md
@@ -1,0 +1,84 @@
+---
+title: TicTacToe3D
+---
+
+# TicTacToe3D
+
+```{figure} ../../_static/videos/atari/tic_tac_toe_3d.gif
+:width: 120px
+:name: TicTacToe3D
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(10) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/TicTacToe3D-v5")` |
+
+For more TicTacToe3D variants with different observation and action spaces, see the variants section.
+
+## Description
+
+TicTacToe3D is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+TicTacToe3D has the action space `Discrete(10)` with the table below lists the meaning of each action's meanings.
+As TicTacToe3D uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning     |
+|---------|-------------|
+| `0`     | `NOOP`      |
+| `1`     | `FIRE`      |
+| `2`     | `UP`        |
+| `3`     | `RIGHT`     |
+| `4`     | `LEFT`      |
+| `5`     | `DOWN`      |
+| `6`     | `UPRIGHT`   |
+| `7`     | `UPLEFT`    |
+| `8`     | `DOWNRIGHT` |
+| `9`     | `DOWNLEFT`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+TicTacToe3D has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                 | obs_type=   | frameskip=   | repeat_action_probability=   |
+|------------------------|-------------|--------------|------------------------------|
+| ALE/TicTacToe3D-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/TicTacToe3D-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, ..., 8]`     | `0`            | `[0, 2]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/time_pilot.md
+++ b/docs/environments/atari/time_pilot.md
@@ -11,11 +11,21 @@ title: TimePilot
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(10) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/TimePilot-v5")` |
+
+For more TimePilot variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 You control an aircraft. Use it to destroy your enemies. As you progress in the game, you encounter enemies with technology that is increasingly from the future.
 
-For a more detailed documentation, see [the AtariAge page](http://www.atarimania.com/game-atari-2600-vcs-time-pilot_8038.html)
+    For a more detailed documentation, see [the AtariAge page](http://www.atarimania.com/game-atari-2600-vcs-time-pilot_8038.html)
 
 ## Actions
 

--- a/docs/environments/atari/trondead.md
+++ b/docs/environments/atari/trondead.md
@@ -1,0 +1,90 @@
+---
+title: Trondead
+---
+
+# Trondead
+
+```{figure} ../../_static/videos/atari/trondead.gif
+:width: 120px
+:name: Trondead
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Trondead-v5")` |
+
+For more Trondead variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Trondead is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Trondead has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As Trondead uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Trondead has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id              | obs_type=   | frameskip=   | repeat_action_probability=   |
+|---------------------|-------------|--------------|------------------------------|
+| ALE/Trondead-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Trondead-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0]`             | `0`            | `[0, 1]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/turmoil.md
+++ b/docs/environments/atari/turmoil.md
@@ -1,0 +1,86 @@
+---
+title: Turmoil
+---
+
+# Turmoil
+
+```{figure} ../../_static/videos/atari/turmoil.gif
+:width: 120px
+:name: Turmoil
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(12) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Turmoil-v5")` |
+
+For more Turmoil variants with different observation and action spaces, see the variants section.
+
+## Description
+
+Turmoil is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+Turmoil has the action space `Discrete(12)` with the table below lists the meaning of each action's meanings.
+As Turmoil uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning     |
+|---------|-------------|
+| `0`     | `NOOP`      |
+| `1`     | `FIRE`      |
+| `2`     | `UP`        |
+| `3`     | `RIGHT`     |
+| `4`     | `LEFT`      |
+| `5`     | `DOWN`      |
+| `6`     | `UPRIGHT`   |
+| `7`     | `UPLEFT`    |
+| `8`     | `DOWNRIGHT` |
+| `9`     | `DOWNLEFT`  |
+| `10`    | `RIGHTFIRE` |
+| `11`    | `LEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+Turmoil has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id             | obs_type=   | frameskip=   | repeat_action_probability=   |
+|--------------------|-------------|--------------|------------------------------|
+| ALE/Turmoil-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Turmoil-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, ..., 8]`     | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/tutankham.md
+++ b/docs/environments/atari/tutankham.md
@@ -11,11 +11,21 @@ title: Tutankham
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(8) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Tutankham-v5")` |
+
+For more Tutankham variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your goal is to rack up points by finding treasures in the mazes of the tomb while eliminating its guardians.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=572)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=572)
 
 ## Actions
 

--- a/docs/environments/atari/up_n_down.md
+++ b/docs/environments/atari/up_n_down.md
@@ -11,11 +11,21 @@ title: UpNDown
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(6) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/UpNDown-v5")` |
+
+For more UpNDown variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your goal is to steer your baja bugger to collect prizes and eliminate opponents.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=574)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=574)
 
 ## Actions
 

--- a/docs/environments/atari/venture.md
+++ b/docs/environments/atari/venture.md
@@ -11,11 +11,21 @@ title: Venture
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Venture-v5")` |
+
+For more Venture variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your goal is to capture the treasure in every chamber of the dungeon while eliminating the monsters.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=576)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=576)
 
 ## Actions
 

--- a/docs/environments/atari/video_checkers.md
+++ b/docs/environments/atari/video_checkers.md
@@ -1,0 +1,79 @@
+---
+title: VideoCheckers
+---
+
+# VideoCheckers
+
+```{figure} ../../_static/videos/atari/video_checkers.gif
+:width: 120px
+:name: VideoCheckers
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(5) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/VideoCheckers-v5")` |
+
+For more VideoCheckers variants with different observation and action spaces, see the variants section.
+
+## Description
+
+VideoCheckers is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+VideoCheckers has the action space `Discrete(5)` with the table below lists the meaning of each action's meanings.
+As VideoCheckers uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning     |
+|---------|-------------|
+| `0`     | `FIRE`      |
+| `1`     | `UPRIGHT`   |
+| `2`     | `UPLEFT`    |
+| `3`     | `DOWNRIGHT` |
+| `4`     | `DOWNLEFT`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+VideoCheckers has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                   | obs_type=   | frameskip=   | repeat_action_probability=   |
+|--------------------------|-------------|--------------|------------------------------|
+| ALE/VideoCheckers-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/VideoCheckers-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes            | Default Mode   | Available Difficulties   | Default Difficulty   |
+|----------------------------|----------------|--------------------------|----------------------|
+| `[1, ..., 9, 11, ..., 19]` | `1`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/video_chess.md
+++ b/docs/environments/atari/video_chess.md
@@ -1,0 +1,84 @@
+---
+title: VideoChess
+---
+
+# VideoChess
+
+```{figure} ../../_static/videos/atari/video_chess.gif
+:width: 120px
+:name: VideoChess
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(10) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/VideoChess-v5")` |
+
+For more VideoChess variants with different observation and action spaces, see the variants section.
+
+## Description
+
+VideoChess is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+VideoChess has the action space `Discrete(10)` with the table below lists the meaning of each action's meanings.
+As VideoChess uses a reduced set of actions for `v0`, `v4` and `v5` versions of the environment.
+To enable all 18 possible actions that can be performed on an Atari 2600, specify `full_action_space=True` during
+initialization or by passing `full_action_space=True` to `gymnasium.make`.
+
+| Value   | Meaning     |
+|---------|-------------|
+| `0`     | `NOOP`      |
+| `1`     | `FIRE`      |
+| `2`     | `UP`        |
+| `3`     | `RIGHT`     |
+| `4`     | `LEFT`      |
+| `5`     | `DOWN`      |
+| `6`     | `UPRIGHT`   |
+| `7`     | `UPLEFT`    |
+| `8`     | `DOWNRIGHT` |
+| `9`     | `DOWNLEFT`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+VideoChess has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-----------------------|-------------|--------------|------------------------------|
+| ALE/VideoChess-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/VideoChess-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, 1, 2, 3, 4]` | `0`            | `[0]`                    | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/video_cube.md
+++ b/docs/environments/atari/video_cube.md
@@ -1,0 +1,90 @@
+---
+title: VideoCube
+---
+
+# VideoCube
+
+```{figure} ../../_static/videos/atari/video_cube.gif
+:width: 120px
+:name: VideoCube
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/VideoCube-v5")` |
+
+For more VideoCube variants with different observation and action spaces, see the variants section.
+
+## Description
+
+VideoCube is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+VideoCube has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As VideoCube uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+VideoCube has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id               | obs_type=   | frameskip=   | repeat_action_probability=   |
+|----------------------|-------------|--------------|------------------------------|
+| ALE/VideoCube-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/VideoCube-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | Default Mode   | Available Difficulties   | Default Difficulty   |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|--------------------------|----------------------|
+| `[0, 1, 2, 100, 101, 102, 200, 201, 202, 300, 301, 302, 400, 401, 402, 500, 501, 502, 600, 601, 602, 700, 701, 702, 800, 801, 802, 900, 901, 902, 1000, 1001, 1002, 1100, 1101, 1102, 1200, 1201, 1202, 1300, 1301, 1302, 1400, 1401, 1402, 1500, 1501, 1502, 1600, 1601, 1602, 1700, 1701, 1702, 1800, 1801, 1802, 1900, 1901, 1902, 2000, 2001, 2002, 2100, 2101, 2102, 2200, 2201, 2202, 2300, 2301, 2302, 2400, 2401, 2402, 2500, 2501, 2502, 2600, 2601, 2602, 2700, 2701, 2702, 2800, 2801, 2802, 2900, 2901, 2902, 3000, 3001, 3002, 3100, 3101, 3102, 3200, 3201, 3202, 3300, 3301, 3302, 3400, 3401, 3402, 3500, 3501, 3502, 3600, 3601, 3602, 3700, 3701, 3702, 3800, 3801, 3802, 3900, 3901, 3902, 4000, 4001, 4002, 4100, 4101, 4102, 4200, 4201, 4202, 4300, 4301, 4302, 4400, 4401, 4402, 4500, 4501, 4502, 4600, 4601, 4602, 4700, 4701, 4702, 4800, 4801, 4802, 4900, 4901, 4902, 5000, 5001, 5002]` | `0`            | `[0, 1]`                 | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/video_pinball.md
+++ b/docs/environments/atari/video_pinball.md
@@ -11,11 +11,21 @@ title: VideoPinball
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(9) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/VideoPinball-v5")` |
+
+For more VideoPinball variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your goal is to keep the ball in play as long as possible and to score as many points as possible.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=588)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=588)
 
 ## Actions
 

--- a/docs/environments/atari/wizard_of_wor.md
+++ b/docs/environments/atari/wizard_of_wor.md
@@ -11,11 +11,21 @@ title: WizardOfWor
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(10) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/WizardOfWor-v5")` |
+
+For more WizardOfWor variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your goal is to beat the Wizard using your laser and radar scanner.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=598)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=598)
 
 ## Actions
 

--- a/docs/environments/atari/word_zapper.md
+++ b/docs/environments/atari/word_zapper.md
@@ -1,0 +1,90 @@
+---
+title: WordZapper
+---
+
+# WordZapper
+
+```{figure} ../../_static/videos/atari/word_zapper.gif
+:width: 120px
+:name: WordZapper
+```
+
+This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
+
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/WordZapper-v5")` |
+
+For more WordZapper variants with different observation and action spaces, see the variants section.
+
+## Description
+
+WordZapper is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+
+## Actions
+
+WordZapper has the action space `Discrete(18)` with the table below lists the meaning of each action's meanings.
+As WordZapper uses the full set of actions then specifying `full_action_space=True` will not modify the action space of the environment if passed to `gymnasium.make`.
+
+| Value   | Meaning         |
+|---------|-----------------|
+| `0`     | `NOOP`          |
+| `1`     | `FIRE`          |
+| `2`     | `UP`            |
+| `3`     | `RIGHT`         |
+| `4`     | `LEFT`          |
+| `5`     | `DOWN`          |
+| `6`     | `UPRIGHT`       |
+| `7`     | `UPLEFT`        |
+| `8`     | `DOWNRIGHT`     |
+| `9`     | `DOWNLEFT`      |
+| `10`    | `UPFIRE`        |
+| `11`    | `RIGHTFIRE`     |
+| `12`    | `LEFTFIRE`      |
+| `13`    | `DOWNFIRE`      |
+| `14`    | `UPRIGHTFIRE`   |
+| `15`    | `UPLEFTFIRE`    |
+| `16`    | `DOWNRIGHTFIRE` |
+| `17`    | `DOWNLEFTFIRE`  |
+
+## Observations
+
+Atari environment have two possible observation types, the observation space is listed below.
+See variants section for the type of observation used by each environment id.
+
+- `obs_type="rgb" -> observation_space=Box(0, 255, (210, 160, 3), np.uint8)`
+- `obs_type="ram" -> observation_space=Box(0, 255, (128,), np.uint8)`
+
+Additionally, `obs_type="grayscale"` cause the environment return a grayscale version of the rgb array for observations with the observation space being `Box(0, 255, (210, 160), np.uint8)`
+
+## Variants
+
+WordZapper has the following variants of the environment id which have the following differences in observation,
+the number of frame-skips and the repeat action probability.
+
+| Env-id                | obs_type=   | frameskip=   | repeat_action_probability=   |
+|-----------------------|-------------|--------------|------------------------------|
+| ALE/WordZapper-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/WordZapper-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
+
+## Difficulty and modes
+
+It is possible to specify various flavors of the environment via the keyword arguments `difficulty` and `mode`.
+A flavor is a combination of a game mode and a difficulty setting. The table below lists the possible difficulty and mode values
+along with the default values.
+
+| Available Modes   | Default Mode   | Available Difficulties   | Default Difficulty   |
+|-------------------|----------------|--------------------------|----------------------|
+| `[0, ..., 23]`    | `0`            | `[0, 1, 2, 3]`           | `0`                  |
+
+## Version History
+
+A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
+
+* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v4: Stickiness of actions was removed
+* v0: Initial versions release

--- a/docs/environments/atari/yars_revenge.md
+++ b/docs/environments/atari/yars_revenge.md
@@ -11,11 +11,21 @@ title: YarsRevenge
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/YarsRevenge-v5")` |
+
+For more YarsRevenge variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 The objective is to break a path through the shield and destroy the Qotile with a blast from the Zorlon Cannon.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_page.php?SoftwareLabelID=603&currentPage=1&maxPages=12)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_page.php?SoftwareLabelID=603&currentPage=1&maxPages=12)
 
 ## Actions
 

--- a/docs/environments/atari/zaxxon.md
+++ b/docs/environments/atari/zaxxon.md
@@ -11,11 +11,21 @@ title: Zaxxon
 
 This environment is part of the <a href='..'>Atari environments</a>. Please read that page first for general information.
 
+|   |   |
+|---|---|
+| Action Space | Discrete(18) |
+| Observation Shape | (210, 160, 3) |
+| Observation High | 255 |
+| Observation Low | 0  |
+| Import | `gymnasium.make("ALE/Zaxxon-v5")` |
+
+For more Zaxxon variants with different observation and action spaces, see the variants section.
+
 ## Description
 
 Your goal is to stop the evil robot Zaxxon and its armies from enslaving the galaxy by piloting your fighter and shooting enemies.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=606)
+    For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=606)
 
 ## Actions
 


### PR DESCRIPTION
Previously, in generating the documentation, atari and autorom was installed which caused issues if the roms failed to install. 
However, atari is not generate each time in the documentation so this was just causing issues for no reason

Furthermore, this PR add documentation for all of the atari environments (not including descriptions)