### PR TITLE
Fix extra tab spacing on homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,14 +26,14 @@ env = gym.make("CartPole-v1", render_mode="human")
 observation, info = env.reset(seed=42) # get the first observation
 
 for step in range(1000):
-	# here you can use your policy to get an action based on the observation
-	action = env.action_space.sample()
+    # here you can use your policy to get an action based on the observation
+    action = env.action_space.sample()
 
-	# execute the action in the environment
-	observation, reward, terminated, truncated, info = env.step(action)
+    # execute the action in the environment
+    observation, reward, terminated, truncated, info = env.step(action)
 
-	if terminated or truncated:
-		observation, info = env.reset()
+    if terminated or truncated:
+        observation, info = env.reset()
 env.close()
 ```
 


### PR DESCRIPTION
# Description
Minor fix, python code in homepage was set to have tabs as 8 spaces rather than 4

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
