### PR TITLE
Update gym_compatibility.md to fix broken example

### DIFF
--- a/docs/content/gym_compatibility.md
+++ b/docs/content/gym_compatibility.md
@@ -44,7 +44,7 @@ Additionally, in Gymnasium we provide specialist environments for compatibility 
 ```python
 import gymnasium
 
-env = gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1", make_kwargs={"length": 1}, render_mode="human")
+env = gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1", render_mode="human")
 # or
 env = gymnasium.make("GymV21Environment-v0", env=OldV21Env())
 


### PR DESCRIPTION
# Description

The previous code throws an error:
```
env = gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1", make_kwargs={"length": 1}, render_mode="human")
/Users/elliottower/anaconda3/envs/shimmy/lib/python3.9/site-packages/gymnasium/envs/registration.py:787: UserWarning: WARN: The environment is being initialised with render_mode='human' that is not in the possible render_modes ([]).
  logger.warn(
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/elliottower/anaconda3/envs/shimmy/lib/python3.9/site-packages/gymnasium/envs/registration.py", line 813, in make
    raise e
  File "/Users/elliottower/anaconda3/envs/shimmy/lib/python3.9/site-packages/gymnasium/envs/registration.py", line 801, in make
    env = env_creator(**env_spec_kwargs)
  File "/Users/elliottower/Documents/GitHub/Shimmy/shimmy/openai_gym_compatibility.py", line 199, in __init__
    gym_env = gym.make(env_id, **make_kwargs)
  File "/Users/elliottower/anaconda3/envs/shimmy/lib/python3.9/site-packages/gym/envs/registration.py", line 652, in make
    raise e
  File "/Users/elliottower/anaconda3/envs/shimmy/lib/python3.9/site-packages/gym/envs/registration.py", line 640, in make
    env = env_creator(**_kwargs)
TypeError: __init__() got an unexpected keyword argument 'length'
```

The new code works perfectly fine. Maybe there are other kwargs other than length which can be used? Not familiar with cartpole v1 and wasn't sure if this was even the right way to do config args.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
