### PR TITLE
Atari docs edits

### DIFF
--- a/docs/environments/atari/backgammon.md
+++ b/docs/environments/atari/backgammon.md
@@ -21,7 +21,9 @@ For more Backgammon variants with different observation and action spaces, see t
 
 ## Description
 
-Backgammon is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Your goal is to move all your pieces off the board (called 'bearing off'). Players take turns rolling dice and moving their pieces.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=12).
 
 ## Actions
 

--- a/docs/environments/atari/basic_math.md
+++ b/docs/environments/atari/basic_math.md
@@ -21,7 +21,10 @@ For more BasicMath variants with different observation and action spaces, see th
 
 ## Description
 
-BasicMath is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+You must solve basic math problems using a joystick
+to scroll to the correct numeric answer.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=14).
 
 ## Actions
 

--- a/docs/environments/atari/beam_rider.md
+++ b/docs/environments/atari/beam_rider.md
@@ -23,7 +23,7 @@ For more BeamRider variants with different observation and action spaces, see th
 
 You control a space-ship that travels forward at a constant speed. You can only steer it sideways between discrete positions. Your goal is to destroy enemy ships, avoid their attacks and dodge space debris.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareID=860)
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareID=860)
 
 ## Actions
 
@@ -50,7 +50,7 @@ See variants section for the type of observation used by each environment id by 
 ### Rewards
 
 You score points for destroying enemies.
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SystemID=2600&SoftwareID=860&itemTypeID=MANUAL).
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SystemID=2600&SoftwareID=860&itemTypeID=MANUAL).
 
 ## Variants
 

--- a/docs/environments/atari/blackjack.md
+++ b/docs/environments/atari/blackjack.md
@@ -21,7 +21,9 @@ For more Blackjack variants with different observation and action spaces, see th
 
 ## Description
 
-Blackjack is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Compete against a dealer to draw cards and score as close to 21 as possible without going over ('bust').
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=34).
 
 ## Actions
 

--- a/docs/environments/atari/casino.md
+++ b/docs/environments/atari/casino.md
@@ -21,7 +21,9 @@ For more Casino variants with different observation and action spaces, see the v
 
 ## Description
 
-Casino is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+This is actually several games packaged together. Games 1 and 2 are Blackjack, where the second allows card splitting (which is when a player splits their cards into two groups and plays two hands simultaneously). Game 3 is stud poker, which involves drawing cards, betting, and attempting to get the highest scoring poker hand. Game 4 is poker solitaire, which involves filling a 5 by 5 matrix with cards and scoring the poker hands formed by the rows. 
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=70).
 
 ## Actions
 

--- a/docs/environments/atari/crossbow.md
+++ b/docs/environments/atari/crossbow.md
@@ -21,7 +21,9 @@ For more Crossbow variants with different observation and action spaces, see the
 
 ## Description
 
-Crossbow is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+You must retrieve stolen treasures from the Evil Master's castle. Along the way you face enemies who you can shoot at with a crossbow.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=115).
 
 ## Actions
 

--- a/docs/environments/atari/darkchambers.md
+++ b/docs/environments/atari/darkchambers.md
@@ -21,7 +21,9 @@ For more Darkchambers variants with different observation and action spaces, see
 
 ## Description
 
-Darkchambers is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+You must survive 26 levels of enemies and curses and collect as much treasure as you can along the way.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=122).
 
 ## Actions
 

--- a/docs/environments/atari/donkey_kong.md
+++ b/docs/environments/atari/donkey_kong.md
@@ -21,7 +21,9 @@ For more DonkeyKong variants with different observation and action spaces, see t
 
 ## Description
 
-DonkeyKong is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+You play as Mario trying to save your girlfriend who has been kidnapped by Donkey Kong. Remove rivets and jump over fireballs, with a score that starts high and counts down throughout the game.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=149).
 
 ## Actions
 

--- a/docs/environments/atari/earthworld.md
+++ b/docs/environments/atari/earthworld.md
@@ -21,7 +21,9 @@ For more Earthworld variants with different observation and action spaces, see t
 
 ## Description
 
-Earthworld is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+A quest to find the sword of Ultimate Sorcery. You must navigate through 12 zodiac-themed rooms in order to solve a puzzle.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=541).
 
 ## Actions
 

