### PR TITLE
Skip Mujoco tests if OpenGL is not available

### DIFF
--- a/bin/all-py.Dockerfile
+++ b/bin/all-py.Dockerfile
@@ -26,6 +26,7 @@ ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/root/.mujoco/mujoco210/bin"
 COPY . /usr/local/gymnasium/
 WORKDIR /usr/local/gymnasium/
 
-RUN pip install .[all,testing] --no-cache-dir
+# Test with PyTorch CPU build, since CUDA is not available in CI anyway
+RUN pip install .[all,testing] --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu
 
 ENTRYPOINT ["/usr/local/gymnasium/bin/docker_entrypoint"]

--- a/tests/envs/test_rendering.py
+++ b/tests/envs/test_rendering.py
@@ -62,13 +62,19 @@ def test_render_modes(spec):
         if mode != "human":
             new_env = spec.make(render_mode=mode)
 
-            new_env.reset()
-            rendered = new_env.render()
-            check_rendered(rendered, mode)
+            try:
+                new_env.reset()
+                rendered = new_env.render()
+                check_rendered(rendered, mode)
 
-            new_env.step(new_env.action_space.sample())
-            rendered = new_env.render()
-            check_rendered(rendered, mode)
-
-            new_env.close()
+                new_env.step(new_env.action_space.sample())
+                rendered = new_env.render()
+                check_rendered(rendered, mode)
+            except Exception as e:
+                if "gladLoadGL error" in str(e):
+                    pytest.skip("OpenGL not available")
+                else:
+                    raise
+            finally:
+                new_env.close()
     env.close()

--- a/tests/envs/utils.py
+++ b/tests/envs/utils.py
@@ -22,6 +22,7 @@ def try_make_env(env_spec: EnvSpec) -> Optional[gym.Env]:
             return env_spec.make(disable_env_checker=True).unwrapped
         except (
             ImportError,
+            AttributeError,
             gym.error.DependencyNotInstalled,
             gym.error.MissingArgument,
         ) as e:


### PR DESCRIPTION
# Description

This PR skips the Mujoco tests in case OpenGL is not available, like in a docker container, see e.g. the section "MuJoCo OpenGL Errors" in [this comment](https://github.com/conda-forge/gymnasium-feedstock/pull/28#issuecomment-1520428770).

When selecting OSMesa by setting the environment variable `MUJOCO_GL=osmesa`, this does not lead to an `ImportError` from Mujoco, but to an `AttributeError` from OpenGL, if OSMesa is not available. This PR adds `AttributeError` to the expected errors, when making the test environments. It triggers a warning, but does not lead to a skipped test. This behavior is analog to the case when EGL is selected, but not available.

Additionally this PR tests if an OffScreenViewer object can be instantiated. It fails when setting the environment variable `MUJOCO_GL=glfw`, if GLFW is not available. In this case, the commit skips the rendering tests with Mujoco environments.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
  → Enhances portability of test suite.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
  → Not required.
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  → This fixes (skips) tests if they are not applicable.
- [x] New and existing unit tests pass locally with my changes