### PR TITLE
Fix negative value sampling in MultiDiscrete with non-zero start

### DIFF
--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -143,9 +143,9 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
 
             return np.array(_apply_mask(mask, self.nvec, self.start), dtype=self.dtype)
 
-        return (self.np_random.random(self.nvec.shape) * self.nvec + self.start).astype(
-            self.dtype
-        )
+        return np.floor(
+            self.np_random.random(self.nvec.shape) * self.nvec + self.start
+        ).astype(self.dtype)
 
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""

--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -143,8 +143,9 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
 
             return np.array(_apply_mask(mask, self.nvec, self.start), dtype=self.dtype)
 
-        return (self.np_random.random(self.nvec.shape) * self.nvec).astype(self.dtype) + self.start
-
+        return (self.np_random.random(self.nvec.shape) * self.nvec).astype(
+            self.dtype
+        ) + self.start
 
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""

--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -143,9 +143,8 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
 
             return np.array(_apply_mask(mask, self.nvec, self.start), dtype=self.dtype)
 
-        return np.floor(
-            self.np_random.random(self.nvec.shape) * self.nvec + self.start
-        ).astype(self.dtype)
+        return (self.np_random.random(self.nvec.shape) * self.nvec).astype(self.dtype) + self.start
+
 
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""


### PR DESCRIPTION
# Description

Fix a bug in negative value sampling. Reproduce:
```py
>>> s = MultiDiscrete([2, 2], start=[-1, -1])
>>> s.sample()
array([0, 0])
```

The sampling always outputs `-1` values because `np.array([-0.9]).astype(np.int32)` and `np.array([0.9]).astype(np.int32)` both give `array([0], dtype=int32)` i.e., the `astype` methods rounds negative values upwards and positive values upwards. As a result, all values between -1 and 1 exclusive are mapped to 0.

I see 3 options:
1. We can fix it by calling `np.floor` (what I did for now)
2. We can fix it by mapping `x = x-1 if x < 0 else x` over `self.start` at initialization
3. We can replace `self.np_random.random` by `self.np_random.integers`, as it is one for `Discrete` spaces

If one of the other option is better, let me know

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works