### PR TITLE
remove Hopper-v4's old render API func

### DIFF
--- a/gymnasium/envs/mujoco/hopper_v4.py
+++ b/gymnasium/envs/mujoco/hopper_v4.py
@@ -296,11 +296,3 @@ class HopperEnv(MujocoEnv, utils.EzPickle):
 
         observation = self._get_obs()
         return observation
-
-    def viewer_setup(self):
-        assert self.viewer is not None
-        for key, value in DEFAULT_CAMERA_CONFIG.items():
-            if isinstance(value, np.ndarray):
-                getattr(self.viewer.cam, key)[:] = value
-            else:
-                setattr(self.viewer.cam, key, value)


### PR DESCRIPTION
fixes https://github.com/Farama-Foundation/Gymnasium/issues/586


the func is not reached with  `render_mode in ['human', 'rgb_array']`