### PR TITLE
Adding starting values to MultiDiscrete spaces

### DIFF
--- a/gymnasium/experimental/vector/utils/space_utils.py
+++ b/gymnasium/experimental/vector/utils/space_utils.py
@@ -73,28 +73,21 @@ def _batch_space_box(space: Box, n: int = 1):
 
 @batch_space.register(Discrete)
 def _batch_space_discrete(space: Discrete, n: int = 1):
-    if space.start == 0:
-        return MultiDiscrete(
-            np.full((n,), space.n, dtype=space.dtype),
-            dtype=space.dtype,
-            seed=deepcopy(space.np_random),
-        )
-    else:
-        return Box(
-            low=space.start,
-            high=space.start + space.n - 1,
-            shape=(n,),
-            dtype=space.dtype,
-            seed=deepcopy(space.np_random),
-        )
+    return MultiDiscrete(
+        np.full((n,), space.n, dtype=space.dtype),
+        dtype=space.dtype,
+        seed=deepcopy(space.np_random),
+        start=np.full((n,), space.start, dtype=space.dtype),
+    )
 
 
 @batch_space.register(MultiDiscrete)
 def _batch_space_multidiscrete(space: MultiDiscrete, n: int = 1):
     repeats = tuple([n] + [1] * space.nvec.ndim)
