### PR TITLE
[MuJoCo] add the abiltiy for `MujocoEnv.reset()` to return `info`

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -132,6 +132,9 @@ class BaseMujocoEnv(gym.Env):
         raise NotImplementedError
 
     # -----------------------------
+    def _get_reset_info(self) -> Dict:
+        """Function that generates the `info` that is returned during a `reset()`."""
+        return {}
 
     def reset(
         self,
@@ -144,9 +147,12 @@ class BaseMujocoEnv(gym.Env):
         self._reset_simulation()
 
         ob = self.reset_model()
+        info = self._get_reset_info()
+
         if self.render_mode == "human":
             self.render()
-        return ob, {}
+        return ob, info
+
 
     def set_state(self, qpos, qvel):
         """

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -153,7 +153,6 @@ class BaseMujocoEnv(gym.Env):
             self.render()
         return ob, info
 
-
     def set_state(self, qpos, qvel):
         """
         Set the joints position qpos and velocity qvel of the model. Override this method depending on the MuJoCo bindings used.

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -1,5 +1,5 @@
 from os import path
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import numpy as np
 

--- a/tests/envs/mujoco/test_mujoco_custom_env.py
+++ b/tests/envs/mujoco/test_mujoco_custom_env.py
@@ -79,7 +79,7 @@ class PointEnv(MujocoEnv, utils.EzPickle):
 
         return observation
 
-    def reset_info():
+    def _get_reset_info():
         return {"works": True}
 
 

--- a/tests/envs/mujoco/test_mujoco_custom_env.py
+++ b/tests/envs/mujoco/test_mujoco_custom_env.py
@@ -5,6 +5,7 @@ import warnings
 
 import numpy as np
 import pytest
+
 from gymnasium import utils
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.error import Error

--- a/tests/envs/mujoco/test_mujoco_custom_env.py
+++ b/tests/envs/mujoco/test_mujoco_custom_env.py
@@ -79,7 +79,7 @@ class PointEnv(MujocoEnv, utils.EzPickle):
 
         return observation
 
-    def _get_reset_info():
+    def _get_reset_info(self):
         return {"works": True}
 
 

--- a/tests/envs/mujoco/test_mujoco_custom_env.py
+++ b/tests/envs/mujoco/test_mujoco_custom_env.py
@@ -5,7 +5,6 @@ import warnings
 
 import numpy as np
 import pytest
-
 from gymnasium import utils
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.error import Error
@@ -80,6 +79,9 @@ class PointEnv(MujocoEnv, utils.EzPickle):
 
         return observation
 
+    def reset_info():
+        return {"works": True}
+
 
 CHECK_ENV_IGNORE_WARNINGS = [
     f"\x1b[33mWARN: {message}\x1b[0m"
@@ -116,3 +118,11 @@ def test_xml_file():
     assert env.unwrapped.data.qpos.size == 9
 
     # note can not test user home path (with '~') because github CI does not have a home folder
+
+
+def test_reset_info():
+    """Verify that the environment returns info at `reset()`"""
+    env = PointEnv()
+
+    _, info = env.reset()
+    assert info["works"]

--- a/tests/envs/mujoco/test_mujoco_custom_env.py
+++ b/tests/envs/mujoco/test_mujoco_custom_env.py
@@ -126,4 +126,4 @@ def test_reset_info():
     env = PointEnv()
 
     _, info = env.reset()
-    assert info["works"]
+    assert info["works"] is True


### PR DESCRIPTION
# Description
This adds the  `MujocoEnv._get_reset_info(self)`  which allows the MuJoCo based environments to return `info`

Fixes # (issue)

## Type of change

- [X] New feature (non-breaking change which adds functionality)



# Checklist:
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

