### PR TITLE
Add ruff linter in CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,22 +23,11 @@ repos:
       - id: codespell
         args:
           - --ignore-words-list=reacher,ure,referenc,wile
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.254'
     hooks:
-      - id: flake8
-        args:
-          - '--per-file-ignores=*/__init__.py:F401 gymnasium/envs/registration.py:E704 docs/tutorials/*.py:E402 gymnasium/experimental/wrappers/__init__.py:E402'
-          - --ignore=E203,W503,E741
-          - --max-complexity=30
-          - --max-line-length=456
-          - --show-source
-          - --statistics
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
-        args: ["--py37-plus"]
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/gymnasium/envs/toy_text/frozen_lake.py
+++ b/gymnasium/envs/toy_text/frozen_lake.py
@@ -38,7 +38,7 @@ def is_valid(board: List[List[str]], max_size: int) -> bool:
     frontier.append((0, 0))
     while frontier:
         r, c = frontier.pop()
-        if not (r, c) in discovered:
+        if (r, c) not in discovered:
             discovered.add((r, c))
             directions = [(1, 0), (0, 1), (-1, 0), (0, -1)]
             for x, y in directions:

--- a/gymnasium/experimental/vector/utils/space_utils.py
+++ b/gymnasium/experimental/vector/utils/space_utils.py
@@ -50,7 +50,6 @@ def batch_space(space: Space[Any], n: int = 1) -> Space[Any]:
         ValueError: Cannot batch space does not have a registered function.
 
     Example:
-
         >>> from gymnasium.spaces import Box, Dict
         >>> import numpy as np
         >>> space = Dict({

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,56 @@ gymnasium = [
 [tool.black]
 safe = true
 
+[tool.ruff]
+select = [
+    "F",    # Pyflakes
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "C90",  # mccabe
+    # "I",    # isort
+    # "D",    # pydocstyle
+    "UP"    # pyupgrade
+]
+ignore = ["E741"]
+
+src = ["gymnasium", "tests", "docs/scripts"]
+
+line-length = 459
+target-version = "py37"
+show-source = true
+show-fixes = true
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["F401"]
+"docs/tutorials/*.py" = ["E402"]
+"gymnasium/experimental/wrappers/__init__.py" = ["E402"]
+
+# Saved ruff.pydocstyle configurations
+# "gymnasium/envs/registration.py" = ["D"]
+# "gymnasium/envs/box2d/*.py" = ["D"]
+# "gymnasium/envs/classic_control/*.py" = ["D"]
+# "gymnasium/envs/mujoco/*.py" = ["D"]
+# "gymnasium/envs/toy_text/*.py" = ["D"]
+# "tests/envs/*.py" = ["D"]
+# "tests/spaces/*.py" = ["D"]
+# "tests/utils/*.py" = ["D"]
+# "tests/vector/*.py" = ["D"]
+# "tests/wrappers/*.py" = ["D"]
+# "docs/*.py" = ["D"]
+
+[tool.ruff.mccabe]
+max-complexity = 30
+
+# Saved ruff.pydocstyle configurations
+# [tool.ruff.pydocstyle]
+# convention = "google"
+
+# Saved ruff.isort configurations
+# [tool.ruff.isort]
+# known-first-party = ["gymnasium", "tests", "docs/scripts"]
+# extra-standard-library = ["typing_extensions"]
+# lines-after-imports = 2
+
 [tool.isort]
 atomic = true
 profile = "black"


### PR DESCRIPTION
# Description

This PR opens the discussion to replace [flake8](https://github.com/PyCQA/flake8) for [ruff](https://github.com/charliermarsh/ruff) in CI.

### flake8 -> ruff 
Pros:
  - Perfomance
  - Unification of configurations (everything is done in `pyproject.toml`)
  - Expendability to include new rules easily (such as flake8 plugins) to provide a robuster linter

Cons:
 - Ruff is still a new project
 - The state of Gymnasium at the moment doesn't require a linter change (only gains 3s -> 1s in linter perfomance)

### pyupgrade -> ruff.pyupgrade

Ruff integrates pyupgrade in his rules, ruff.pyupgrade doesn't raise new issues. In the PR I removed pyupgrade for ruff.pyupgrade.

### pydocstyle -> ruff.pydocstyle

Ruff integrates pydocstyle in his rules, but ruff.pydocstyle raises new errors. In the PR I have kept pydocstyle configuration and commented out the ruff.pydocstyle one.
<details>
    <summary>Errors</summary>

    ```
    gymnasium/experimental/vector/async_vector_env.py:40:7: D101 Missing docstring in public class
       |
    40 | class AsyncState(Enum):
       |       ^^^^^^^^^^ D101
       |
    
    gymnasium/vector/async_vector_env.py:37:7: D101 Missing docstring in public class
       |
    37 | class AsyncState(Enum):
       |       ^^^^^^^^^^ D101
       |
    
    gymnasium/vector/vector_env.py:354:9: D107 Missing docstring in `__init__`
        |
    354 |     def __init__(self, env: VectorEnv):
        |         ^^^^^^^^ D107
        |
    
    gymnasium/vector/vector_env.py:360:9: D102 Missing docstring in public method
        |
    360 |     def reset_async(self, **kwargs):
        |         ^^^^^^^^^^^ D102
        |
    
    gymnasium/vector/vector_env.py:363:9: D102 Missing docstring in public method
        |
    363 |     def reset_wait(self, **kwargs):
        |         ^^^^^^^^^^ D102
        |
    
    gymnasium/vector/vector_env.py:366:9: D102 Missing docstring in public method
        |
    366 |     def step_async(self, actions):
        |         ^^^^^^^^^^ D102
        |
    
    gymnasium/vector/vector_env.py:369:9: D102 Missing docstring in public method
        |
    369 |     def step_wait(self):
        |         ^^^^^^^^^ D102
        |
    
    gymnasium/vector/vector_env.py:372:9: D102 Missing docstring in public method
        |
    372 |     def close(self, **kwargs):
        |         ^^^^^ D102
        |
    
    gymnasium/vector/vector_env.py:375:9: D102 Missing docstring in public method
        |
    375 |     def close_extras(self, **kwargs):
        |         ^^^^^^^^^^^^ D102
        |
    
    gymnasium/vector/vector_env.py:378:9: D102 Missing docstring in public method
        |
    378 |     def call(self, name, *args, **kwargs):
        |         ^^^^ D102
        |
    
    gymnasium/vector/vector_env.py:381:9: D102 Missing docstring in public method
        |
    381 |     def set_attr(self, name, values):
        |         ^^^^^^^^ D102
        |
    
    gymnasium/vector/vector_env.py:385:9: D105 Missing docstring in magic method
        |
    385 |     def __getattr__(self, name):
        |         ^^^^^^^^^^^ D105
        |
    
    gymnasium/vector/vector_env.py:391:9: D102 Missing docstring in public method
        |
    391 |     def unwrapped(self):
        |         ^^^^^^^^^ D102
        |
    
    gymnasium/vector/vector_env.py:394:9: D105 Missing docstring in magic method
        |
    394 |     def __repr__(self):
        |         ^^^^^^^^ D105
        |
    
    gymnasium/vector/vector_env.py:397:9: D105 Missing docstring in magic method
        |
    397 |     def __del__(self):
        |         ^^^^^^^ D105
        |
    ```
</details>

### isort -> ruff.isort

Ruff integrates isort in his rules, ruff.isort doesn't raise new issues. But ruff.isort doesn't contain the `multi_line_output`, so I have kept isort configuration and commented out the ruff.isort ones. (The `multi_line_output`is marked as an issue in ruff repo.)
 
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
