### PR TITLE
Add Gym-Trading-Env to Thrid Party Environments

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -59,10 +59,10 @@ gym-jiminy presents an extension of the initial Gym for robotics using [Jiminy](
 
 Highly scalable and customizable Safe Reinforcement Learning library.
 
-### [gym-trading-env: Trading Environment]([https://github.com/ClementPerroud/Gym-Trading-Env](https://gym-trading-env.readthedocs.io/))
+### [gym-trading-env: Trading Environment](https://gym-trading-env.readthedocs.io/))
 
 [![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.28.1-blue)]()
-[![Github stars]([https://gym-trading-env.readthedocs.io/](https://img.shields.io/github/stars/ClementPerroud/Gym-Trading-Env)]()
+[![Github stars](https://img.shields.io/github/stars/ClementPerroud/Gym-Trading-Env)]()
 
 Gym Trading Env simulates stock (or crypto) market on historical data. It was designed to be fast and easily customizable for easy RL trading algorithms implementation.
 

--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -59,10 +59,10 @@ gym-jiminy presents an extension of the initial Gym for robotics using [Jiminy](
 
 Highly scalable and customizable Safe Reinforcement Learning library.
 
-### [gym-trading-env: Trading Environment](https://gym-trading-env.readthedocs.io/))
+### [gym-trading-env: Trading Environment](https://gym-trading-env.readthedocs.io/)
 
 [![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.28.1-blue)]()
-[![Github stars](https://img.shields.io/github/stars/ClementPerroud/Gym-Trading-Env)]()
+[![Github stars](https://img.shields.io/github/stars/ClementPerroud/Gym-Trading-Env)()
 
 Gym Trading Env simulates stock (or crypto) market on historical data. It was designed to be fast and easily customizable for easy RL trading algorithms implementation.
 

--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -62,7 +62,7 @@ Highly scalable and customizable Safe Reinforcement Learning library.
 ### [gym-trading-env: Trading Environment](https://gym-trading-env.readthedocs.io/)
 
 [![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.28.1-blue)]()
-[![Github stars](https://img.shields.io/github/stars/ClementPerroud/Gym-Trading-Env)()
+[![Github stars](https://img.shields.io/github/stars/ClementPerroud/Gym-Trading-Env)]()
 
 Gym Trading Env simulates stock (or crypto) market on historical data. It was designed to be fast and easily customizable for easy RL trading algorithms implementation.
 

--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -59,6 +59,13 @@ gym-jiminy presents an extension of the initial Gym for robotics using [Jiminy](
 
 Highly scalable and customizable Safe Reinforcement Learning library.
 
+### [gym-trading-env: Trading Environment]([https://github.com/ClementPerroud/Gym-Trading-Env](https://gym-trading-env.readthedocs.io/))
+
+[![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.28.1-blue)]()
+[![Github stars]([https://gym-trading-env.readthedocs.io/](https://img.shields.io/github/stars/ClementPerroud/Gym-Trading-Env)]()
+
+Gym Trading Env simulates stock (or crypto) market on historical data. It was designed to be fast and easily customizable for easy RL trading algorithms implementation.
+
 ### [stable-retro: Classic retro games, a maintained version of OpenAI Retro](https://github.com/MatPoliquin/stable-retro)
 
 [![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.27.1-blue)]()

--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -64,7 +64,7 @@ Highly scalable and customizable Safe Reinforcement Learning library.
 [![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.28.1-blue)]()
 [![Github stars](https://img.shields.io/github/stars/ClementPerroud/Gym-Trading-Env)]()
 
-Gym Trading Env simulates stock (or crypto) market on historical data. It was designed to be fast and easily customizable for easy RL trading algorithms implementation.
+Gym Trading Env simulates stock (or crypto) market from historical data. It was designed to be fast and easily customizable.
 
 ### [stable-retro: Classic retro games, a maintained version of OpenAI Retro](https://github.com/MatPoliquin/stable-retro)
 


### PR DESCRIPTION
# Description

This PR is about adding Gym-Trading-Env to the Thrid Party Environments page.
Over the past weeks, I have been worked on a Trading Gymnasium Environment. This environment is now available though a package named `gym_trading_env`. I made a [documentation available here](https://gym-trading-env.readthedocs.io) with explanations, tutorials, and references.

## Type of change

- Adding a Gym-Trading-Env section in the page "Third-Party Environments" in the "Third-Party Environments" section with : 
- It looks like the environments are sorted by star counts. So I positioned my env according to that right after [Safety-Gymnasium: Ensuring safety in real-world RL scenarios](https://gymnasium.farama.org/environments/third_party_environments/#safety-gymnasium-ensuring-safety-in-real-world-rl-scenarios) :



### [gym-trading-env: Trading Environment](https://gym-trading-env.readthedocs.io/)

[![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.28.1-blue)]() [![Github stars](https://img.shields.io/github/stars/ClementPerroud/Gym-Trading-Env)]()

Gym Trading Env simulates stock (or crypto) market from historical data. It was designed to be fast and easily customizable.


