### PR TITLE
Move `import moviepy` such that `__del__` doesn't raise AttributeErrors

### DIFF
--- a/gymnasium/experimental/wrappers/rendering.py
+++ b/gymnasium/experimental/wrappers/rendering.py
@@ -138,13 +138,6 @@ class RecordVideoV0(
         )
         gym.Wrapper.__init__(self, env)
 
-        try:
-            import moviepy  # noqa: F401
-        except ImportError as e:
-            raise error.DependencyNotInstalled(
-                "MoviePy is not installed, run `pip install moviepy`"
-            ) from e
-
         if env.render_mode in {None, "human", "ansi"}:
             raise ValueError(
                 f"Render mode is {env.render_mode}, which is incompatible with RecordVideo.",
@@ -185,6 +178,13 @@ class RecordVideoV0(
 
         self.step_id = -1
         self.episode_id = -1
+
+        try:
+            import moviepy  # noqa: F401
+        except ImportError as e:
+            raise error.DependencyNotInstalled(
+                "MoviePy is not installed, run `pip install moviepy`"
+            ) from e
 
     def _capture_frame(self):
         assert self.recording, "Cannot capture a frame, recording wasn't started."

--- a/gymnasium/wrappers/monitoring/video_recorder.py
+++ b/gymnasium/wrappers/monitoring/video_recorder.py
@@ -40,14 +40,6 @@ class VideoRecorder:
             Error: You can pass at most one of `path` or `base_path`
             Error: Invalid path given that must have a particular file extension
         """
-        try:
-            # check that moviepy is now installed
-            import moviepy  # noqa: F401
-        except ImportError as e:
-            raise error.DependencyNotInstalled(
-                "moviepy is not installed, run `pip install moviepy`"
-            ) from e
-
         self._async = env.metadata.get("semantics.async")
         self.enabled = enabled
         self.disable_logger = disable_logger
@@ -57,6 +49,14 @@ class VideoRecorder:
         self.env = env
 
         self.render_mode = env.render_mode
+
+        try:
+            # check that moviepy is now installed
+            import moviepy  # noqa: F401
+        except ImportError as e:
+            raise error.DependencyNotInstalled(
+                "moviepy is not installed, run `pip install moviepy`"
+            ) from e
 
         if "rgb_array_list" != self.render_mode and "rgb_array" != self.render_mode:
             logger.warn(


### PR DESCRIPTION
To replicate the issue, install gymnasium but not moviepy

```python
import gymnasium as gym

env = gym.make("CartPole-v1", render_mode="rgb_array")
env = gym.wrappers.RecordVideo(env, "videos")
env.reset()
for _ in range(100):
    env.step(env.action_space.sample())

env.close()
```
```
gymnasium.error.DependencyNotInstalled: moviepy is not installed, run `pip install moviepy`
Exception ignored in: <function VideoRecorder.__del__ at 0x7f68807770d0>
Traceback (most recent call last):
  File ".../Gymnasium/gymnasium/wrappers/monitoring/video_recorder.py", line 178, in __del__
    if not self._closed:
AttributeError: 'VideoRecorder' object has no attribute '_closed'
```
This is partially confusing as the issue is not with `VideoRecorder` but with `_closed`

This PR solves the issue by moving the variables or try except such that the variables exist if the import fails