### PR TITLE
Add MaxAndSkipObservation wrapper

### DIFF
--- a/gymnasium/experimental/wrappers/__init__.py
+++ b/gymnasium/experimental/wrappers/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "NormalizeObservationV0",
     "TimeAwareObservationV0",
     "FrameStackObservationV0",
+    "MaxAndSkipObservationV0",
     "DelayObservationV0",
     "AtariPreprocessingV0",
     # --- Action Wrappers ---
@@ -74,6 +75,7 @@ _wrapper_to_class = {
     "DelayObservationV0": "stateful_observation",
     "FrameStackObservationV0": "stateful_observation",
     "NormalizeObservationV0": "stateful_observation",
+    "MaxAndSkipObservationV0": "stateful_observation",
     # stateful_reward
     "NormalizeRewardV1": "stateful_reward",
     # atari_preprocessing

--- a/gymnasium/experimental/wrappers/stateful_observation.py
+++ b/gymnasium/experimental/wrappers/stateful_observation.py
@@ -4,6 +4,7 @@
 * ``TimeAwareObservationV0`` - A wrapper for adding time aware observations to environment observation
 * ``FrameStackObservationV0`` - Frame stack the observations
 * ``NormalizeObservationV0`` - Normalized the observations to a mean and
+* ``MaxAndSkipObservationV0`` - Return only every ``skip``-th frame (frameskipping) and return the max between the two last frames.
 """
 from __future__ import annotations
 
@@ -431,3 +432,65 @@ class NormalizeObservationV0(
         return (observation - self.obs_rms.mean) / np.sqrt(
             self.obs_rms.var + self.epsilon
         )
+
+
+class MaxAndSkipObservationV0(
+    gym.Wrapper[WrapperObsType, ActType, ObsType, ActType],
+    gym.utils.RecordConstructorArgs,
+):
+    """This wrapper will return only every ``skip``-th frame (frameskipping) and return the max between the two last observations.
+
+    Note: This wrapper is based on the wrapper from stable-baselines3: https://stable-baselines3.readthedocs.io/en/master/_modules/stable_baselines3/common/atari_wrappers.html#MaxAndSkipEnv
+    """
+
+    def __init__(self, env: gym.Env[ObsType, ActType], skip: int = 4):
+        """This wrapper will return only every ``skip``-th frame (frameskipping) and return the max between the two last frames.
+
+        Args:
+            env (Env): The environment to apply the wrapper
+            skip: The number of frames to skip
+        """
+        gym.utils.RecordConstructorArgs.__init__(self, skip=skip)
+        gym.Wrapper.__init__(self, env)
+
+        if not np.issubdtype(type(skip), np.integer):
+            raise TypeError(
+                f"The skip is expected to be an integer, actual type: {type(skip)}"
+            )
+        if skip < 2:
+            raise ValueError(
+                f"The skip value needs to be equal or greater than two, actual value: {skip}"
+            )
+
+        self._skip = skip
+        self._obs_buffer = np.zeros(
+            (2, *env.observation_space.shape), dtype=env.observation_space.dtype
+        )
+
+    def step(
+        self, action: WrapperActType
+    ) -> tuple[WrapperObsType, SupportsFloat, bool, bool, dict[str, Any]]:
+        """Step the environment with the given action for ``skip`` steps.
+
+        Repeat action, sum reward, and max over last observations.
+
+        Args:
+            action: The action to step through the environment with
+        Returns:
+            Max of the last two observations, reward, terminated, truncated, and info from the environment
+        """
+        total_reward = 0.0
+        terminated = truncated = False
+        for i in range(self._skip):
+            obs, reward, terminated, truncated, info = self.env.step(action)
+            done = terminated or truncated
+            if i == self._skip - 2:
+                self._obs_buffer[0] = obs
+            if i == self._skip - 1:
+                self._obs_buffer[1] = obs
+            total_reward += float(reward)
+            if done:
+                break
+        max_frame = self._obs_buffer.max(axis=0)
+
+        return max_frame, total_reward, terminated, truncated, info

--- a/tests/experimental/wrappers/test_max_and_skip_observation.py
+++ b/tests/experimental/wrappers/test_max_and_skip_observation.py
@@ -35,6 +35,8 @@ def test_skip_size_failures():
 
     with pytest.raises(
         ValueError,
-        match=re.escape("The skip value needs to be equal or greater than two, actual value: 0"),
+        match=re.escape(
+            "The skip value needs to be equal or greater than two, actual value: 0"
+        ),
     ):
         MaxAndSkipObservationV0(env, skip=0)

--- a/tests/experimental/wrappers/test_max_and_skip_observation.py
+++ b/tests/experimental/wrappers/test_max_and_skip_observation.py
@@ -1,0 +1,40 @@
+"""Test suite for MaxAndSkipObservationV0."""
+import re
+
+import pytest
+
+import gymnasium as gym
+from gymnasium.experimental.wrappers import MaxAndSkipObservationV0
+
+
+def test_max_and_skip_obs(skip: int = 4):
+    """Test MaxAndSkipObservationV0."""
+    env = gym.make("CartPole-v1")
+
+    env = MaxAndSkipObservationV0(env, skip=skip)
+
+    obs, _ = env.reset()
+    assert obs in env.observation_space
+
+    for i in range(10):
+        obs, _, _, _, _ = env.step(env.action_space.sample())
+        assert obs in env.observation_space
+
+
+def test_skip_size_failures():
+    """Test the error raised by the MaxAndSkipObservation."""
+    env = gym.make("CartPole-v1")
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "The skip is expected to be an integer, actual type: <class 'float'>"
+        ),
+    ):
+        MaxAndSkipObservationV0(env, skip=1.0)
+
+    with pytest.raises(
+        ValueError,
+        match=re.escape("The skip value needs to be equal or greater than two, actual value: 0"),
+    ):
+        MaxAndSkipObservationV0(env, skip=0)


### PR DESCRIPTION
# Description

This PR adds the MaxAndSkipObservation wrapper. This wrapper is equivalent to: https://stable-baselines3.readthedocs.io/en/master/_modules/stable_baselines3/common/atari_wrappers.html#MaxAndSkipEnv

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes