### PR TITLE
Add a note on how to seed the action space

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -45,6 +45,9 @@ class Env(Generic[ObsType, ActType]):
       ``super().reset(seed=seed)`` and when assessing ``self.np_random``.
 
     .. seealso:: For modifying or extending environments use the :py:class:`gymnasium.Wrapper` class
+
+    Note:
+        To get reproducible sampling of actions, a seed can be set with ``env.action_space.seed(123)``.
     """
 
     # Set this in SOME subclasses


### PR DESCRIPTION
# Description

This PR adds a note to the docs to explicitely say how to seed the action space.

Fixes https://github.com/Farama-Foundation/Gymnasium/issues/185.

## Type of change

Please delete options that are not relevant.

- [x] Minor documentation change

### Screenshots
![image](https://user-images.githubusercontent.com/6053592/224837821-49b96049-4296-4771-bc8b-d8afcfe6f4c7.png)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have made corresponding changes to the documentation