### PR TITLE
Update record_video.py

### DIFF
--- a/gymnasium/wrappers/record_video.py
+++ b/gymnasium/wrappers/record_video.py
@@ -108,7 +108,7 @@ class RecordVideo(gym.Wrapper, gym.utils.RecordConstructorArgs):
         self.truncated = False
         if self.recording:
             assert self.video_recorder is not None
-            self.video_recorder.frames = []
+            self.video_recorder.recorded_frames = []
             self.video_recorder.capture_frame()
             self.recorded_frames += 1
             if self.video_length > 0:


### PR DESCRIPTION
# Description

Changed self.video_recorder.frames to self.video_recorder.recorded_frames in the reset() method; video_recorder.VideoRecorder() actually doesn't have a frames attribute, only a recorded_frames attribute. This should fix a bug with video recording where the video shows a frame from the previous rollout.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots
Before:
![image](https://github.com/Farama-Foundation/Gymnasium/assets/60494418/32723185-373b-4349-a28b-dd288346484e)

After:
![image](https://github.com/Farama-Foundation/Gymnasium/assets/60494418/ff11430b-9ef3-404c-8eed-67f8226e0cbd)

VideoRecorder class from gymnasium.wrappers.monitoring.video_recorder.py:
![image](https://github.com/Farama-Foundation/Gymnasium/assets/60494418/ca5df4e4-1197-4c18-bc97-c5041af792a8)




