### PR TITLE
Update observation space bounds of LunarLander environment. 

### DIFF
--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -283,8 +283,41 @@ class LunarLander(gym.Env, EzPickle):
 
         self.continuous = continuous
 
+        low = np.array(
+            [
+                # these are bounds for position
+                # realistically the environment should have ended
+                # long before we reach more than 50% outside
+                -1.5,
+                -1.5,
+                # velocity bounds is 5x rated speed
+                -5.0,
+                -5.0,
+                -math.pi,
+                -5.0,
+                -0.0,
+                -0.0,
+            ]
+        ).astype(np.float32) * SCALE * 2
+        high = np.array(
+            [
+                # these are bounds for position
+                # realistically the environment should have ended
+                # long before we reach more than 50% outside
+                1.5,
+                1.5,
+                # velocity bounds is 5x rated speed
+                5.0,
+                5.0,
+                math.pi,
+                5.0,
+                1.0,
+                1.0,
+            ]
+        ).astype(np.float32) * SCALE * 2
+
         # useful range is -1 .. +1, but spikes can be higher
-        self.observation_space = spaces.Box(-np.inf, np.inf, shape=(8,), dtype=np.float32)
+        self.observation_space = spaces.Box(low, high)
 
         if self.continuous:
             # Action is two floats [main engine, left-right engines].

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -283,41 +283,8 @@ class LunarLander(gym.Env, EzPickle):
 
         self.continuous = continuous
 
-        low = np.array(
-            [
-                # these are bounds for position
-                # realistically the environment should have ended
-                # long before we reach more than 50% outside
-                -1.5,
-                -1.5,
-                # velocity bounds is 5x rated speed
-                -5.0,
-                -5.0,
-                -math.pi,
-                -5.0,
-                -0.0,
-                -0.0,
-            ]
-        ).astype(np.float32)
-        high = np.array(
-            [
-                # these are bounds for position
-                # realistically the environment should have ended
-                # long before we reach more than 50% outside
-                1.5,
-                1.5,
-                # velocity bounds is 5x rated speed
-                5.0,
-                5.0,
-                math.pi,
-                5.0,
-                1.0,
-                1.0,
-            ]
-        ).astype(np.float32)
-
         # useful range is -1 .. +1, but spikes can be higher
-        self.observation_space = spaces.Box(low, high)
+        self.observation_space = spaces.Box(-np.inf, np.inf, shape=(8,), dtype=np.float32)
 
         if self.continuous:
             # Action is two floats [main engine, left-right engines].

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -288,8 +288,8 @@ class LunarLander(gym.Env, EzPickle):
                 # these are bounds for position
                 # realistically the environment should have ended
                 # long before we reach more than 50% outside
-                -1.5,
-                -1.5,
+                -1.5 * SCALE * 2,
+                -1.5 * SCALE * 2,
                 # velocity bounds is 5x rated speed
                 -5.0,
                 -5.0,
@@ -298,14 +298,14 @@ class LunarLander(gym.Env, EzPickle):
                 -0.0,
                 -0.0,
             ]
-        ).astype(np.float32) * SCALE * 2
+        ).astype(np.float32)
         high = np.array(
             [
                 # these are bounds for position
                 # realistically the environment should have ended
                 # long before we reach more than 50% outside
-                1.5,
-                1.5,
+                1.5 * SCALE * 2,
+                1.5 * SCALE * 2,
                 # velocity bounds is 5x rated speed
                 5.0,
                 5.0,
@@ -314,7 +314,7 @@ class LunarLander(gym.Env, EzPickle):
                 1.0,
                 1.0,
             ]
-        ).astype(np.float32) * SCALE * 2
+        ).astype(np.float32)
 
         # useful range is -1 .. +1, but spikes can be higher
         self.observation_space = spaces.Box(low, high)


### PR DESCRIPTION
# Description

Revert changes in Lunar Lander environment's observation space changes. Now the observation space is same as that of `gym` version `0.23`

Fixes #377 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
