### PR TITLE
Fix homepage header text alignment on mobile

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -50,19 +50,15 @@ img{
     padding-top: 0
  }
 .logo{
-    padding-left: 7%;
+    padding-left: 8%;
+    padding-top: 10px
 }
-@media (min-width: 1072px) {
+@media (min-width: 455px) {
     .header-text{
         text-align: center;
     }
 }
-@media (min-width: 450px) and (max-width: 1072px) {
-    .header-text{
-        text-align: center;
-    }
-}
-@media (max-width: 450px) {
+@media (max-width: 455px) {
     .header-text{
         text-align: left;
     }

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,8 +8,11 @@ lastpage:
     <div class="logo">
         <img src="_static/img/gymnasium-text.png" width="65%" alt="Gymnasium Logo">
     </div>
-    <h2>An API standard for reinforcement learning with a diverse collection of reference environments</h2>
 </center>
+
+<div class="header-text">
+    <h2>An API standard for reinforcement learning with a diverse collection of reference environments</h2>
+</div>
 
 ```{figure} _static/videos/box2d/lunar_lander.gif
    :alt: Lunar Lander
@@ -42,12 +45,27 @@ h2 {
     overflow: auto;
 }
 img{
-  vertical-align:bottom;
-  padding-bottom: 0;
-  padding-top: 0
+    vertical-align:bottom;
+    padding-bottom: 0;
+    padding-top: 0
  }
 .logo{
-  padding-left: 7%;
+    padding-left: 7%;
+}
+@media (min-width: 1072px) {
+    .header-text{
+        text-align: center;
+    }
+}
+@media (min-width: 450px) and (max-width: 1072px) {
+    .header-text{
+        text-align: center;
+    }
+}
+@media (max-width: 450px) {
+    .header-text{
+        text-align: left;
+    }
 }
 </style>
 


### PR DESCRIPTION
# Description

Minor CSS changes to make header text aligned to the left on mobile.

Also added 10px padding to the top of the logo because in darkmode it looks bad being right next to the top border. I tested this out on PettingZoo (see darkmode here https://pettingzoo.farama.org/main/) and it looks good so I'm mirroring it. Would have preferred a single PR but it's hard to know what mobile will look like before the site is live.

Note: this does not affect any screen sizes above 455px (desktop looks exactly the same)

Note 2:unfortunately I couldn't get the preview with GitHub pages working, but I scaled the text on my browser magnification and screen size until it looked exactly the same as in the phone screenshot, and then adjusted the alignment to look better.

New view:
![firefox_4k9QD5NqGn](https://user-images.githubusercontent.com/32176771/235831730-673bd779-625a-451d-b4b4-057f7a2cc3a3.png)

Previous mobile view:
![image](https://user-images.githubusercontent.com/32176771/235831739-78b2dd9e-8bd7-420f-a658-b37d9f8fcb5b.png)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