-    high = np.tile(space.nvec, repeats) - 1
+    low = np.tile(space.start, repeats)
+    high = low + np.tile(space.nvec, repeats) - 1
     return Box(
-        low=np.zeros_like(high),
+        low=low,
         high=high,
         dtype=space.dtype,
         seed=deepcopy(space.np_random),

--- a/gymnasium/experimental/wrappers/utils.py
+++ b/gymnasium/experimental/wrappers/utils.py
@@ -99,8 +99,12 @@ def _create_discrete_zero_array(space: Discrete):
 
 
 @create_zero_array.register(MultiDiscrete)
+def _create_multidiscrete_zero_array(space: MultiDiscrete):
+    return np.array(space.start, copy=True, dtype=space.dtype)
+
+
 @create_zero_array.register(MultiBinary)
-def _create_array_zero_array(space: Discrete):
+def _create_array_zero_array(space: MultiBinary):
     return np.zeros(space.shape, dtype=space.dtype)
 
 

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -176,7 +176,7 @@ def _flatten_multidiscrete(
     offsets[1:] = np.cumsum(space.nvec.flatten())
 
     onehot = np.zeros((offsets[-1],), dtype=space.dtype)
-    onehot[offsets[:-1] + x.flatten()] = 1
+    onehot[offsets[:-1] + (x - space.start).flatten()] = 1
     return onehot
 
 
@@ -308,7 +308,10 @@ def _unflatten_multidiscrete(
             "Not all valid samples in a flattened space can be unflattened."
         )
     (indices,) = cast(type(offsets[:-1]), nonzero)
-    return np.asarray(indices - offsets[:-1], dtype=space.dtype).reshape(space.shape)
+    return (
+        np.asarray(indices - offsets[:-1], dtype=space.dtype).reshape(space.shape)
+        + space.start
+    )
 
 
 @unflatten.register(Tuple)

--- a/gymnasium/vector/utils/spaces.py
+++ b/gymnasium/vector/utils/spaces.py
@@ -61,28 +61,21 @@ def _batch_space_box(space, n=1):
 
 @batch_space.register(Discrete)
 def _batch_space_discrete(space, n=1):
-    if space.start == 0:
-        return MultiDiscrete(
-            np.full((n,), space.n, dtype=space.dtype),
-            dtype=space.dtype,
-            seed=deepcopy(space.np_random),
-        )
-    else:
-        return Box(
-            low=space.start,
-            high=space.start + space.n - 1,
-            shape=(n,),
-            dtype=space.dtype,
-            seed=deepcopy(space.np_random),
-        )
+    return MultiDiscrete(
+        np.full((n,), space.n, dtype=space.dtype),
+        dtype=space.dtype,
+        seed=deepcopy(space.np_random),
+        start=np.full((n,), space.start, dtype=space.dtype),
+    )
 
 
 @batch_space.register(MultiDiscrete)
 def _batch_space_multidiscrete(space, n=1):
     repeats = tuple([n] + [1] * space.nvec.ndim)
-    high = np.tile(space.nvec, repeats) - 1
+    low = np.tile(space.start, repeats)
+    high = low + np.tile(space.nvec, repeats) - 1
     return Box(
-        low=np.zeros_like(high),
+        low=low,
         high=high,
         dtype=space.dtype,
         seed=deepcopy(space.np_random),

--- a/tests/spaces/test_multidiscrete.py
+++ b/tests/spaces/test_multidiscrete.py
@@ -29,6 +29,34 @@ def test_multidiscrete_as_tuple():
     assert space[:, :] == space and space[:, :] is not space
 
 
+def test_multidiscrete_start_as_tuple():
+    # 1D multi-discrete
+    space = MultiDiscrete([3, 4, 5], start=[10, 20, 30])
+
+    assert space.shape == (3,)
+    assert space[0] == Discrete(3, start=10)
+    assert space[0:1] == MultiDiscrete([3], start=[10])
+    assert space[0:2] == MultiDiscrete([3, 4], start=[10, 20])
+    assert space[:] == space and space[:] is not space
+
+    # 2D multi-discrete
+    space = MultiDiscrete([[3, 4, 5], [6, 7, 8]], start=[[10, 20, 30], [40, 50, 60]])
+
+    assert space.shape == (2, 3)
+    assert space[0, 1] == Discrete(4, start=20)
+    assert space[0] == MultiDiscrete([3, 4, 5], start=[10, 20, 30])
+    assert space[0:1] == MultiDiscrete([[3, 4, 5]], start=[[10, 20, 30]])
+    assert space[0:2, :] == MultiDiscrete(
+        [[3, 4, 5], [6, 7, 8]], start=[[10, 20, 30], [40, 50, 60]]
+    )
+    assert space[:, 0:1] == MultiDiscrete([[3], [6]], start=[[10], [40]])
+    assert space[0:2, 0:2] == MultiDiscrete(
+        [[3, 4], [6, 7]], start=[[10, 20], [40, 50]]
+    )
+    assert space[:] == space and space[:] is not space
+    assert space[:, :] == space and space[:, :] is not space
+
+
 def test_multidiscrete_subspace_reproducibility():
     # 1D multi-discrete
     space = MultiDiscrete([100, 200, 300])
@@ -55,11 +83,50 @@ def test_multidiscrete_subspace_reproducibility():
     assert data_equivalence(space[:, :].sample(), space.sample())
 
 
+def test_multidiscrete_start_subspace_reproducibility():
+    # 1D multi-discrete
+    space = MultiDiscrete([100, 200, 300], start=[-50, -100, -150])
+    space.seed()
+
+    assert data_equivalence(space[0].sample(), space[0].sample())
+    assert data_equivalence(space[0:1].sample(), space[0:1].sample())
+    assert data_equivalence(space[0:2].sample(), space[0:2].sample())
+    assert data_equivalence(space[:].sample(), space[:].sample())
+    assert data_equivalence(space[:].sample(), space.sample())
+
+    # 2D multi-discrete
+    space = MultiDiscrete(
+        [[300, 400, 500], [600, 700, 800]],
+        start=[[-150, -200, -250], [-300, -350, -400]],
+    )
+    space.seed()
+
+    assert data_equivalence(space[0, 1].sample(), space[0, 1].sample())
+    assert data_equivalence(space[0].sample(), space[0].sample())
+    assert data_equivalence(space[0:1].sample(), space[0:1].sample())
+    assert data_equivalence(space[0:2, :].sample(), space[0:2, :].sample())
+    assert data_equivalence(space[:, 0:1].sample(), space[:, 0:1].sample())
+    assert data_equivalence(space[0:2, 0:2].sample(), space[0:2, 0:2].sample())
+    assert data_equivalence(space[:].sample(), space[:].sample())
+    assert data_equivalence(space[:, :].sample(), space[:, :].sample())
+    assert data_equivalence(space[:, :].sample(), space.sample())
+
+
 def test_multidiscrete_length():
     space = MultiDiscrete(nvec=[3, 2, 4])
     assert len(space) == 3
 
+    space = MultiDiscrete(nvec=[3, 2, 4], start=[10, 10, 10])
+    assert len(space) == 3
+
     space = MultiDiscrete(nvec=[[2, 3], [3, 2]])
+    with pytest.warns(
+        UserWarning,
+        match="Getting the length of a multi-dimensional MultiDiscrete space.",
+    ):
+        assert len(space) == 2
+
+    space = MultiDiscrete(nvec=[[2, 3], [3, 2]], start=[[10, 20], [30, 40]])
     with pytest.warns(
         UserWarning,
         match="Getting the length of a multi-dimensional MultiDiscrete space.",
@@ -76,3 +143,13 @@ def test_multidiscrete_integer_overflow():
 
     assert len(z) == 4
     assert np.array_equal(x, z)
+
+
+def test_multidiscrete_start_contains():
+    space = MultiDiscrete([3, 4, 5], start=[10, 20, 30])
+
+    assert [10, 20, 30] in space
+    assert [9, 20, 30] not in space
+
+    assert [12, 23, 34] in space
+    assert [13, 23, 34] not in space

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -433,7 +433,7 @@ def test_space_sample_mask(space: Space, mask, n_trials: int = 100):
             space.nvec, mask, lambda dim, _: np.zeros(dim)
         )
         for sample in samples:
-            _update_observed_frequency(sample, observed_frequency)
+            _update_observed_frequency(sample - space.start, observed_frequency)
 
         def _chi_squared_test(dim, _mask, exp_freq, obs_freq):
             if isinstance(dim, np.ndarray):

--- a/tests/spaces/test_spaces.py
+++ b/tests/spaces/test_spaces.py
@@ -165,7 +165,7 @@ def test_sample(space: Space, n_trials: int = 1_000):
         )
         observed_frequency = _generate_frequency(space.nvec, lambda dim: np.zeros(dim))
         for sample in samples:
-            _update_observed_frequency(sample, observed_frequency)
+            _update_observed_frequency(sample - space.start, observed_frequency)
 
         def _chi_squared_test(dim, exp_freq, obs_freq):
             if isinstance(dim, np.ndarray):
@@ -326,6 +326,11 @@ SAMPLE_MASK_RNG, _ = seeding.np_random(1)
             None,
             None,
             # Multi-discrete
+            (np.array([1, 1], dtype=np.int8), np.array([0, 0], dtype=np.int8)),
+            (
+                (np.array([1, 0], dtype=np.int8), np.array([0, 1, 1], dtype=np.int8)),
+                (np.array([1, 1, 0], dtype=np.int8), np.array([0, 1], dtype=np.int8)),
+            ),
             (np.array([1, 1], dtype=np.int8), np.array([0, 0], dtype=np.int8)),
             (
                 (np.array([1, 0], dtype=np.int8), np.array([0, 1, 1], dtype=np.int8)),

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -26,6 +26,8 @@ TESTING_SPACES_EXPECTED_FLATDIMS = [
     # Multi-discrete
     4,
     10,
+    4,
+    10,
     # Multi-binary
     8,
     6,

--- a/tests/spaces/utils.py
+++ b/tests/spaces/utils.py
@@ -33,6 +33,8 @@ TESTING_FUNDAMENTAL_SPACES = [
     ),
     MultiDiscrete([2, 2]),
     MultiDiscrete([[2, 3], [3, 2]]),
+    MultiDiscrete([2, 2], start=[10, 10]),
+    MultiDiscrete([[2, 3], [3, 2]], start=[[10, 20], [30, 40]]),
     MultiBinary(8),
     MultiBinary([2, 3]),
     Text(6),

--- a/tests/vector/test_shared_memory.py
+++ b/tests/vector/test_shared_memory.py
@@ -29,6 +29,7 @@ expected_types = [
     (Array("i", 1), Array("i", 1)),
     (Array("i", 1), Array("f", 2)),
     Array("B", 3),
+    Array("B", 3),
     Array("B", 19),
     OrderedDict([("position", Array("i", 1)), ("velocity", Array("f", 1))]),
     OrderedDict(

--- a/tests/vector/test_spaces.py
+++ b/tests/vector/test_spaces.py
@@ -36,7 +36,7 @@ expected_batch_spaces_4 = [
     Box(low=0, high=255, shape=(4,), dtype=np.uint8),
     Box(low=0, high=255, shape=(4, 32, 32, 3), dtype=np.uint8),
     MultiDiscrete([2, 2, 2, 2]),
-    Box(low=-2, high=2, shape=(4,), dtype=np.int64),
+    MultiDiscrete([5, 5, 5, 5], start=[-2, -2, -2, -2]),
     Tuple((MultiDiscrete([3, 3, 3, 3]), MultiDiscrete([5, 5, 5, 5]))),
     Tuple(
         (
@@ -51,6 +51,11 @@ expected_batch_spaces_4 = [
     Box(
         low=np.array([[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]]),
         high=np.array([[10, 12, 16], [10, 12, 16], [10, 12, 16], [10, 12, 16]]),
+        dtype=np.int64,
+    ),
+    Box(
+        low=np.array([[-5, -7, -9], [-5, -7, -9], [-5, -7, -9], [-5, -7, -9]]),
+        high=np.array([[4, 6, 8], [4, 6, 8], [4, 6, 8], [4, 6, 8]]),
         dtype=np.int64,
     ),
     Box(low=0, high=1, shape=(4, 19), dtype=np.int8),

--- a/tests/vector/utils.py
+++ b/tests/vector/utils.py
@@ -29,6 +29,7 @@ spaces = [
         )
     ),
     MultiDiscrete([11, 13, 17]),
+    MultiDiscrete([10, 14, 18], start=[-5, -7, -9]),
     MultiBinary(19),
     Dict(
         {


### PR DESCRIPTION
Feature addition: `MultiDiscrete` spaces with a starting value, much like `Discrete` spaces. 

No additional dependencies required for this change.

## Best practice question:
To me it makes more sense to have the `start` argument of the `__init__()` function in second place, however if I did so it would break the code providing `dtype` by position. That's why I put it in the last position, should I change?

## New feature

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (to the docstrings, is that it ?)
- [x] My changes generate no new warnings (AFAIK no, I'll see that with testing)
- [x] I have added tests that prove (my fix is effective or) that my feature works
- [x] New and existing unit tests pass locally with my changes