### PR TITLE
[MuJoCo] Add support for relative paths with `xml_file` arguments

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -56,8 +56,10 @@ class BaseMujocoEnv(gym.Env):
             OSError: when the `model_path` does not exist.
             error.DependencyNotInstalled: When `mujoco` is not installed.
         """
-        if model_path.startswith("/"):
+        if model_path.startswith(".") or model_path.startswith("/"):
             self.fullpath = model_path
+        elif model_path.startswith("~"):
+            self.fullpath = path.expanduser(model_path)
         else:
             self.fullpath = path.join(path.dirname(__file__), "assets", model_path)
         if not path.exists(self.fullpath):


### PR DESCRIPTION
# Description

Manual testing
```py
>>> import gymnasium
>>> env = gymnasium.make('Humanoid-v5', xml_file="~/op3-scene.xml")
>>> env = gymnasium.make('Humanoid-v5', xml_file="./op3-scene.xml")
```

Fixes # (issue)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [DNA] I have commented my code, particularly in hard-to-understand areas
- [DNA] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes