### PR TITLE
drop `python 3.7` support

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -21,9 +21,6 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          python: 37
-          platform: manylinux_x86_64
-        - os: ubuntu-latest
           python: 38
           platform: manylinux_x86_64
         - os: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
     rev: v3.3.2
     hooks:
       - id: pyupgrade
-        args: ["--py37-plus"]
+        args: ["--py38-plus"]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To install the base Gymnasium library, use `pip install gymnasium`
 
 This does not include dependencies for all families of environments (there's a massive number, and some can be problematic to install on certain systems). You can install these dependencies for one family like `pip install "gymnasium[atari]"` or use `pip install "gymnasium[all]"` to install all dependencies.
 
-We support and test for Python 3.7, 3.8, 3.9, 3.10, 3.11 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
+We support and test for Python 3.8, 3.9, 3.10, 3.11 on Linux and macOS. We will accept PRs related to Windows, but do not officially support it.
 
 ## API
 

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -24,10 +24,7 @@ if sys.version_info < (3, 10):
 else:
     import importlib.metadata as metadata
 
-if sys.version_info < (3, 8):
-    from typing_extensions import Protocol
-else:
-    from typing import Protocol
+from typing import Protocol
 
 
 ENV_ID_RE = re.compile(

--- a/gymnasium/experimental/wrappers/lambda_observation.py
+++ b/gymnasium/experimental/wrappers/lambda_observation.py
@@ -12,8 +12,7 @@
 """
 from __future__ import annotations
 
-from typing import Any, Callable, Sequence
-from typing_extensions import Final
+from typing import Any, Callable, Final, Sequence
 
 import numpy as np
 

--- a/gymnasium/experimental/wrappers/stateful_observation.py
+++ b/gymnasium/experimental/wrappers/stateful_observation.py
@@ -10,8 +10,7 @@ from __future__ import annotations
 
 from collections import deque
 from copy import deepcopy
-from typing import Any, SupportsFloat
-from typing_extensions import Final
+from typing import Any, Final, SupportsFloat
 
 import numpy as np
 

--- a/gymnasium/wrappers/compatibility.py
+++ b/gymnasium/wrappers/compatibility.py
@@ -1,6 +1,6 @@
 """A compatibility wrapper converting an old-style environment into a valid environment."""
 import sys
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Protocol, Tuple, runtime_checkable
 
 import gymnasium as gym
 from gymnasium import logger
@@ -8,12 +8,6 @@ from gymnasium.core import ObsType
 from gymnasium.utils.step_api_compatibility import (
     convert_to_terminated_truncated_step_api,
 )
-
-
-if sys.version_info >= (3, 8):
-    from typing import Protocol, runtime_checkable
-else:
-    from typing_extensions import Protocol, runtime_checkable
 
 
 @runtime_checkable

--- a/gymnasium/wrappers/compatibility.py
+++ b/gymnasium/wrappers/compatibility.py
@@ -1,5 +1,4 @@
 """A compatibility wrapper converting an old-style environment into a valid environment."""
-import sys
 from typing import Any, Dict, Optional, Protocol, Tuple, runtime_checkable
 
 import gymnasium as gym

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "gymnasium"
 description = "A standard API for reinforcement learning and a diverse set of reference environments (formerly Gym)."
 readme = "README.md"
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 authors = [{ name = "Farama Foundation", email = "contact@farama.org" }]
 license = { text = "MIT License" }
 keywords = ["Reinforcement Learning", "game", "RL", "AI", "gymnasium"]
@@ -16,7 +16,6 @@ classifiers = [
     "Development Status :: 4 - Beta",  # change to `5 - Production/Stable` when ready
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
`python 3.7` becomes EOL today
so we should drop support for it 