### PR TITLE
Remove jumpy due to its partial implementation

### DIFF
--- a/gymnasium/experimental/vector/vector_env.py
+++ b/gymnasium/experimental/vector/vector_env.py
@@ -299,11 +299,11 @@ class VectorWrapper(VectorEnv):
         """Step all environments."""
         return self.env.step(actions)
 
-    def close(self, **kwargs):
+    def close(self, **kwargs: Any):
         """Close all environments."""
         return self.env.close(**kwargs)
 
-    def close_extras(self, **kwargs):
+    def close_extras(self, **kwargs: Any):
         """Close all extra resources."""
         return self.env.close_extras(**kwargs)
 

--- a/gymnasium/experimental/wrappers/lambda_action.py
+++ b/gymnasium/experimental/wrappers/lambda_action.py
@@ -9,10 +9,6 @@ from __future__ import annotations
 from typing import Callable
 
 
-try:
-    import jumpy.numpy as jp
-except ImportError as e:
-    raise ImportError("Jumpy is not installed, run `pip install jax-jumpy`") from e
 import numpy as np
 
 import gymnasium as gym
@@ -83,7 +79,7 @@ class ClipActionV0(
         LambdaActionV0.__init__(
             self,
             env=env,
-            func=lambda action: jp.clip(
+            func=lambda action: np.clip(
                 action, env.action_space.low, env.action_space.high
             ),
             action_space=Box(

--- a/gymnasium/experimental/wrappers/lambda_observation.py
+++ b/gymnasium/experimental/wrappers/lambda_observation.py
@@ -16,10 +16,6 @@ from typing import Any, Callable, Sequence
 from typing_extensions import Final
 
 
-try:
-    import jumpy.numpy as jp
-except ImportError as e:
-    raise ImportError("Jumpy is not installed, run `pip install jax-jumpy`") from e
 import numpy as np
 
 import gymnasium as gym
@@ -273,9 +269,9 @@ class GrayscaleObservationV0(
             LambdaObservationV0.__init__(
                 self,
                 env=env,
-                func=lambda obs: jp.expand_dims(
-                    jp.sum(
-                        jp.multiply(obs, jp.array([0.2125, 0.7154, 0.0721])), axis=-1
+                func=lambda obs: np.expand_dims(
+                    np.sum(
+                        np.multiply(obs, np.array([0.2125, 0.7154, 0.0721])), axis=-1
                     ).astype(np.uint8),
                     axis=-1,
                 ),
@@ -288,8 +284,8 @@ class GrayscaleObservationV0(
             LambdaObservationV0.__init__(
                 self,
                 env=env,
-                func=lambda obs: jp.sum(
-                    jp.multiply(obs, jp.array([0.2125, 0.7154, 0.0721])), axis=-1
+                func=lambda obs: np.sum(
+                    np.multiply(obs, np.array([0.2125, 0.7154, 0.0721])), axis=-1
                 ).astype(np.uint8),
                 observation_space=new_observation_space,
             )
@@ -398,7 +394,7 @@ class ReshapeObservationV0(
         LambdaObservationV0.__init__(
             self,
             env=env,
-            func=lambda obs: jp.reshape(obs, shape),
+            func=lambda obs: np.reshape(obs, shape),
             observation_space=new_observation_space,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 ]
 dependencies = [
     "numpy >=1.21.0",
-    "jax-jumpy>=1.0.0",
     "cloudpickle >=1.2.0",
     "importlib-metadata >=4.8.0; python_version < '3.10'",
     "typing-extensions >=4.3.0",


### PR DESCRIPTION
Jumpy was added due to the belief that Jax-based environment were going to replace a number of current environment implementations.
However, due to several factors, this has not happened. 
Therefore, this PR removes Jumpy from the project in order that when jax-based environment are properly added, then Jumpy can be properly added and tested