### PR TITLE
Update jax environment names

### DIFF
--- a/docs/scripts/gen_mds.py
+++ b/docs/scripts/gen_mds.py
@@ -14,9 +14,9 @@ exclude_env_names = [
     "FrozenLake8x8",
     "LunarLanderContinuous",
     "BipedalWalkerHardcore",
-    "CartPoleJax",
-    "PendulumJax",
-    "Jax-Blackjack",
+    "phys2d/CartPole",
+    "phys2d/PendulumJax",
+    "tabular/Blackjack",
 ]
 for env_spec in gym.registry.values():
     if env_spec.name not in exclude_env_names:

--- a/docs/scripts/gen_mds.py
+++ b/docs/scripts/gen_mds.py
@@ -15,7 +15,7 @@ exclude_env_names = [
     "LunarLanderContinuous",
     "BipedalWalkerHardcore",
     "phys2d/CartPole",
-    "phys2d/PendulumJax",
+    "phys2d/Pendulum",
     "tabular/Blackjack",
 ]
 for env_spec in gym.registry.values():

--- a/gymnasium/envs/__init__.py
+++ b/gymnasium/envs/__init__.py
@@ -62,7 +62,7 @@ register(
 # ----------------------------------------
 
 register(
-    id="CartPoleJax-v0",
+    id="phys2d/CartPole-v0",
     entry_point="gymnasium.envs.phys2d.cartpole:CartPoleJaxEnv",
     vector_entry_point="gymnasium.envs.phys2d.cartpole:CartPoleJaxVectorEnv",
     max_episode_steps=200,
@@ -70,7 +70,7 @@ register(
 )
 
 register(
-    id="CartPoleJax-v1",
+    id="phys2d/CartPole-v1",
     entry_point="gymnasium.envs.phys2d.cartpole:CartPoleJaxEnv",
     vector_entry_point="gymnasium.envs.phys2d.cartpole:CartPoleJaxVectorEnv",
     max_episode_steps=500,
@@ -78,7 +78,7 @@ register(
 )
 
 register(
-    id="PendulumJax-v0",
+    id="phys2d/Pendulum-v0",
     entry_point="gymnasium.envs.phys2d.pendulum:PendulumJaxEnv",
     vector_entry_point="gymnasium.envs.phys2d.pendulum:PendulumJaxVectorEnv",
     max_episode_steps=200,
@@ -166,7 +166,7 @@ register(
 # ----------------------------------------
 
 register(
-    id="Jax-Blackjack-v0",
+    id="tabular/Blackjack-v0",
     entry_point="gymnasium.envs.tabular.blackjack:BlackJackJaxEnv",
     kwargs={"sutton_and_barto": True, "natural": False},
 )

--- a/gymnasium/experimental/wrappers/rendering.py
+++ b/gymnasium/experimental/wrappers/rendering.py
@@ -317,7 +317,7 @@ class HumanRenderingV0(
         ``render_mode="human"`` to ``make``. The wrapper will only be applied if the environment does not
         implement human-rendering natively (i.e. ``render_mode`` does not contain ``"human"``).
 
-        >>> env = gym.make("CartPoleJax-v1", render_mode="human")      # CartPoleJax-v1 doesn't implement human-rendering natively
+        >>> env = gym.make("phys2d/CartPole-v1", render_mode="human")      # CartPoleJax-v1 doesn't implement human-rendering natively
         >>> obs, _ = env.reset()     # This will start rendering to the screen
 
         Warning: If the base environment uses ``render_mode="rgb_array_list"``, its (i.e. the *base environment's*) render method

--- a/gymnasium/wrappers/human_rendering.py
+++ b/gymnasium/wrappers/human_rendering.py
@@ -28,7 +28,7 @@ class HumanRendering(gym.Wrapper, gym.utils.RecordConstructorArgs):
         ``render_mode="human"`` to ``make``. The wrapper will only be applied if the environment does not
         implement human-rendering natively (i.e. ``render_mode`` does not contain ``"human"``).
 
-        >>> env = gym.make("CartPoleJax-v1", render_mode="human")      # CartPoleJax-v1 doesn't implement human-rendering natively
+        >>> env = gym.make("phys2d/CartPole-v1", render_mode="human")      # phys2d/CartPole-v1 doesn't implement human-rendering natively
         >>> obs, _ = env.reset()     # This will start rendering to the screen
 
         Warning: If the base environment uses ``render_mode="rgb_array_list"``, its (i.e. the *base environment's*) render method


### PR DESCRIPTION
Currently the jax environment have no consistent environment names for registration.
This PR updates the environments to use a phys2d and tabular as the namespace