### PR TITLE
Make the environment creator error more helpful for debugging

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -811,7 +811,7 @@ def make(
             ) from e
         else:
             raise type(e)(
-                f"The environment creator for {env_spec.id} with kwargs ({env_spec_kwargs}) raised the following error: {e}"
+                f"{e} was raised from the environment creator for {env_spec.id} with kwargs ({env_spec_kwargs})"
             )
 
     # Set the minimal env spec for the environment.

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -810,7 +810,9 @@ def make(
                 "rendering API, which is not supported by the HumanRendering wrapper."
             ) from e
         else:
-            raise e
+            raise type(e)(
+                f"The environment creator for {env_spec.id} with kwargs ({env_spec_kwargs}) raised the following error: {e}"
+            )
 
     # Set the minimal env spec for the environment.
     env.unwrapped.spec = EnvSpec(


### PR DESCRIPTION
When users make an environment, if an error is raised then it can be unclear what the env id was or the kwargs, this adds this information to the error.
I choose not to use `raise error("helpful message") from e`, partially due to testing making it more difficult (using pytest) to extract the inner error (`e`). 