### PR TITLE
docs: fix typo

### DIFF
--- a/docs/api/env.md
+++ b/docs/api/env.md
@@ -73,7 +73,7 @@ title: Utils
 ```{eval-rst}
 .. py:currentmodule:: gymnasium
 
-When implementing an environment, the :meth:Env.reset and :meth:`Env.step` functions much be created describing the
+When implementing an environment, the :meth:`Env.reset` and :meth:`Env.step` functions much be created describing the
 dynamics of the environment.
 For more information see the environment creation tutorial.
 ```


### PR DESCRIPTION
# Description

In the https://gymnasium.farama.org/api/env/#implementing-environments section, it looks like "Env.reset" is missing backticks.

## Type of change

- [x] This change requires a documentation update

### Screenshots


| Before | After |
| ------ | ----- |
| ![image](https://github.com/Farama-Foundation/Gymnasium/assets/15034841/f7cb51e2-340a-43f6-80fe-752e51d6d560) | _gif/png after_ |


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