--- a/docs/environments/atari/elevator_action.md
+++ b/docs/environments/atari/elevator_action.md
@@ -23,7 +23,7 @@ For more ElevatorAction variants with different observation and action spaces, s
 
 You are a secret agent that must retrieve some secret documents and reach the ground level of a building by going down an elevator/stairs. Once you reach the ground level, you are picked up and taken to the next level. You are equipped with a gun to defend yourself against enemy agents waiting for you in each floor. You gather points by shooting down enemy agents and visiting apartments marked with a red door, which contain the secret documents.This is an unreleased prototype based on the arcade game.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=1131)
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=1131)
 
 ## Actions
 

--- a/docs/environments/atari/entombed.md
+++ b/docs/environments/atari/entombed.md
@@ -21,7 +21,9 @@ For more Entombed variants with different observation and action spaces, see the
 
 ## Description
 
-Entombed is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+You and your team of archeologists must navigate a maze filled with zombies.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=165).
 
 ## Actions
 

--- a/docs/environments/atari/et.md
+++ b/docs/environments/atari/et.md
@@ -17,11 +17,13 @@ This environment is part of the <a href='..'>Atari environments</a>. Please read
 | Observation Space | Box(0, 255, (210, 160, 3), uint8) |
 | Import | `gymnasium.make("ALE/Et-v5")` |
 
-For more Et variants with different observation and action spaces, see the variants section.
+For more E.T. variants with different observation and action spaces, see the variants section.
 
 ## Description
 
-Et is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Help E.T. (the extra-terrestrial) get home! He has to collect pieces of a telephone, call his ship, and get to the landing pad.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=157).
 
 ## Actions
 

--- a/docs/environments/atari/fishing_derby.md
+++ b/docs/environments/atari/fishing_derby.md
@@ -21,7 +21,7 @@ For more FishingDerby variants with different observation and action spaces, see
 
 ## Description
 
-your objective is to catch more sunfish than your opponent.
+Your objective is to catch more sunfish than your opponent.
 
 For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=182)
 

--- a/docs/environments/atari/flag_capture.md
+++ b/docs/environments/atari/flag_capture.md
@@ -21,7 +21,9 @@ For more FlagCapture variants with different observation and action spaces, see 
 
 ## Description
 
-FlagCapture is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+You are an explorer navigating from square to square, collecting clues, and looking for a flag.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=183).
 
 ## Actions
 

--- a/docs/environments/atari/freeway.md
+++ b/docs/environments/atari/freeway.md
@@ -21,9 +21,9 @@ For more Freeway variants with different observation and action spaces, see the 
 
 ## Description
 
-your objective is to guide your chicken across lane after lane of busy rush hour traffic. You receive a point for every chicken that makes it to the top of the screen after crossing all the lanes of traffic.
+Your objective is to guide your chicken across lane after lane of busy rush hour traffic. You receive a point for every chicken that makes it to the top of the screen after crossing all the lanes of traffic.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=192)
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=192)
 
 ## Actions
 
@@ -48,7 +48,7 @@ See variants section for the type of observation used by each environment id by 
 ### Rewards
 
 The exact reward dynamics depend on the environment and are usually documented in the game's manual. You can
-find these manuals on [AtariAge](https://atariage.com/manual_thumbs.php?SoftwareLabelID=192).
+find these manuals on [AtariAge](https://atariage.com/manual_html_page.php?SoftwareLabelID=192).
 
 Atari environments are simulated via the Arcade Learning Environment (ALE) [[1]](#1).
 

--- a/docs/environments/atari/frogger.md
+++ b/docs/environments/atari/frogger.md
@@ -21,7 +21,9 @@ For more Frogger variants with different observation and action spaces, see the 
 
 ## Description
 
-Frogger is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+You are a frog trying to make their way home. Cross a highway and a perilous river without being crushed or eaten.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=194).
 
 ## Actions
 

--- a/docs/environments/atari/galaxian.md
+++ b/docs/environments/atari/galaxian.md
@@ -21,7 +21,9 @@ For more Galaxian variants with different observation and action spaces, see the
 
 ## Description
 
-Galaxian is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Protect your laser base from a Galaxian invasion. Defeat each wave by firing lasers at the attackers.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=202).
 
 ## Actions
 

--- a/docs/environments/atari/hangman.md
+++ b/docs/environments/atari/hangman.md
@@ -21,7 +21,9 @@ For more Hangman variants with different observation and action spaces, see the 
 
 ## Description
 
-Hangman is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Guess the hidden word one letter at a time, and don't make too many incorrect guesses or you will lose. Word difficulty increases as you traverse through the games.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=231).
 
 ## Actions
 

--- a/docs/environments/atari/haunted_house.md
+++ b/docs/environments/atari/haunted_house.md
@@ -21,7 +21,9 @@ For more HauntedHouse variants with different observation and action spaces, see
 
 ## Description
 
-HauntedHouse is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Explore a mansion haunted by the ghost of mean, old Samuel Graves. Your goal is to find three pieces of a magic urn and leave the mansion before losing your 9 lives.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=233).
 
 ## Actions
 

