### PR TITLE
Allow users to view source code of referenced objects on the website

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,6 +41,7 @@ extensions = [
     "sphinx.ext.doctest",
     "sphinx.ext.autodoc",
     "sphinx.ext.githubpages",
+    "sphinx.ext.viewcode",
     "myst_parser",
     "furo.gen_tutorials",
     "sphinx_gallery.gen_gallery",


### PR DESCRIPTION
# Description

User on discord requested that we add a button to link to the source code

Enabled sphinx extension viewcode - https://documentation.help/Sphinx/viewcode.html
Which adds the functionality for us