### PR TITLE
Fix the wrong nstep in _step_mujoco_simulation function of class MujocoEnv

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -368,7 +368,7 @@ class MujocoEnv(BaseMujocoEnv):
     def _step_mujoco_simulation(self, ctrl, n_frames):
         self.data.ctrl[:] = ctrl
 
-        mujoco.mj_step(self.model, self.data, nstep=self.frame_skip)
+        mujoco.mj_step(self.model, self.data, nstep=n_frames)
 
         # As of MuJoCo 2.0, force-related quantities like cacc are not computed
         # unless there's a force sensor in the model.


### PR DESCRIPTION
# Description
This fixes the incorrect value passed to the argument `nstep` in `_step_mujoco_simulation` function of class `MujocoEnv`, according to the discussion of issue https://github.com/Farama-Foundation/Gymnasium/issues/420:

Fixes # (420)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