--- a/docs/environments/atari/human_cannonball.md
+++ b/docs/environments/atari/human_cannonball.md
@@ -21,7 +21,9 @@ For more HumanCannonball variants with different observation and action spaces, 
 
 ## Description
 
-HumanCannonball is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Shoot a person out of a cannonball and try to get them into the water tower.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=238).
 
 ## Actions
 

--- a/docs/environments/atari/kaboom.md
+++ b/docs/environments/atari/kaboom.md
@@ -21,7 +21,9 @@ For more Kaboom variants with different observation and action spaces, see the v
 
 ## Description
 
-Kaboom is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+A mad bomber is dropping bombs! Try to catch each of them in a bucket of water before they hit the ground.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=257).
 
 ## Actions
 

--- a/docs/environments/atari/keystone_kapers.md
+++ b/docs/environments/atari/keystone_kapers.md
@@ -21,7 +21,9 @@ For more KeystoneKapers variants with different observation and action spaces, s
 
 ## Description
 
-KeystoneKapers is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+You are a police officer (or 'Kop') trying to catch a 'Krook' as quickly as you can.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=261).
 
 ## Actions
 

--- a/docs/environments/atari/king_kong.md
+++ b/docs/environments/atari/king_kong.md
@@ -21,7 +21,9 @@ For more KingKong variants with different observation and action spaces, see the
 
 ## Description
 
-KingKong is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Climb the Empire State Building to save the person that King Kong kidnapped and placed there. Beware the bombs that King Kong throws at you as you climb!
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=265).
 
 ## Actions
 

--- a/docs/environments/atari/klax.md
+++ b/docs/environments/atari/klax.md
@@ -21,7 +21,9 @@ For more Klax variants with different observation and action spaces, see the var
 
 ## Description
 
-Klax is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Flip tumbling tiles into bins to create rows of three or more matching-colored tiles (such a row is called a Klax).
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=1130).
 
 ## Actions
 

--- a/docs/environments/atari/koolaid.md
+++ b/docs/environments/atari/koolaid.md
@@ -21,7 +21,9 @@ For more Koolaid variants with different observation and action spaces, see the 
 
 ## Description
 
-Koolaid is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+You are the Kool-Aid Man and you are trying to stop Thirsties from drinking your pool water by running into them.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=266).
 
 ## Actions
 

--- a/docs/environments/atari/kung_fu_master.md
+++ b/docs/environments/atari/kung_fu_master.md
@@ -23,7 +23,7 @@ For more KungFuMaster variants with different observation and action spaces, see
 
 You are a Kung-Fu Master fighting your way through the Evil Wizard's temple. Your goal is to rescue Princess Victoria, defeating various enemies along the way.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=268)
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=268)
 
 ## Actions
 

--- a/docs/environments/atari/laser_gates.md
+++ b/docs/environments/atari/laser_gates.md
@@ -21,7 +21,9 @@ For more LaserGates variants with different observation and action spaces, see t
 
 ## Description
 
-LaserGates is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+The Cryptic Computer is malfunctioning! Use your Dante Dart to navigate through the computer and deestroy the four Failsafe Detonators.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=271).
 
 ## Actions
 

--- a/docs/environments/atari/lost_luggage.md
+++ b/docs/environments/atari/lost_luggage.md
@@ -21,7 +21,9 @@ For more LostLuggage variants with different observation and action spaces, see 
 
 ## Description
 
