### PR TITLE
docs: update custom env step return :memo:

### DIFF
--- a/docs/tutorials/gymnasium_basics/environment_creation.py
+++ b/docs/tutorials/gymnasium_basics/environment_creation.py
@@ -225,12 +225,13 @@ class GridWorldEnv(gym.Env):
 #
 # The ``step`` method usually contains most of the logic of your
 # environment. It accepts an ``action``, computes the state of the
-# environment after applying that action and returns the 4-tuple
-# ``(observation, reward, done, info)``. Once the new state of the
-# environment has been computed, we can check whether it is a terminal
-# state and we set ``done`` accordingly. Since we are using sparse binary
-# rewards in ``GridWorldEnv``, computing ``reward`` is trivial once we
-# know ``done``. To gather ``observation`` and ``info``, we can again make
+# environment after applying that action and returns the 5-tuple
+# ``(observation, reward, terminated, truncated, info)``. See
+# :meth:`gymnasium.Env.step`. Once the new state of the environment has
+# been computed, we can check whether it is a terminal state and we set
+# ``done`` accordingly. Since we are using sparse binary rewards in
+# ``GridWorldEnv``, computing ``reward`` is trivial once we know
+# ``done``.To gather ``observation`` and ``info``, we can again make
 # use of ``_get_obs`` and ``_get_info``:
 
     def step(self, action):


### PR DESCRIPTION
# Description

This commit replaces the old documentation for the tutorial, in which Env.step returns a tuple with `done`, with the proper `terminated, truncated`.

Fixes #505 

## Type of change

- [x] Documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] My changes generate no new warnings
