### PR TITLE
Updates the action-space of wrappers.RescaleAction

### DIFF
--- a/gymnasium/wrappers/__init__.py
+++ b/gymnasium/wrappers/__init__.py
@@ -15,7 +15,7 @@ with (possibly optional) parameters to the wrapper's constructor.
     Box(-1.0, 1.0, (3,), float32)
     >>> wrapped_env = RescaleAction(base_env, min_action=0, max_action=1)
     >>> wrapped_env.action_space
-    Box(-1.0, 1.0, (3,), float32)
+    Box(0.0, 1.0, (3,), float32)
 
 You can access the environment underneath the **first** wrapper by using the :attr:`gymnasium.Wrapper.env` attribute.
 As the :class:`gymnasium.Wrapper` class inherits from :class:`gymnasium.Env` then :attr:`gymnasium.Wrapper.env` can be another wrapper.

--- a/gymnasium/wrappers/rescale_action.py
+++ b/gymnasium/wrappers/rescale_action.py
@@ -59,6 +59,13 @@ class RescaleAction(gym.ActionWrapper, gym.utils.RecordConstructorArgs):
             np.zeros(env.action_space.shape, dtype=env.action_space.dtype) + max_action
         )
 
+        self.action_space = Box(
+            low=min_action,
+            high=max_action,
+            shape=env.action_space.shape,
+            dtype=env.action_space.dtype,
+        )
+
     def action(self, action):
         """Rescales the action affinely from  [:attr:`min_action`, :attr:`max_action`] to the action space of the base environment, :attr:`env`.
 


### PR DESCRIPTION
# Description

Describe the bug
Copy and pasted from issue #568 
> The RescaleAction wrapper in (gymnasium.wrappers.rescale_action) does not change the action_space accordingly.
> 
> In contrast, the RescaleAction wrapper in gym.wrappers.rescale_action does!
> 
> When I compare both implementations, the following lines are missing in the gymnasium variant compared to the gym variant.
> 
> self.action_space = spaces.Box(
>     low=min_action,
>     high=max_action,
>     shape=env.action_space.shape,
>     dtype=env.action_space.dtype,
> )
> This looks like a bug to me.
> 
> Code example
> import gymnasium as gym
> #import gym
> 
> env = gym.make("Pendulum-v1")
> env = gym.wrappers.rescale_action.RescaleAction(env, min_action=-1, max_action=1)
> 
> print(env.action_space)
> # gymnasium-->Box(-2.0, 2.0, (1,), float32)
> # gym --> Box([-1.], [1.], (1,), float32)

Fixes #568

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
