### PR TITLE
Import `vector` in `gymnasium.__init__`

### DIFF
--- a/gymnasium/__init__.py
+++ b/gymnasium/__init__.py
@@ -20,7 +20,7 @@ from gymnasium.envs.registration import (
 )
 
 # necessary for `envs.__init__` which registers all gymnasium environments and loads plugins
-from gymnasium import envs
+from gymnasium import envs, vector
 
 
 __all__ = [
@@ -48,7 +48,8 @@ __all__ = [
     "error",
     "logger",
 ]
-__version__ = "0.28.0"
+__version__ = "0.28.1"
+
 
 # Initializing pygame initializes audio connections through SDL. SDL uses alsa by default on all Linux systems
 # SDL connecting to alsa frequently create these giant lists of warnings every time you import an environment using

--- a/gymnasium/__init__.py
+++ b/gymnasium/__init__.py
@@ -1,6 +1,5 @@
 """Root `__init__` of the gymnasium module setting the `__all__` of gymnasium modules."""
 # isort: skip_file
-# pyright: reportUnsupportedDunderAll=false
 
 from gymnasium.core import (
     Env,
@@ -20,7 +19,8 @@ from gymnasium.envs.registration import (
 )
 
 # necessary for `envs.__init__` which registers all gymnasium environments and loads plugins
-from gymnasium import envs, vector
+from gymnasium import envs
+from gymnasium import experimental, spaces, utils, vector, wrappers, error, logger
 
 
 __all__ = [


### PR DESCRIPTION
For some reason, `import gymnasium` followed by `gymnasium.vector` fails as the module is not imported in `gymnasium/__init__.py`. More alarming this is not picked up by the CI 