### PR TITLE
feat: throw error on invalid render mode :technologist:

### DIFF
--- a/gymnasium/wrappers/monitoring/video_recorder.py
+++ b/gymnasium/wrappers/monitoring/video_recorder.py
@@ -58,13 +58,12 @@ class VideoRecorder:
                 "moviepy is not installed, run `pip install moviepy`"
             ) from e
 
-        if "rgb_array_list" != self.render_mode and "rgb_array" != self.render_mode:
-            logger.warn(
-                f"Disabling video recorder because environment {env} was not initialized with any compatible video "
-                "mode between `rgb_array` and `rgb_array_list`"
+        if self.render_mode in {None, "human", "ansi", "ansi_list"}:
+            raise ValueError(
+                f"Render mode is {self.render_mode}, which is incompatible with"
+                f" RecordVideo. Initialize your environment with a render_mode"
+                f" that returns an image, such as rgb_array."
             )
-            # Disable since the environment has not been initialized with a compatible `render_mode`
-            self.enabled = False
 
         # Don't bother setting anything else if not enabled
         if not self.enabled:

--- a/gymnasium/wrappers/record_video.py
+++ b/gymnasium/wrappers/record_video.py
@@ -70,6 +70,13 @@ class RecordVideo(gym.Wrapper, gym.utils.RecordConstructorArgs):
         )
         gym.Wrapper.__init__(self, env)
 
+        if env.render_mode in {None, "human", "ansi", "ansi_list"}:
+            raise ValueError(
+                f"Render mode is {env.render_mode}, which is incompatible with"
+                f" RecordVideo. Initialize your environment with a render_mode"
+                f" that returns an image, such as rgb_array."
+            )
+
         if episode_trigger is None and step_trigger is None:
             episode_trigger = capped_cubic_video_schedule
 

--- a/tests/wrappers/test_video_recorder.py
+++ b/tests/wrappers/test_video_recorder.py
@@ -52,12 +52,12 @@ def test_no_frames():
 
 
 def test_record_unrecordable_method():
-    with pytest.warns(
-        UserWarning,
-        match=re.escape(
-            "\x1b[33mWARN: Disabling video recorder because environment <UnrecordableEnv instance> was not initialized with any compatible video mode between `rgb_array` and `rgb_array_list`\x1b[0m"
-        ),
-    ):
+    error_message = (
+        "Render mode is None, which is incompatible with RecordVideo."
+        " Initialize your environment with a render_mode that returns an"
+        " image, such as rgb_array."
+    )
+    with pytest.raises(ValueError, match=re.escape(error_message)):
         env = UnrecordableEnv()
         rec = VideoRecorder(env)
         assert not rec.enabled


### PR DESCRIPTION
# Description

I changed the `UserWarning` thrown by `VideoRecorder` into a `ValueError` that gets thrown if `render_mode` is an invalid value. The exception is mirrored inside the constructor of `RecordVideo` so that it fails as soon as possible.

## Motivation

Right now, when you wrap an env in a `RecordVideo`, the code throws only an user warning at the end of the training when it tries to save a video but `render_mode` is set to `None`, or in general to any other value except `rgb_array` and `rgb_array_list`.

It would be nice to check the render mode early, ideally inside the `RecordVideo` constructor, so that the training doesn't have to be restarted in case the parameter was accidentally left unspecified.

| Before                                                                                                                                                                             | After                                                                                                               |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
| env = gym.make(env_name)<br>env = RecordVideo(env, directory)<br>train(model, env)<br>...<br># throws user warning here, without recording<br># you now have to start from scratch | env = gym.make(env_name)<br>env = RecordVideo(env, directory) # will throw exception 🚫                              |
|                                                                                                                                                                                    | env = gym.make(env_name, render_mode="rgb_array")<br>env = RecordVideo(env, directory)  # will continue execution ✅  |

Fixes #560 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
