### PR TITLE
Add docstring to `MujocoEnv.__init__()`

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -41,17 +41,17 @@ class BaseMujocoEnv(gym.Env):
         camera_name: Optional[str] = None,
     ):
         """Base abstract class for mujoco based environments.
-        
+
         Args:
             model_path: Path to the MuJoCo Model.
             frame_skip: Number of mujoco simulation steps per gym `step()`.
             observation_space: The observation space of the environment.
             render_mode: The `render_mode` used.
-            widht: The width of the render window.
+            width: The width of the render window.
             height: The height of the render window.
             camera_id: The Default camera used.
             camera_name: The name for the default camera.
-            
+
         Raises:
             OSError: when the `model_path` does not exist.
             error.DependencyNotInstalled: When `mujoco` is not installed.

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -40,6 +40,22 @@ class BaseMujocoEnv(gym.Env):
         camera_id: Optional[int] = None,
         camera_name: Optional[str] = None,
     ):
+        """Base abstract class for mujoco based environments.
+        
+        Args:
+            model_path: Path to the MuJoCo Model.
+            frame_skip: Number of mujoco simulation steps per gym `step()`.
+            observation_space: The observation space of the environment.
+            render_mode: The `render_mode` used.
+            widht: The width of the render window.
+            height: The height of the render window.
+            camera_id: The Default camera used.
+            camera_name: The name for the default camera.
+            
+        Raises:
+            OSError: when the `model_path` does not exist.
+            error.DependencyNotInstalled: When `mujoco` is not installed.
+        """
         if model_path.startswith("/"):
             self.fullpath = model_path
         else:


### PR DESCRIPTION
# Description

adds a docstring to the `init` of `MujocoEnv`, there has been plenty of confusion on what some arguments do such as `frame_skip` 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [X] Documentation change


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
