### PR TITLE
Add imports for `wrappers/__init__.py` and `wrappers/vector/__init__.py` for certain wrappers 

### DIFF
--- a/gymnasium/experimental/wrappers/__init__.py
+++ b/gymnasium/experimental/wrappers/__init__.py
@@ -4,6 +4,47 @@ import importlib
 import re
 
 from gymnasium.error import DeprecatedWrapper
+from gymnasium.experimental.wrappers import vector
+from gymnasium.experimental.wrappers.atari_preprocessing import AtariPreprocessingV0
+from gymnasium.experimental.wrappers.common import (
+    AutoresetV0,
+    OrderEnforcingV0,
+    PassiveEnvCheckerV0,
+    RecordEpisodeStatisticsV0,
+)
+from gymnasium.experimental.wrappers.lambda_action import (
+    ClipActionV0,
+    LambdaActionV0,
+    RescaleActionV0,
+)
+from gymnasium.experimental.wrappers.lambda_observation import (
+    DtypeObservationV0,
+    FilterObservationV0,
+    FlattenObservationV0,
+    GrayscaleObservationV0,
+    LambdaObservationV0,
+    PixelObservationV0,
+    RescaleObservationV0,
+    ReshapeObservationV0,
+    ResizeObservationV0,
+)
+from gymnasium.experimental.wrappers.lambda_reward import ClipRewardV0, LambdaRewardV0
+from gymnasium.experimental.wrappers.rendering import (
+    HumanRenderingV0,
+    RecordVideoV0,
+    RenderCollectionV0,
+)
+from gymnasium.experimental.wrappers.stateful_action import StickyActionV0
+from gymnasium.experimental.wrappers.stateful_observation import (
+    DelayObservationV0,
+    FrameStackObservationV0,
+    NormalizeObservationV0,
+    TimeAwareObservationV0,
+)
+from gymnasium.experimental.wrappers.stateful_reward import NormalizeRewardV1
+
+
+# Todo - Add legacy wrapper to new wrapper error for users when merged into gymnasium.wrappers
 
 
 __all__ = [
@@ -49,44 +90,9 @@ __all__ = [
 ]
 
 
+# As these wrappers requires `jax` or `torch`, they are loaded by runtime on users trying to access them
+#   to avoid `import jax` or `import torch` on `import gymnasium`.
 _wrapper_to_class = {
-    # lambda_action.py
-    "LambdaActionV0": "lambda_action",
-    "ClipActionV0": "lambda_action",
-    "RescaleActionV0": "lambda_action",
-    # lambda_observation.py
-    "LambdaObservationV0": "lambda_observation",
-    "FilterObservationV0": "lambda_observation",
-    "FlattenObservationV0": "lambda_observation",
-    "GrayscaleObservationV0": "lambda_observation",
-    "ResizeObservationV0": "lambda_observation",
-    "ReshapeObservationV0": "lambda_observation",
-    "RescaleObservationV0": "lambda_observation",
-    "DtypeObservationV0": "lambda_observation",
-    "PixelObservationV0": "lambda_observation",
-    # lambda_reward.py
-    "ClipRewardV0": "lambda_reward",
-    "LambdaRewardV0": "lambda_reward",
-    # stateful_action
-    "StickyActionV0": "stateful_action",
-    # stateful_observation
-    "TimeAwareObservationV0": "stateful_observation",
-    "DelayObservationV0": "stateful_observation",
-    "FrameStackObservationV0": "stateful_observation",
-    "NormalizeObservationV0": "stateful_observation",
-    # stateful_reward
-    "NormalizeRewardV1": "stateful_reward",
-    # atari_preprocessing
-    "AtariPreprocessingV0": "atari_preprocessing",
-    # common
-    "PassiveEnvCheckerV0": "common",
-    "OrderEnforcingV0": "common",
-    "AutoresetV0": "common",
-    "RecordEpisodeStatisticsV0": "common",
-    # rendering
-    "RenderCollectionV0": "rendering",
-    "RecordVideoV0": "rendering",
-    "HumanRenderingV0": "rendering",
     # data converters
     "JaxToNumpyV0": "jax_to_numpy",
     "JaxToTorchV0": "jax_to_torch",
@@ -110,10 +116,8 @@ def __getattr__(wrapper_name: str):
         AttributeError: If the wrapper does not exist.
         DeprecatedWrapper: If the version is not the latest.
     """
-    if wrapper_name == "vector":
-        return importlib.import_module("gymnasium.experimental.wrappers.vector")
     # Check if the requested wrapper is in the _wrapper_to_class dictionary
-    elif wrapper_name in _wrapper_to_class:
+    if wrapper_name in _wrapper_to_class:
         import_stmt = (
             f"gymnasium.experimental.wrappers.{_wrapper_to_class[wrapper_name]}"
         )

--- a/gymnasium/experimental/wrappers/atari_preprocessing.py
+++ b/gymnasium/experimental/wrappers/atari_preprocessing.py
@@ -13,6 +13,9 @@ except ImportError:
     )
 
 
+__all__ = ["AtariPreprocessingV0"]
+
+
 class AtariPreprocessingV0(gym.Wrapper, gym.utils.RecordConstructorArgs):
     """Atari 2600 preprocessing wrapper.
 

--- a/gymnasium/experimental/wrappers/common.py
+++ b/gymnasium/experimental/wrappers/common.py
@@ -25,6 +25,14 @@ from gymnasium.utils.passive_env_checker import (
 )
 
 
+__all__ = [
+    "AutoresetV0",
+    "PassiveEnvCheckerV0",
+    "OrderEnforcingV0",
+    "RecordEpisodeStatisticsV0",
+]
+
+
 class AutoresetV0(
     gym.Wrapper[ObsType, ActType, ObsType, ActType], gym.utils.RecordConstructorArgs
 ):

--- a/gymnasium/experimental/wrappers/jax_to_numpy.py
+++ b/gymnasium/experimental/wrappers/jax_to_numpy.py
@@ -20,7 +20,7 @@ except ImportError:
         "Jax is not installed therefore cannot call `numpy_to_jax`, run `pip install gymnasium[jax]`"
     )
 
-__all__ = ["jax_to_numpy", "numpy_to_jax", "JaxToNumpyV0"]
+__all__ = ["JaxToNumpyV0", "jax_to_numpy", "numpy_to_jax"]
 
 
 @functools.singledispatch

--- a/gymnasium/experimental/wrappers/lambda_action.py
+++ b/gymnasium/experimental/wrappers/lambda_action.py
@@ -20,6 +20,9 @@ from gymnasium.core import ActType, ObsType, WrapperActType
 from gymnasium.spaces import Box, Space
 
 
+__all__ = ["LambdaActionV0", "ClipActionV0", "RescaleActionV0"]
+
+
 class LambdaActionV0(
     gym.ActionWrapper[ObsType, WrapperActType, ActType], gym.utils.RecordConstructorArgs
 ):

--- a/gymnasium/experimental/wrappers/lambda_observation.py
+++ b/gymnasium/experimental/wrappers/lambda_observation.py
@@ -28,6 +28,19 @@ from gymnasium.core import ActType, ObsType, WrapperObsType
 from gymnasium.error import DependencyNotInstalled
 
 
+__all__ = [
+    "LambdaObservationV0",
+    "FilterObservationV0",
+    "FlattenObservationV0",
+    "GrayscaleObservationV0",
+    "ResizeObservationV0",
+    "ReshapeObservationV0",
+    "RescaleObservationV0",
+    "DtypeObservationV0",
+    "PixelObservationV0",
+]
+
+
 class LambdaObservationV0(
     gym.ObservationWrapper[WrapperObsType, ActType, ObsType],
     gym.utils.RecordConstructorArgs,

--- a/gymnasium/experimental/wrappers/lambda_reward.py
+++ b/gymnasium/experimental/wrappers/lambda_reward.py
@@ -14,6 +14,9 @@ from gymnasium.core import ActType, ObsType
 from gymnasium.error import InvalidBound
 
 
+__all__ = ["LambdaRewardV0", "ClipRewardV0"]
+
+
 class LambdaRewardV0(
     gym.RewardWrapper[ObsType, ActType], gym.utils.RecordConstructorArgs
 ):

--- a/gymnasium/experimental/wrappers/numpy_to_torch.py
+++ b/gymnasium/experimental/wrappers/numpy_to_torch.py
@@ -23,7 +23,7 @@ except ImportError:
     )
 
 
-__all__ = ["torch_to_numpy", "numpy_to_torch", "NumpyToTorchV0"]
+__all__ = ["NumpyToTorchV0", "torch_to_numpy", "numpy_to_torch"]
 
 
 @functools.singledispatch

--- a/gymnasium/experimental/wrappers/rendering.py
+++ b/gymnasium/experimental/wrappers/rendering.py
@@ -18,6 +18,9 @@ from gymnasium.core import ActType, ObsType, RenderFrame
 from gymnasium.error import DependencyNotInstalled
 
 
+__all__ = ["RenderCollectionV0", "RecordVideoV0", "HumanRenderingV0"]
+
+
 class RenderCollectionV0(
     gym.Wrapper[ObsType, ActType, ObsType, ActType], gym.utils.RecordConstructorArgs
 ):

--- a/gymnasium/experimental/wrappers/stateful_action.py
+++ b/gymnasium/experimental/wrappers/stateful_action.py
@@ -8,6 +8,9 @@ from gymnasium.core import ActType, ObsType
 from gymnasium.error import InvalidProbability
 
 
+__all__ = ["StickyActionV0"]
+
+
 class StickyActionV0(
     gym.ActionWrapper[ObsType, ActType, ActType], gym.utils.RecordConstructorArgs
 ):

--- a/gymnasium/experimental/wrappers/stateful_observation.py
+++ b/gymnasium/experimental/wrappers/stateful_observation.py
@@ -26,6 +26,14 @@ from gymnasium.experimental.wrappers.utils import RunningMeanStd, create_zero_ar
 from gymnasium.spaces import Box, Dict, Tuple
 
 
+__all__ = [
+    "DelayObservationV0",
+    "TimeAwareObservationV0",
+    "FrameStackObservationV0",
+    "NormalizeObservationV0",
+]
+
+
 class DelayObservationV0(
     gym.ObservationWrapper[ObsType, ActType, ObsType], gym.utils.RecordConstructorArgs
 ):

--- a/gymnasium/experimental/wrappers/stateful_reward.py
+++ b/gymnasium/experimental/wrappers/stateful_reward.py
@@ -13,6 +13,9 @@ from gymnasium.core import ActType, ObsType
 from gymnasium.experimental.wrappers.utils import RunningMeanStd
 
 
+__all__ = ["NormalizeRewardV1"]
+
+
 class NormalizeRewardV1(
     gym.Wrapper[ObsType, ActType, ObsType, ActType], gym.utils.RecordConstructorArgs
 ):

--- a/gymnasium/experimental/wrappers/utils.py
+++ b/gymnasium/experimental/wrappers/utils.py
@@ -21,6 +21,9 @@ from gymnasium.spaces import (
 from gymnasium.spaces.space import T_cov
 
 
+__all__ = ["RunningMeanStd", "update_mean_var_count_from_moments", "create_zero_array"]
+
+
 class RunningMeanStd:
     """Tracks the mean, variance and count of values."""
 

--- a/gymnasium/experimental/wrappers/vector/__init__.py
+++ b/gymnasium/experimental/wrappers/vector/__init__.py
@@ -1,36 +1,43 @@
 """Wrappers for vector environments."""
 # pyright: reportUnsupportedDunderAll=false
 import importlib
+import re
+
+from gymnasium.error import DeprecatedWrapper
+from gymnasium.experimental.wrappers.vector.dict_info_to_list import DictInfoToListV0
+from gymnasium.experimental.wrappers.vector.record_episode_statistics import (
+    RecordEpisodeStatisticsV0,
+)
 
 
 __all__ = [
     # --- Vector only wrappers
-    "VectoriseLambdaObservationV0",
-    "VectoriseLambdaActionV0",
-    "VectoriseLambdaRewardV0",
+    # "VectoriseLambdaObservationV0",
+    # "VectoriseLambdaActionV0",
+    # "VectoriseLambdaRewardV0",
     "DictInfoToListV0",
     # --- Observation wrappers ---
-    "LambdaObservationV0",
-    "FilterObservationV0",
-    "FlattenObservationV0",
-    "GrayscaleObservationV0",
-    "ResizeObservationV0",
-    "ReshapeObservationV0",
-    "RescaleObservationV0",
-    "DtypeObservationV0",
-    "PixelObservationV0",
-    "NormalizeObservationV0",
+    # "LambdaObservationV0",
+    # "FilterObservationV0",
+    # "FlattenObservationV0",
+    # "GrayscaleObservationV0",
+    # "ResizeObservationV0",
+    # "ReshapeObservationV0",
+    # "RescaleObservationV0",
+    # "DtypeObservationV0",
+    # "PixelObservationV0",
+    # "NormalizeObservationV0",
     # "TimeAwareObservationV0",
     # "FrameStackObservationV0",
     # "DelayObservationV0",
     # --- Action Wrappers ---
-    "LambdaActionV0",
-    "ClipActionV0",
-    "RescaleActionV0",
+    # "LambdaActionV0",
+    # "ClipActionV0",
+    # "RescaleActionV0",
     # --- Reward wrappers ---
-    "LambdaRewardV0",
-    "ClipRewardV0",
-    "NormalizeRewardV1",
+    # "LambdaRewardV0",
+    # "ClipRewardV0",
+    # "NormalizeRewardV1",
     # --- Common ---
     "RecordEpisodeStatisticsV0",
     # --- Rendering ---
@@ -42,3 +49,76 @@ __all__ = [
     "JaxToTorchV0",
     "NumpyToTorchV0",
 ]
+
+
+# As these wrappers requires `jax` or `torch`, they are loaded by runtime on users trying to access them
+#   to avoid `import jax` or `import torch` on `import gymnasium`.
+_wrapper_to_class = {
+    # data converters
+    "JaxToNumpyV0": "jax_to_numpy",
+    "JaxToTorchV0": "jax_to_torch",
+    "NumpyToTorchV0": "numpy_to_torch",
+}
+
+
+def __getattr__(wrapper_name: str):
+    """Load a wrapper by name.
+
+    This optimizes the loading of gymnasium wrappers by only loading the wrapper if it is used.
+    Errors will be raised if the wrapper does not exist or if the version is not the latest.
+
+    Args:
+        wrapper_name: The name of a wrapper to load.
+
+    Returns:
+        The specified wrapper.
+
+    Raises:
+        AttributeError: If the wrapper does not exist.
+        DeprecatedWrapper: If the version is not the latest.
+    """
+    # Check if the requested wrapper is in the _wrapper_to_class dictionary
+    if wrapper_name in _wrapper_to_class:
+        import_stmt = (
+            f"gymnasium.experimental.wrappers.vector.{_wrapper_to_class[wrapper_name]}"
+        )
+        module = importlib.import_module(import_stmt)
+        return getattr(module, wrapper_name)
+
+    # Define a regex pattern to match the integer suffix (version number) of the wrapper
+    int_suffix_pattern = r"(\d+)$"
+    version_match = re.search(int_suffix_pattern, wrapper_name)
+
+    # If a version number is found, extract it and the base wrapper name
+    if version_match:
+        version = int(version_match.group())
+        base_name = wrapper_name[: -len(version_match.group())]
+    else:
+        version = float("inf")
+        base_name = wrapper_name[:-2]
+
+    # Filter the list of all wrappers to include only those with the same base name
+    matching_wrappers = [name for name in __all__ if name.startswith(base_name)]
+
+    # If no matching wrappers are found, raise an AttributeError
+    if not matching_wrappers:
+        raise AttributeError(f"module {__name__!r} has no attribute {wrapper_name!r}")
+
+    # Find the latest version of the matching wrappers
+    latest_wrapper = max(
+        matching_wrappers, key=lambda s: int(re.findall(int_suffix_pattern, s)[0])
+    )
+    latest_version = int(re.findall(int_suffix_pattern, latest_wrapper)[0])
+
+    # If the requested wrapper is an older version, raise a DeprecatedWrapper exception
+    if version < latest_version:
+        raise DeprecatedWrapper(
+            f"{wrapper_name!r} is now deprecated, use {latest_wrapper!r} instead.\n"
+            f"To see the changes made, go to "
+            f"https://gymnasium.farama.org/api/experimental/vector-wrappers/#gymnasium.experimental.wrappers.vector.{latest_wrapper}"
+        )
+    # If the requested version is invalid, raise an AttributeError
+    else:
+        raise AttributeError(
+            f"module {__name__!r} has no attribute {wrapper_name!r}, did you mean {latest_wrapper!r}"
+        )

--- a/gymnasium/experimental/wrappers/vector/dict_info_to_list.py
+++ b/gymnasium/experimental/wrappers/vector/dict_info_to_list.py
@@ -7,6 +7,9 @@ from gymnasium.core import ActType, ObsType
 from gymnasium.experimental.vector.vector_env import ArrayType, VectorEnv, VectorWrapper
 
 
+__all__ = ["DictInfoToListV0"]
+
+
 class DictInfoToListV0(VectorWrapper):
     """Converts infos of vectorized environments from dict to List[dict].
 

--- a/gymnasium/experimental/wrappers/vector/jax_to_numpy.py
+++ b/gymnasium/experimental/wrappers/vector/jax_to_numpy.py
@@ -12,6 +12,9 @@ from gymnasium.experimental.vector.vector_env import ArrayType
 from gymnasium.experimental.wrappers.jax_to_numpy import jax_to_numpy, numpy_to_jax
 
 
+__all__ = ["JaxToNumpyV0"]
+
+
 class JaxToNumpyV0(VectorWrapper):
     """Wraps a jax vector environment so that it can be interacted with through numpy arrays.
 

--- a/gymnasium/experimental/wrappers/vector/jax_to_torch.py
+++ b/gymnasium/experimental/wrappers/vector/jax_to_torch.py
@@ -13,6 +13,9 @@ from gymnasium.experimental.wrappers.jax_to_torch import (
 )
 
 
+__all__ = ["JaxToTorchV0"]
+
+
 class JaxToTorchV0(VectorWrapper):
     """Wraps a Jax-based vector environment so that it can be interacted with through PyTorch Tensors.
 

--- a/gymnasium/experimental/wrappers/vector/numpy_to_torch.py
+++ b/gymnasium/experimental/wrappers/vector/numpy_to_torch.py
@@ -13,6 +13,9 @@ from gymnasium.experimental.wrappers.numpy_to_torch import (
 )
 
 
+__all__ = ["NumpyToTorchV0"]
+
+
 class NumpyToTorchV0(VectorWrapper):
     """Wraps a numpy-based environment so that it can be interacted with through PyTorch Tensors."""
 

--- a/gymnasium/experimental/wrappers/vector/record_episode_statistics.py
+++ b/gymnasium/experimental/wrappers/vector/record_episode_statistics.py
@@ -10,6 +10,9 @@ from gymnasium.core import ActType, ObsType
 from gymnasium.experimental.vector.vector_env import ArrayType, VectorEnv, VectorWrapper
 
 
+__all__ = ["RecordEpisodeStatisticsV0"]
+
+
 class RecordEpisodeStatisticsV0(VectorWrapper):
     """This wrapper will keep track of cumulative rewards and episode lengths.
 

--- a/tests/experimental/wrappers/test_resize_observation.py
+++ b/tests/experimental/wrappers/test_resize_observation.py
@@ -34,6 +34,7 @@ def test_resize_observation_wrapper(env):
     """Test the ``ResizeObservation`` that the observation has changed size."""
 
     wrapped_env = ResizeObservationV0(env, (25, 25))
+    assert isinstance(wrapped_env.observation_space, Box)
     assert wrapped_env.observation_space.shape[:2] == (25, 25)
 
     obs, info = wrapped_env.reset()


### PR DESCRIPTION
Due to `JaxToTorch` and other data conversion wrappers, we looked loading wrapper programmatically on import.
However, this is annoying to work with using IDE as they don't run the import loading code to point you at the correct file.
Additionally with removing Jumpy in #548 then we should be able to load all wrappers like normal in `__init__.py` except for the data conversion wrappers.

The programmatic code is kept as it will raise a helpful error if users use the old version of a wrapper.