### PR TITLE
Pin MuJoCo 2.3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ classic-control = ["pygame ==2.1.3"]
 classic_control = ["pygame ==2.1.3"]  # kept for backward compatibility
 mujoco-py = ["mujoco-py >=2.1,<2.2"]
 mujoco_py = ["mujoco-py >=2.1,<2.2"]       # kept for backward compatibility
-mujoco = ["mujoco >=2.3.2", "imageio >=2.14.1"]
+mujoco = ["mujoco <=2.3.3", "imageio >=2.14.1"]
 toy-text = ["pygame ==2.1.3"]
 toy_text = ["pygame ==2.1.3"]         # kept for backward compatibility
 jax = ["jax ==0.3.24", "jaxlib ==0.3.24"]
@@ -68,7 +68,7 @@ all = [
     # mujoco-py
     "mujoco-py >=2.1,<2.2",
     # mujoco
-    "mujoco >=2.3.2",
+    "mujoco <=2.3.3",
     "imageio >=2.14.1",
     # toy-text
     "pygame ==2.1.3",


### PR DESCRIPTION
In order that CI pass without issues related to part of the code base, we are pinning the MuJoCo version to `<=2.3.3` due to a change introduced in [`2.3.4`](https://github.com/deepmind/mujoco/releases).
The issue has been reported, https://github.com/deepmind/mujoco/issues/833 and we hope to unpin soon