### PR TITLE
Disallow Degenerate box space

### DIFF
--- a/gymnasium/spaces/box.py
+++ b/gymnasium/spaces/box.py
@@ -102,6 +102,11 @@ class Box(Space[NDArray[Any]]):
                 f"Box shape is inferred from low and high, expect their types to be np.ndarray, an integer or a float, actual type low: {type(low)}, high: {type(high)}"
             )
 
+        # check that we don't have a degenerate space
+        assert np.array(
+            low != high
+        ).all(), f"Some elements in low: {low} are equal to some elements in high: {high}, this will lead to a degenerate space and is not allowed"
+
         # Capture the boundedness information before replacing np.inf with get_inf
         _low = np.full(shape, low, dtype=float) if is_float_integer(low) else low
         self.bounded_below: NDArray[np.bool_] = -np.inf < _low


### PR DESCRIPTION
# Description

This disallows the user from creating box spaces where the range is 0.

Fixes #493

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes