### PR TITLE
Use SupportsFloat in step_api_compatibility

### DIFF
--- a/gymnasium/utils/step_api_compatibility.py
+++ b/gymnasium/utils/step_api_compatibility.py
@@ -1,5 +1,5 @@
 """Contains methods for step compatibility, from old-to-new and new-to-old API."""
-from typing import Tuple, Union
+from typing import Tuple, Union, SupportsFloat
 
 import numpy as np
 
@@ -8,14 +8,14 @@ from gymnasium.core import ObsType
 
 DoneStepType = Tuple[
     Union[ObsType, np.ndarray],
-    Union[float, np.ndarray],
+    Union[SupportsFloat, np.ndarray],
     Union[bool, np.ndarray],
     Union[dict, list],
 ]
 
 TerminatedTruncatedStepType = Tuple[
     Union[ObsType, np.ndarray],
-    Union[float, np.ndarray],
+    Union[SupportsFloat, np.ndarray],
     Union[bool, np.ndarray],
     Union[bool, np.ndarray],
     Union[dict, list],

--- a/gymnasium/utils/step_api_compatibility.py
+++ b/gymnasium/utils/step_api_compatibility.py
@@ -1,5 +1,5 @@
 """Contains methods for step compatibility, from old-to-new and new-to-old API."""
-from typing import Tuple, Union, SupportsFloat
+from typing import SupportsFloat, Tuple, Union
 
 import numpy as np
 


### PR DESCRIPTION
The problem is that gym.Env defines step return as Tuple[..., SupportsFloat, ...], and this then can't be passed into functions of `step_api_compatibility`. Alternative to my fix would be to define centrally what is a step return, and reuse the type alias in both places.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


