### PR TITLE
Skip Jax and PyTorch tests if module is missing

### DIFF
--- a/tests/envs/functional/test_jax.py
+++ b/tests/envs/functional/test_jax.py
@@ -1,11 +1,13 @@
-import jax
-import jax.numpy as jnp
-import jax.random as jrng
-import numpy as np
 import pytest
 
-from gymnasium.envs.phys2d.cartpole import CartPoleFunctional
-from gymnasium.envs.phys2d.pendulum import PendulumFunctional
+
+jax = pytest.importorskip("jax")
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jrng  # noqa: E402
+import numpy as np  # noqa: E402
+
+from gymnasium.envs.phys2d.cartpole import CartPoleFunctional  # noqa: E402
+from gymnasium.envs.phys2d.pendulum import PendulumFunctional  # noqa: E402
 
 
 @pytest.mark.parametrize("env_class", [CartPoleFunctional, PendulumFunctional])

--- a/tests/experimental/functional/test_func_jax_env.py
+++ b/tests/experimental/functional/test_func_jax_env.py
@@ -1,12 +1,14 @@
 """Test the functional jax environment."""
 
-import jax
-import jax.numpy as jnp
-import jax.random as jrng
 import pytest
 
-from gymnasium.envs.phys2d.cartpole import CartPoleFunctional
-from gymnasium.envs.phys2d.pendulum import PendulumFunctional
+
+jax = pytest.importorskip("jax")
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jrng  # noqa: E402
+
+from gymnasium.envs.phys2d.cartpole import CartPoleFunctional  # noqa: E402
+from gymnasium.envs.phys2d.pendulum import PendulumFunctional  # noqa: E402
 
 
 @pytest.mark.parametrize("env_class", [CartPoleFunctional, PendulumFunctional])

--- a/tests/experimental/functional/test_jax_blackjack.py
+++ b/tests/experimental/functional/test_jax_blackjack.py
@@ -1,12 +1,14 @@
 """Tests for Jax Blackjack functional env."""
 
 
-import jax
-import jax.numpy as jnp
-import jax.random as jrng
 import pytest
 
-from gymnasium.envs.tabular.blackjack import BlackjackFunctional
+
+jax = pytest.importorskip("jax")
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jrng  # noqa: E402
+
+from gymnasium.envs.tabular.blackjack import BlackjackFunctional  # noqa: E402
 
 
 def test_normal_BlackjackFunctional():

--- a/tests/experimental/functional/test_jax_cliffwalking.py
+++ b/tests/experimental/functional/test_jax_cliffwalking.py
@@ -1,12 +1,14 @@
 """Tests for Jax cliffwalking functional env."""
 
 
-import jax
-import jax.numpy as jnp
-import jax.random as jrng
 import pytest
 
-from gymnasium.envs.tabular.cliffwalking import CliffWalkingFunctional
+
+jax = pytest.importorskip("jax")
+import jax.numpy as jnp  # noqa: E402
+import jax.random as jrng  # noqa: E402
+
+from gymnasium.envs.tabular.cliffwalking import CliffWalkingFunctional  # noqa: E402
 
 
 def test_normal_CliffWalkingFunctional():

--- a/tests/experimental/wrappers/test_init_shorten_import.py
+++ b/tests/experimental/wrappers/test_init_shorten_import.py
@@ -10,7 +10,7 @@ from gymnasium.experimental.wrappers import __all__
 
 
 def test_all_wrapper_shorten():
-    """Test that all wrappers in `__alL__` are contained within the `_wrapper_to_class` conversion."""
+    """Test that all wrappers in `__all__` are contained within the `_wrapper_to_class` conversion."""
     all_wrappers = set(__all__)
     all_wrappers.remove("vector")
     assert all_wrappers == set(_wrapper_to_class.keys())
@@ -18,6 +18,9 @@ def test_all_wrapper_shorten():
 
 @pytest.mark.parametrize("wrapper_name", __all__)
 def test_all_wrappers_shortened(wrapper_name):
-    """Check that each element of the `__all__` wrappers can be loaded."""
+    """Check that each element of the `__all__` wrappers can be loaded, provided dependencies are installed."""
     if wrapper_name != "vector":
-        assert getattr(gymnasium.experimental.wrappers, wrapper_name) is not None
+        try:
+            assert getattr(gymnasium.experimental.wrappers, wrapper_name) is not None
+        except gymnasium.error.DependencyNotInstalled as e:
+            pytest.skip(str(e))

--- a/tests/experimental/wrappers/test_jax_to_numpy.py
+++ b/tests/experimental/wrappers/test_jax_to_numpy.py
@@ -1,16 +1,18 @@
 """Test suite for JaxToNumpyV0."""
 
-import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from gymnasium.experimental.wrappers.jax_to_numpy import (
+
+jnp = pytest.importorskip("jax.numpy")
+
+from gymnasium.experimental.wrappers.jax_to_numpy import (  # noqa: E402
     JaxToNumpyV0,
     jax_to_numpy,
     numpy_to_jax,
 )
-from gymnasium.utils.env_checker import data_equivalence
-from tests.testing_env import GenericTestEnv
+from gymnasium.utils.env_checker import data_equivalence  # noqa: E402
+from tests.testing_env import GenericTestEnv  # noqa: E402
 
 
 @pytest.mark.parametrize(

--- a/tests/experimental/wrappers/test_jax_to_torch.py
+++ b/tests/experimental/wrappers/test_jax_to_torch.py
@@ -1,16 +1,18 @@
 """Test suite for TorchToJaxV0."""
 
-import jax.numpy as jnp
 import numpy as np
 import pytest
-import torch
 
-from gymnasium.experimental.wrappers.jax_to_torch import (
+
+jnp = pytest.importorskip("jax.numpy")
+torch = pytest.importorskip("torch")
+
+from gymnasium.experimental.wrappers.jax_to_torch import (  # noqa: E402
     JaxToTorchV0,
     jax_to_torch,
     torch_to_jax,
 )
-from tests.testing_env import GenericTestEnv
+from tests.testing_env import GenericTestEnv  # noqa: E402
 
 
 def torch_data_equivalence(data_1, data_2) -> bool:


### PR DESCRIPTION
# Description

Jax and PyTorch are optional dependencies. As such, tests importing them, should also be optional. This PR skips these tests, if the module is missing. This is an issue, because Jax is not available for Windows from conda-forge or PyPI and PyTorch is not available for Windows from conda-forge. A similar patch has been applied in https://github.com/conda-forge/gymnasium-feedstock/pull/28.

The same actually holds for OpenCV, which is required in [this test](https://github.com/Farama-Foundation/Gymnasium/blob/main/tests/wrappers/test_atari_preprocessing.py#L51). However, OpenCV is well available and skipping the test is not so easy, because it throws in the pytest parametrization.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
  → Enhances windows compatibility of test suite.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  → Not required.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  → This fixes (skips) tests if they are not applicable.
- [x] New and existing unit tests pass locally with my changes