### PR TITLE
Skip tests with multiprocessing start method fork on windows

### DIFF
--- a/tests/experimental/vector/utils/test_shared_memory.py
+++ b/tests/experimental/vector/utils/test_shared_memory.py
@@ -23,6 +23,11 @@ from tests.spaces.utils import TESTING_SPACES, TESTING_SPACES_IDS
 )
 def test_shared_memory_create_read_write(space, num, ctx):
     """Test the shared memory functions, create, read and write for all of the testing spaces."""
+    if ctx not in mp.get_all_start_methods():
+        pytest.skip(
+            f"Multiprocessing start method {ctx} not available on this platform."
+        )
+
     ctx = mp if ctx is None else mp.get_context(ctx)
     samples = [space.sample() for _ in range(num)]
 

--- a/tests/vector/test_shared_memory.py
+++ b/tests/vector/test_shared_memory.py
@@ -50,6 +50,11 @@ expected_types = [
     "ctx", [None, "fork", "spawn"], ids=["default", "fork", "spawn"]
 )
 def test_create_shared_memory(space, expected_type, n, ctx):
+    if ctx not in mp.get_all_start_methods():
+        pytest.skip(
+            f"Multiprocessing start method {ctx} not available on this platform."
+        )
+
     def assert_nested_type(lhs, rhs, n):
         assert type(lhs) == type(rhs)
         if isinstance(lhs, (list, tuple)):
@@ -81,6 +86,11 @@ def test_create_shared_memory(space, expected_type, n, ctx):
 )
 @pytest.mark.parametrize("space", custom_spaces)
 def test_create_shared_memory_custom_space(n, ctx, space):
+    if ctx not in mp.get_all_start_methods():
+        pytest.skip(
+            f"Multiprocessing start method {ctx} not available on this platform."
+        )
+
     ctx = mp if (ctx is None) else mp.get_context(ctx)
     with pytest.raises(CustomSpaceError):
         create_shared_memory(space, n=n, ctx=ctx)


### PR DESCRIPTION
# Description

The fork start method is not available on windows. To enhance windows compatibility of the tests this commit skips tests of start methods that are not available.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
  → Enhances windows compatibility of test suite.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
  → All changes are easy to understand and the code is rather explicit in its intention.
- [ ] I have made corresponding changes to the documentation
  → Not required.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  → This fixes (skips) tests if they are not applicable.
- [x] New and existing unit tests pass locally with my changes