### PR TITLE
removing unnecessary warnings (#269)

### DIFF
--- a/gymnasium/utils/passive_env_checker.py
+++ b/gymnasium/utils/passive_env_checker.py
@@ -21,29 +21,6 @@ def _check_box_observation_space(observation_space: spaces.Box):
     Args:
         observation_space: A box observation space
     """
-    # Check if the box is an image
-    if (len(observation_space.shape) == 3 and observation_space.shape[0] != 1) or (
-        len(observation_space.shape) == 4 and observation_space.shape[0] == 1
-    ):
-        if observation_space.dtype != np.uint8:
-            logger.warn(
-                f"It seems a Box observation space is an image but the `dtype` is not `np.uint8`, actual type: {observation_space.dtype}. "
-                "If the Box observation space is not an image, we recommend flattening the observation to have only a 1D vector."
-            )
-        if np.any(observation_space.low != 0) or np.any(observation_space.high != 255):
-            logger.warn(
-                "It seems a Box observation space is an image but the lower and upper bounds are not [0, 255]. "
-                f"Actual lower bound: {np.min(observation_space.low)}, upper bound: {np.max(observation_space.high)}. "
-                "Generally, CNN policies assume observations are within that range, so you may encounter an issue if the observation values are not."
-            )
-
-    if len(observation_space.shape) not in [1, 3]:
-        if not (len(observation_space.shape) == 2 and observation_space.shape[0] == 1):
-            logger.warn(
-                "A Box observation space has an unconventional shape (neither an image, nor a 1D vector). "
-                "We recommend flattening the observation to have only a 1D vector or use a custom policy to properly process the data. "
-                f"Actual observation shape: {observation_space.shape}"
-            )
 
     assert (
         observation_space.low.shape == observation_space.shape


### PR DESCRIPTION
# Description

This removes three warnings that are no longer necessary, according to the discussion of issue #269:
"It seems a Box observation space is an image but the lower and upper bounds are not [0, 255]...."
"A box observation space has an unconventional shape (neither an image, nor a 1D vector)..."
"It seems a Box observation space is an image but the dtype is not np.uint8..."

Fixes # (269)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

This only removes the warnings above, no new code was added, so I have not runany of the following checks:
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
