### PR TITLE
Test GymV26 compatibility env only for gym>=0.26.0

### DIFF
--- a/tests/envs/test_compatibility.py
+++ b/tests/envs/test_compatibility.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import numpy as np
 import pytest
+from packaging import version
 
 import gymnasium
 from gymnasium.error import DependencyNotInstalled
@@ -142,9 +143,22 @@ def test_make_compatibility_in_make():
     del gymnasium.envs.registration.registry["LegacyTestEnv-v0"]
 
 
-def test_shimmy_gym_compatibility():
-    assert gymnasium.spec("GymV21Environment-v0") is not None
-    assert gymnasium.spec("GymV26Environment-v0") is not None
+@pytest.mark.parametrize(
+    "env",
+    (
+        "GymV21Environment-v0",
+        pytest.param(
+            "GymV26Environment-v0",
+            marks=pytest.mark.skipif(
+                gym is not None
+                and version.parse(gym.version.VERSION) < version.parse("0.26.0"),
+                reason="Cannot test GymV26Environment-v0 compatibility env with gym < 0.26.0",
+            ),
+        ),
+    ),
+)
+def test_shimmy_gym_compatibility(env):
+    assert gymnasium.spec(env) is not None
 
     if shimmy is None:
         with pytest.raises(
@@ -153,14 +167,7 @@ def test_shimmy_gym_compatibility():
                 "To use the gym compatibility environments, run `pip install shimmy[gym]`"
             ),
         ):
-            gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1")
-        with pytest.raises(
-            ImportError,
-            match=re.escape(
-                "To use the gym compatibility environments, run `pip install shimmy[gym]`"
-            ),
-        ):
-            gymnasium.make("GymV26Environment-v0", env_id="CartPole-v1")
+            gymnasium.make(env)
     elif gym is None:
         with pytest.raises(
             DependencyNotInstalled,
@@ -168,14 +175,6 @@ def test_shimmy_gym_compatibility():
                 "No module named 'gym' (Hint: You need to install gym with `pip install gym` to use gym environments"
             ),
         ):
-            gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1")
-        with pytest.raises(
-            DependencyNotInstalled,
-            match=re.escape(
-                "No module named 'gym' (Hint: You need to install gym with `pip install gym` to use gym environments"
-            ),
-        ):
-            gymnasium.make("GymV26Environment-v0", env_id="CartPole-v1")
+            gymnasium.make(env, env_id="CartPole-v1")
     else:
-        gymnasium.make("GymV21Environment-v0", env_id="CartPole-v1")
-        gymnasium.make("GymV26Environment-v0", env_id="CartPole-v1")
+        gymnasium.make(env, env_id="CartPole-v1")


### PR DESCRIPTION
# Description

This parametrizes the test `tests/envs/test_compatibility.py::test_shimmy_gym_compatibility` with the parameters `GymV21Environment-v0` and `GymV26Environment-v0`. The latter is skipped if gym < 0.26.0 is installed.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
  → For older gym versions the test failed, but it just should not have been tested.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
  → not required, the purpose is documented in the reason argument of `pytest.mark.skipif`.
- [ ] I have made corresponding changes to the documentation
  → not required
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  → This fixes (skips) tests if they are not applicable.
- [x] New and existing unit tests pass locally with my changes