### PR TITLE
Add missing phys2d asset in setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ include = ["gymnasium", "gymnasium.*"]
 gymnasium = [
     "envs/mujoco/assets/*.xml",
     "envs/classic_control/assets/*.png",
+    "envs/phys2d/assets/*.png",
     "envs/toy_text/font/*.ttf",
     "envs/toy_text/img/*.png",
     "py.typed",


### PR DESCRIPTION
# Description

In the installed package the `assets/` directory is missing in `envs/phys2d/`, because it is not listed at `tool.setuptools.package-data` in `pyproject.toml`. This leads for `tests/envs/test_rendering.py::test_render_modes[PendulumJax-v0]` to an error: "FileNotFoundError: No such file or directory: `'/path/to/my/env/lib/python3.9/site-packages/gymnasium/envs/phys2d/assets/clockwise.png'`." caused from `envs/phys2d/pendulum.py:136`. This commit should fix the test.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