-LostLuggage is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Catch falling luggage before it spills open on the ground.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=276).
 
 ## Actions
 

--- a/docs/environments/atari/mario_bros.md
+++ b/docs/environments/atari/mario_bros.md
@@ -21,7 +21,9 @@ For more MarioBros variants with different observation and action spaces, see th
 
 ## Description
 
-MarioBros is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Help Mario and Luigi knock pipe pests into a puddle of water.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=286).
 
 ## Actions
 

--- a/docs/environments/atari/miniature_golf.md
+++ b/docs/environments/atari/miniature_golf.md
@@ -21,7 +21,9 @@ For more MiniatureGolf variants with different observation and action spaces, se
 
 ## Description
 
-MiniatureGolf is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Hit a golf ball as few times as possible in order to get it into the hole, avoiding obstacles.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=305).
 
 ## Actions
 

--- a/docs/environments/atari/mr_do.md
+++ b/docs/environments/atari/mr_do.md
@@ -21,7 +21,9 @@ For more MrDo variants with different observation and action spaces, see the var
 
 ## Description
 
-MrDo is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Help Mr. Do harvest apples before the bad guys get to him.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=318).
 
 ## Actions
 

--- a/docs/environments/atari/othello.md
+++ b/docs/environments/atari/othello.md
@@ -21,7 +21,9 @@ For more Othello variants with different observation and action spaces, see the 
 
 ## Description
 
-Othello is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Take turns placing tiles of your color (white or black) on a grid. You can surround an opponents tiles to change their color to yours. The goals is to end the game with the most tiles of your color on the board.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=335).
 
 ## Actions
 

--- a/docs/environments/atari/pacman.md
+++ b/docs/environments/atari/pacman.md
@@ -21,7 +21,7 @@ For more Pacman variants with different observation and action spaces, see the v
 
 ## Description
 
-Pacman is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+A classic arcade game. Move Pac Man around a maze collecting food and avoiding ghosts- unless you eat a Power Pellet, then you can eat the ghosts too!
 
 ## Actions
 

--- a/docs/environments/atari/phoenix.md
+++ b/docs/environments/atari/phoenix.md
@@ -23,7 +23,7 @@ For more Phoenix variants with different observation and action spaces, see the 
 
 Your goal is to reach and shoot the alien pilot. On your way there, you must eliminate waves of war birds while avoiding their bombs.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=355)
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=355)
 
 ## Actions
 

--- a/docs/environments/atari/pitfall2.md
+++ b/docs/environments/atari/pitfall2.md
@@ -21,7 +21,9 @@ For more Pitfall2 variants with different observation and action spaces, see the
 
 ## Description
 
-Pitfall2 is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Navigate Peruvian caves searching for niece Rhonda and cat Quicklaw as well as the lost Raj diamond.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=359).
 
 ## Actions
 

--- a/docs/environments/atari/sir_lancelot.md
+++ b/docs/environments/atari/sir_lancelot.md
@@ -21,7 +21,9 @@ For more SirLancelot variants with different observation and action spaces, see 
 
 ## Description
 
-SirLancelot is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+You control Sir Lancelot, riding atop Pegasus, and your goal is to save a prisoner locked in a castle and protected by a fire-breathing dragon.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=431).
 
 ## Actions
 

--- a/docs/environments/atari/space_war.md
+++ b/docs/environments/atari/space_war.md
@@ -21,7 +21,9 @@ For more SpaceWar variants with different observation and action spaces, see the
 
 ## Description
 
-SpaceWar is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Use your Star Ship to compete in a sequence of games wher eyou try to shoot your opponent as many times as possible without being hit yourself.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=470).
 
 ## Actions
 

--- a/docs/environments/atari/superman.md
+++ b/docs/environments/atari/superman.md
@@ -21,7 +21,9 @@ For more Superman variants with different observation and action spaces, see the
 
 ## Description
 
-Superman is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Play as Superman trying to capture Lex Luther and avoid the kryptonite satellites along the way.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=533).
 
 ## Actions
 

--- a/docs/environments/atari/surround.md
+++ b/docs/environments/atari/surround.md
@@ -21,7 +21,9 @@ For more Surround variants with different observation and action spaces, see the
 
 ## Description
 
