### PR TITLE
Add single-action and observation spaces in the experimental vector space

### DIFF
--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -362,10 +362,10 @@ class CartPoleVectorEnv(VectorEnv):
         self.low = -0.05
         self.high = 0.05
 
-        self.action_space = batch_space(spaces.Discrete(2), num_envs)
-        self.observation_space = batch_space(
-            spaces.Box(-high, high, dtype=np.float32), num_envs
-        )
+        self.single_action_space = spaces.Discrete(2)
+        self.action_space = batch_space(self.single_action_space, num_envs)
+        self.single_observation_space = spaces.Box(-high, high, dtype=np.float32)
+        self.observation_space = batch_space(self.single_observation_space, num_envs)
 
         self.render_mode = render_mode
 

--- a/gymnasium/experimental/functional_jax_env.py
+++ b/gymnasium/experimental/functional_jax_env.py
@@ -135,9 +135,9 @@ class FunctionalJaxVectorEnv(gym.experimental.vector.VectorEnv):
             metadata = {}
         self.func_env = func_env
         self.num_envs = num_envs
+
         self.single_observation_space = func_env.observation_space
         self.single_action_space = func_env.action_space
-
         self.observation_space = batch_space(
             self.single_observation_space, self.num_envs
         )

--- a/gymnasium/experimental/vector/vector_env.py
+++ b/gymnasium/experimental/vector/vector_env.py
@@ -67,6 +67,8 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
 
     observation_space: gym.Space
     action_space: gym.Space
+    single_observation_space: gym.Space
+    single_action_space: gym.Space
 
     num_envs: int
 
@@ -267,6 +269,11 @@ class VectorWrapper(VectorEnv):
         Don't forget to call ``super().__init__(env)`` if the subclass overrides :meth:`__init__`.
     """
 
+    _observation_space: gym.Space | None = None
+    _action_space: gym.Space | None = None
+    _single_observation_space: gym.Space | None = None
+    _single_action_space: gym.Space | None = None
+
     def __init__(self, env: VectorEnv):
         """Initialize the vectorized environment wrapper."""
         super().__init__()
@@ -312,6 +319,64 @@ class VectorWrapper(VectorEnv):
     def __del__(self):
         """Close the vectorized environment."""
         self.env.__del__()
+
+    @property
+    def spec(self) -> EnvSpec | None:
+        """Gets the specification of the wrapped environment."""
+        return self.env.spec
+
+    @property
+    def observation_space(self) -> gym.Space:
+        """Gets the observation space of the vector environment."""
+        if self._observation_space is None:
+            return self.env.observation_space
+        return self._observation_space
+
+    @observation_space.setter
+    def observation_space(self, space: gym.Space):
+        """Sets the observation space of the vector environment."""
+        self._observation_space = space
+
+    @property
+    def action_space(self) -> gym.Space:
+        """Gets the action space of the vector environment."""
+        if self._action_space is None:
+            return self.env.action_space
+        return self._action_space
+
+    @action_space.setter
+    def action_space(self, space: gym.Space):
+        """Sets the action space of the vector environment."""
+        self._action_space = space
+
+    @property
+    def single_observation_space(self) -> gym.Space:
+        """Gets the single observation space of the vector environment."""
+        if self._single_observation_space is None:
+            return self.env.single_observation_space
+        return self._single_observation_space
+
+    @single_observation_space.setter
+    def single_observation_space(self, space: gym.Space):
+        """Sets the single observation space of the vector environment."""
+        self._single_observation_space = space
+
+    @property
+    def single_action_space(self) -> gym.Space:
+        """Gets the single action space of the vector environment."""
+        if self._single_action_space is None:
+            return self.env.single_action_space
+        return self._single_action_space
+
+    @single_action_space.setter
+    def single_action_space(self, space):
+        """Sets the single action space of the vector environment."""
+        self._single_action_space = space
+
+    @property
+    def num_envs(self) -> int:
+        """Gets the wrapped vector environment's num of the sub-environments."""
+        return self.env.num_envs
 
 
 class VectorObservationWrapper(VectorWrapper):


### PR DESCRIPTION
# Description

The experimental vector environment is missing the `single_action_space` and `single_observation_space` in `VectorEnv` and `VectorWrapper` with property forwarding like in `Wrapper`