### PR TITLE
Fix the doc filter to check only args values

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,9 +72,9 @@ autodoc_preserve_defaults = True
 # the class docstring.
 def remove_lines_before_parameters(app, what, name, obj, options, lines):
     if what == "class":
-        # ":" represents args values such as :param: or :raises:
+        # ":param" represents args values
         first_idx_to_keep = next(
-            (i for i, line in enumerate(lines) if line.startswith(":")), 0
+            (i for i, line in enumerate(lines) if line.startswith(":param")), 0
         )
         lines[:] = lines[first_idx_to_keep:]
 


### PR DESCRIPTION
# Description

The documentation filter I added before is too large, and removes too much content like : 
- https://gymnasium.farama.org/api/experimental/wrappers/#gymnasium.experimental.wrappers.TimeAwareObservationV0
- https://gymnasium.farama.org/api/wrappers/misc_wrappers/#gymnasium.wrappers.RecordEpisodeStatistics

I fixed it to be stricter and it should working as expected

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