-Surround is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Surround your opponent without running into anything yourself.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=537).
 
 ## Actions
 

--- a/docs/environments/atari/tetris.md
+++ b/docs/environments/atari/tetris.md
@@ -21,7 +21,7 @@ For more Tetris variants with different observation and action spaces, see the v
 
 ## Description
 
-Tetris is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Direct falling tile-based shapes to try and perfectly fill the board without leaving empty space.
 
 ## Actions
 

--- a/docs/environments/atari/tic_tac_toe_3d.md
+++ b/docs/environments/atari/tic_tac_toe_3d.md
@@ -21,7 +21,9 @@ For more TicTacToe3D variants with different observation and action spaces, see 
 
 ## Description
 
-TicTacToe3D is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Players take turns placing their mark (an X or an O) on a 3-dimensional, 4 x 4 x 4 grid in an attempt to get 4 in a row before their opponent does.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=521).
 
 ## Actions
 

--- a/docs/environments/atari/trondead.md
+++ b/docs/environments/atari/trondead.md
@@ -21,7 +21,9 @@ For more Trondead variants with different observation and action spaces, see the
 
 ## Description
 
-Trondead is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Use your deadly saucer to knock out encroaching opponents before they get to you.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=569).
 
 ## Actions
 

--- a/docs/environments/atari/turmoil.md
+++ b/docs/environments/atari/turmoil.md
@@ -21,7 +21,9 @@ For more Turmoil variants with different observation and action spaces, see the 
 
 ## Description
 
-Turmoil is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Blast aliens while avoiding deadly collisions.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=571).
 
 ## Actions
 

--- a/docs/environments/atari/tutankham.md
+++ b/docs/environments/atari/tutankham.md
@@ -23,7 +23,7 @@ For more Tutankham variants with different observation and action spaces, see th
 
 Your goal is to rack up points by finding treasures in the mazes of the tomb while eliminating its guardians.
 
-For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_thumbs.php?SoftwareLabelID=572)
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=572)
 
 ## Actions
 

--- a/docs/environments/atari/video_checkers.md
+++ b/docs/environments/atari/video_checkers.md
@@ -21,7 +21,9 @@ For more VideoCheckers variants with different observation and action spaces, se
 
 ## Description
 
-VideoCheckers is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Classic checkers: move your color pieces towards the opposite end of the board, jumping over opponents pieces to remove them from the board and gaining a king when you reach the other side.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=579).
 
 ## Actions
 

--- a/docs/environments/atari/video_chess.md
+++ b/docs/environments/atari/video_chess.md
@@ -21,7 +21,9 @@ For more VideoChess variants with different observation and action spaces, see t
 
 ## Description
 
-VideoChess is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+This is the usual game of chess: capture the opponents king.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=581).
 
 ## Actions
 

--- a/docs/environments/atari/video_cube.md
+++ b/docs/environments/atari/video_cube.md
@@ -21,7 +21,9 @@ For more VideoCube variants with different observation and action spaces, see th
 
 ## Description
 
-VideoCube is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Solve a Rubik's cube in a nonstandard way: guide Hubie around the cube and swap tiles on the cubes face with one another until each face consists of only one color.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=974).
 
 ## Actions
 

--- a/docs/environments/atari/word_zapper.md
+++ b/docs/environments/atari/word_zapper.md
@@ -21,7 +21,9 @@ For more WordZapper variants with different observation and action spaces, see t
 
 ## Description
 
-WordZapper is missing description documentation. If you are interested in writing up a description, please create an issue or PR with the information on the Gymnasium github.
+Shoot letters under time pressure in the prescribed order as they scroll across the screen.
+
+For a more detailed documentation, see [the AtariAge page](https://atariage.com/manual_html_page.php?SoftwareLabelID=599).
 
 ## Actions
 


### PR DESCRIPTION
# Description

Added minimal description and link to Atari Age manual page for all Atari games with a missing description. Also made all links to Atari Age manuals go to the HTML version of the manual rather than the thumbnails of the physical manual to improve readability. 

Note: There were a few games that did not have an Atari Age manual at all (like Pac Man), so these do not have a link.

As requested in the docs contributing guidelines for Atari game descriptions, I have edited the Markdown files directly.

## Type of change

- [x] This change requires a documentation update.
