### PR TITLE
Typo in the documentation for single_observation_space

### DIFF
--- a/docs/api/vector.md
+++ b/docs/api/vector.md
@@ -52,7 +52,7 @@ title: Vector
     The observation space of an environment copy.::
 
         >>> envs = gymnasium.vector.make("CartPole-v1", num_envs=3)
-        >>> envs.single_action_space
+        >>> envs.single_observation_space
         Box([-4.8 ...], [4.8 ...], (4,), float32)
 ```
 


### PR DESCRIPTION
# Description

Fixed a copy/paste typo in the documentation for single_observation_space

## Type of change

[x] Bug fix (non-breaking change which fixes an issue)
