### PR TITLE
Update shimmy[gym] to shimmy[gym-v21] or shimmy[gym-v26]

### DIFF
--- a/gymnasium/envs/__init__.py
+++ b/gymnasium/envs/__init__.py
@@ -369,7 +369,7 @@ register(
 # --- For shimmy compatibility
 def _raise_shimmy_error(*args: Any, **kwargs: Any):
     raise ImportError(
-        "To use the gym compatibility environments, run `pip install shimmy[gym]`"
+        "To use the gym compatibility environments, run `pip install shimmy[gym-v21]` or `pip install shimmy[gym-v26]`"
     )
 
 

--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -150,14 +150,14 @@ def test_shimmy_gym_compatibility():
         with pytest.raises(
             ImportError,
             match=re.escape(
-                "To use the gym compatibility environments, run `pip install shimmy[gym]`"
+                "To use the gym compatibility environments, run `pip install shimmy[gym-v21]` or `pip install shimmy[gym-v26]`"
             ),
         ):
             gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1")
         with pytest.raises(
             ImportError,
             match=re.escape(
-                "To use the gym compatibility environments, run `pip install shimmy[gym]`"
+                "To use the gym compatibility environments, run `pip install shimmy[gym-v21]` or `pip install shimmy[gym-v26]`"
             ),
         ):
             gymnasium.make("GymV26Environment-v0", env_id="CartPole-v1")


### PR DESCRIPTION
# Description

This updates some debug print lines which say to install shimmy[gym], because we are planning to change it to shimmy[gym-v21] and shimmy[gym-v26] for simplicity. Otherwise, there are installation issues with version of pyglet and it's not as user friendly to have to install these versions manually. Setting as draft until these changes are finalized in shimmy.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
