### PR TITLE
Fix comments for correct rendering of warnings

### DIFF
--- a/gymnasium/experimental/vector/async_vector_env.py
+++ b/gymnasium/experimental/vector/async_vector_env.py
@@ -84,7 +84,7 @@ class AsyncVectorEnv(VectorEnv):
             worker: If set, then use that worker in a subprocess instead of a default one.
                 Can be useful to override some inner vector env logic, for instance, how resets on termination or truncation are handled.
 
-        Warnings: 
+        Warnings:
             worker is an advanced mode option. It provides a high degree of flexibility and a high chance
             to shoot yourself in the foot; thus, if you are writing your own worker, it is recommended to start
             from the code for ``_worker`` (or ``_worker_shared_memory``) method, and add changes.

--- a/gymnasium/experimental/vector/async_vector_env.py
+++ b/gymnasium/experimental/vector/async_vector_env.py
@@ -84,7 +84,8 @@ class AsyncVectorEnv(VectorEnv):
             worker: If set, then use that worker in a subprocess instead of a default one.
                 Can be useful to override some inner vector env logic, for instance, how resets on termination or truncation are handled.
 
-        Warnings: worker is an advanced mode option. It provides a high degree of flexibility and a high chance
+        Warnings: 
+            worker is an advanced mode option. It provides a high degree of flexibility and a high chance
             to shoot yourself in the foot; thus, if you are writing your own worker, it is recommended to start
             from the code for ``_worker`` (or ``_worker_shared_memory``) method, and add changes.
 

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -87,7 +87,7 @@ class AsyncVectorEnv(VectorEnv):
             worker: If set, then use that worker in a subprocess instead of a default one.
                 Can be useful to override some inner vector env logic, for instance, how resets on termination or truncation are handled.
 
-        Warnings: 
+        Warnings:
             worker is an advanced mode option. It provides a high degree of flexibility and a high chance
             to shoot yourself in the foot; thus, if you are writing your own worker, it is recommended to start
             from the code for ``_worker`` (or ``_worker_shared_memory``) method, and add changes.

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -87,7 +87,8 @@ class AsyncVectorEnv(VectorEnv):
             worker: If set, then use that worker in a subprocess instead of a default one.
                 Can be useful to override some inner vector env logic, for instance, how resets on termination or truncation are handled.
 
-        Warnings: worker is an advanced mode option. It provides a high degree of flexibility and a high chance
+        Warnings: 
+            worker is an advanced mode option. It provides a high degree of flexibility and a high chance
             to shoot yourself in the foot; thus, if you are writing your own worker, it is recommended to start
             from the code for ``_worker`` (or ``_worker_shared_memory``) method, and add changes.
 

--- a/gymnasium/wrappers/autoreset.py
+++ b/gymnasium/wrappers/autoreset.py
@@ -26,7 +26,8 @@ class AutoResetWrapper(gym.Wrapper, gym.utils.RecordConstructorArgs):
        with an additional key "final_observation" containing the observation returned by the last call to :meth:`self.env.step`
        and "final_info" containing the info dict returned by the last call to :meth:`self.env.step`.
 
-    Warning: When using this wrapper to collect rollouts, note that when :meth:`Env.step` returns `terminated` or `truncated`, a
+    Warning: 
+        When using this wrapper to collect rollouts, note that when :meth:`Env.step` returns `terminated` or `truncated`, a
         new observation from after calling :meth:`Env.reset` is returned by :meth:`Env.step` alongside the
         final reward, terminated and truncated state from the previous episode.
         If you need the final state from the previous episode, you need to retrieve it via the

--- a/gymnasium/wrappers/autoreset.py
+++ b/gymnasium/wrappers/autoreset.py
@@ -26,7 +26,7 @@ class AutoResetWrapper(gym.Wrapper, gym.utils.RecordConstructorArgs):
        with an additional key "final_observation" containing the observation returned by the last call to :meth:`self.env.step`
        and "final_info" containing the info dict returned by the last call to :meth:`self.env.step`.
 
-    Warning: 
+    Warning:
         When using this wrapper to collect rollouts, note that when :meth:`Env.step` returns `terminated` or `truncated`, a
         new observation from after calling :meth:`Env.reset` is returned by :meth:`Env.step` alongside the
         final reward, terminated and truncated state from the previous episode.


### PR DESCRIPTION
# Description

The warning in the function's documentation was not rendering properly, so I fixed it.

### Screenshots

[AutoResetWrapper](https://gymnasium.farama.org/api/wrappers/misc_wrappers/#gymnasium.wrappers.AutoResetWrapper)

| Before | After |
| ------ | ----- |
| ![스크린샷 2023-05-25 02-44-32](https://github.com/Farama-Foundation/Gymnasium/assets/54899900/973d0fb1-ad89-423c-b7de-13c13d50346e) | ![스크린샷 2023-05-25 02-44-21](https://github.com/Farama-Foundation/Gymnasium/assets/54899900/ce3233a5-6e4a-4298-a4b7-db5140105232) |

[gymnasium.vector.AsyncVectorEnv](https://gymnasium.farama.org/api/vector/#gymnasium.vector.AsyncVectorEnv)
[gymnasium-experimental-vector-asyncvectorenv](https://gymnasium.farama.org/api/experimental/vector/#gymnasium-experimental-vector-asyncvectorenv)


| Before | After |
| ------ | ----- |
| ![스크린샷 2023-05-25 02-44-32](https://github.com/Farama-Foundation/Gymnasium/assets/54899900/6a1dd92c-a890-4c53-8539-e355f030d8e5) | ![스크린샷 2023-05-25 02-44-21](https://github.com/Farama-Foundation/Gymnasium/assets/54899900/35356cc4-233c-464e-a88c-a4096c238e3f) |
