### PR TITLE
enable `pyright.reportUntypedFunctionDecorator`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ reportInvalidTypeVarUse = "none"
 # reportUnknownVariableType = "warning"  # -> raises 2585 warnings
 # reportUnknownArgumentType = "warning"  # -> raises 2104 warnings
 reportGeneralTypeIssues = "none"  # -> commented out raises 489 errors
-reportUntypedFunctionDecorator = "none"  # -> pytest.mark.parameterize issues
+# reportUntypedFunctionDecorator = "none"  # -> pytest.mark.parameterize issues
 
 reportPrivateUsage = "warning"
 reportUnboundVariable = "warning"


### PR DESCRIPTION
does not create new errors