### PR TITLE
Change all instances of `jax.numpy.DeviceArray` to `jax.numpy.Array`

### DIFF
--- a/gymnasium/experimental/wrappers/jax_to_numpy.py
+++ b/gymnasium/experimental/wrappers/jax_to_numpy.py
@@ -25,7 +25,7 @@ __all__ = ["JaxToNumpyV0", "jax_to_numpy", "numpy_to_jax"]
 
 @functools.singledispatch
 def numpy_to_jax(value: Any) -> Any:
-    """Converts a value to a Jax DeviceArray."""
+    """Converts a value to a Jax Array."""
     raise Exception(
         f"No known conversion for Numpy type ({type(value)}) to Jax registered. Report as issue on github."
     )
@@ -34,30 +34,30 @@ def numpy_to_jax(value: Any) -> Any:
 @numpy_to_jax.register(numbers.Number)
 def _number_to_jax(
     value: numbers.Number,
-) -> jnp.DeviceArray:
-    """Converts a number (int, float, etc.) to a Jax DeviceArray."""
+) -> jnp.Array:
+    """Converts a number (int, float, etc.) to a Jax Array."""
     assert jnp is not None
     return jnp.array(value)
 
 
 @numpy_to_jax.register(np.ndarray)
-def _numpy_array_to_jax(value: np.ndarray) -> jnp.DeviceArray:
-    """Converts a NumPy Array to a Jax DeviceArray with the same dtype (excluding float64 without being enabled)."""
+def _numpy_array_to_jax(value: np.ndarray) -> jnp.Array:
+    """Converts a NumPy Array to a Jax Array with the same dtype (excluding float64 without being enabled)."""
     assert jnp is not None
     return jnp.array(value, dtype=value.dtype)
 
 
 @numpy_to_jax.register(abc.Mapping)
 def _mapping_numpy_to_jax(value: Mapping[str, Any]) -> Mapping[str, Any]:
-    """Converts a dictionary of numpy arrays to a mapping of Jax DeviceArrays."""
+    """Converts a dictionary of numpy arrays to a mapping of Jax Arrays."""
     return type(value)(**{k: numpy_to_jax(v) for k, v in value.items()})
 
 
 @numpy_to_jax.register(abc.Iterable)
 def _iterable_numpy_to_jax(
     value: Iterable[np.ndarray | Any],
-) -> Iterable[jnp.DeviceArray | Any]:
-    """Converts an Iterable from Numpy Arrays to an iterable of Jax DeviceArrays."""
+) -> Iterable[jnp.Array | Any]:
+    """Converts an Iterable from Numpy Arrays to an iterable of Jax Arrays."""
     return type(value)(numpy_to_jax(v) for v in value)
 
 
@@ -69,25 +69,25 @@ def jax_to_numpy(value: Any) -> Any:
     )
 
 
-@jax_to_numpy.register(jnp.DeviceArray)
-def _devicearray_jax_to_numpy(value: jnp.DeviceArray) -> np.ndarray:
-    """Converts a Jax DeviceArray to a numpy array."""
+@jax_to_numpy.register(jnp.Array)
+def _Array_jax_to_numpy(value: jnp.Array) -> np.ndarray:
+    """Converts a Jax Array to a numpy array."""
     return np.array(value)
 
 
 @jax_to_numpy.register(abc.Mapping)
 def _mapping_jax_to_numpy(
-    value: Mapping[str, jnp.DeviceArray | Any]
+    value: Mapping[str, jnp.Array | Any]
 ) -> Mapping[str, np.ndarray | Any]:
-    """Converts a dictionary of Jax DeviceArrays to a mapping of numpy arrays."""
+    """Converts a dictionary of Jax Arrays to a mapping of numpy arrays."""
     return type(value)(**{k: jax_to_numpy(v) for k, v in value.items()})
 
 
 @jax_to_numpy.register(abc.Iterable)
 def _iterable_jax_to_numpy(
     value: Iterable[np.ndarray | Any],
-) -> Iterable[jnp.DeviceArray | Any]:
-    """Converts an Iterable from Numpy arrays to an iterable of Jax DeviceArrays."""
+) -> Iterable[jnp.Array | Any]:
+    """Converts an Iterable from Numpy arrays to an iterable of Jax Arrays."""
     return type(value)(jax_to_numpy(v) for v in value)
 
 
@@ -101,7 +101,7 @@ class JaxToNumpyV0(
 
     Notes:
         The Jax To Numpy and Numpy to Jax conversion does not guarantee a roundtrip (jax -> numpy -> jax) and vice versa.
-        The reason for this is jax does not support non-array values, therefore numpy ``int_32(5) -> DeviceArray([5], dtype=jnp.int23)``
+        The reason for this is jax does not support non-array values, therefore numpy ``int_32(5) -> Array([5], dtype=jnp.int23)``
     """
 
     def __init__(self, env: gym.Env[ObsType, ActType]):

--- a/gymnasium/experimental/wrappers/jax_to_torch.py
+++ b/gymnasium/experimental/wrappers/jax_to_torch.py
@@ -44,7 +44,7 @@ __all__ = ["JaxToTorchV0", "jax_to_torch", "torch_to_jax", "Device"]
 
 @functools.singledispatch
 def torch_to_jax(value: Any) -> Any:
-    """Converts a PyTorch Tensor into a Jax DeviceArray."""
+    """Converts a PyTorch Tensor into a Jax Array."""
     raise Exception(
         f"No known conversion for Torch type ({type(value)}) to Jax registered. Report as issue on github."
     )
@@ -57,8 +57,8 @@ def _number_torch_to_jax(value: numbers.Number) -> Any:
 
 
 @torch_to_jax.register(torch.Tensor)
-def _tensor_torch_to_jax(value: torch.Tensor) -> jnp.DeviceArray:
-    """Converts a PyTorch Tensor into a Jax DeviceArray."""
+def _tensor_torch_to_jax(value: torch.Tensor) -> jnp.Array:
+    """Converts a PyTorch Tensor into a Jax Array."""
     tensor = torch_dlpack.to_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
     tensor = jax_dlpack.from_dlpack(tensor)  # pyright: ignore[reportPrivateImportUsage]
     return tensor
@@ -66,29 +66,29 @@ def _tensor_torch_to_jax(value: torch.Tensor) -> jnp.DeviceArray:
 
 @torch_to_jax.register(abc.Mapping)
 def _mapping_torch_to_jax(value: Mapping[str, Any]) -> Mapping[str, Any]:
-    """Converts a mapping of PyTorch Tensors into a Dictionary of Jax DeviceArrays."""
+    """Converts a mapping of PyTorch Tensors into a Dictionary of Jax Arrays."""
     return type(value)(**{k: torch_to_jax(v) for k, v in value.items()})
 
 
 @torch_to_jax.register(abc.Iterable)
 def _iterable_torch_to_jax(value: Iterable[Any]) -> Iterable[Any]:
-    """Converts an Iterable from PyTorch Tensors to an iterable of Jax DeviceArrays."""
+    """Converts an Iterable from PyTorch Tensors to an iterable of Jax Arrays."""
     return type(value)(torch_to_jax(v) for v in value)
 
 
 @functools.singledispatch
 def jax_to_torch(value: Any, device: Device | None = None) -> Any:
-    """Converts a Jax DeviceArray into a PyTorch Tensor."""
+    """Converts a Jax Array into a PyTorch Tensor."""
     raise Exception(
         f"No known conversion for Jax type ({type(value)}) to PyTorch registered. Report as issue on github."
     )
 
 
-@jax_to_torch.register(jnp.DeviceArray)
-def _devicearray_jax_to_torch(
-    value: jnp.DeviceArray, device: Device | None = None
+@jax_to_torch.register(jnp.Array)
+def _Array_jax_to_torch(
+    value: jnp.Array, device: Device | None = None
 ) -> torch.Tensor:
-    """Converts a Jax DeviceArray into a PyTorch Tensor."""
+    """Converts a Jax Array into a PyTorch Tensor."""
     assert jax_dlpack is not None and torch_dlpack is not None
     dlpack = jax_dlpack.to_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
     tensor = torch_dlpack.from_dlpack(dlpack)
@@ -101,7 +101,7 @@ def _devicearray_jax_to_torch(
 def _jax_mapping_to_torch(
     value: Mapping[str, Any], device: Device | None = None
 ) -> Mapping[str, Any]:
-    """Converts a mapping of Jax DeviceArrays into a Dictionary of PyTorch Tensors."""
+    """Converts a mapping of Jax Arrays into a Dictionary of PyTorch Tensors."""
     return type(value)(**{k: jax_to_torch(v, device) for k, v in value.items()})
 
 
@@ -109,7 +109,7 @@ def _jax_mapping_to_torch(
 def _jax_iterable_to_torch(
     value: Iterable[Any], device: Device | None = None
 ) -> Iterable[Any]:
-    """Converts an Iterable from Jax DeviceArrays to an iterable of PyTorch Tensors."""
+    """Converts an Iterable from Jax Arrays to an iterable of PyTorch Tensors."""
     return type(value)(jax_to_torch(v, device) for v in value)
 
 

--- a/gymnasium/experimental/wrappers/numpy_to_torch.py
+++ b/gymnasium/experimental/wrappers/numpy_to_torch.py
@@ -43,19 +43,19 @@ def _number_torch_to_numpy(value: numbers.Number | torch.Tensor) -> Any:
 
 @torch_to_numpy.register(abc.Mapping)
 def _mapping_torch_to_numpy(value: Mapping[str, Any]) -> Mapping[str, Any]:
-    """Converts a mapping of PyTorch Tensors into a Dictionary of Jax DeviceArrays."""
+    """Converts a mapping of PyTorch Tensors into a Dictionary of Jax Arrays."""
     return type(value)(**{k: torch_to_numpy(v) for k, v in value.items()})
 
 
 @torch_to_numpy.register(abc.Iterable)
 def _iterable_torch_to_numpy(value: Iterable[Any]) -> Iterable[Any]:
-    """Converts an Iterable from PyTorch Tensors to an iterable of Jax DeviceArrays."""
+    """Converts an Iterable from PyTorch Tensors to an iterable of Jax Arrays."""
     return type(value)(torch_to_numpy(v) for v in value)
 
 
 @functools.singledispatch
 def numpy_to_torch(value: Any, device: Device | None = None) -> Any:
-    """Converts a Jax DeviceArray into a PyTorch Tensor."""
+    """Converts a Jax Array into a PyTorch Tensor."""
     raise Exception(
         f"No known conversion for NumPy type ({type(value)}) to PyTorch registered. Report as issue on github."
     )
@@ -63,7 +63,7 @@ def numpy_to_torch(value: Any, device: Device | None = None) -> Any:
 
 @numpy_to_torch.register(np.ndarray)
 def _numpy_to_torch(value: np.ndarray, device: Device | None = None) -> torch.Tensor:
-    """Converts a Jax DeviceArray into a PyTorch Tensor."""
+    """Converts a Jax Array into a PyTorch Tensor."""
     assert torch is not None
     tensor = torch.tensor(value)
     if device:
@@ -75,7 +75,7 @@ def _numpy_to_torch(value: np.ndarray, device: Device | None = None) -> torch.Te
 def _numpy_mapping_to_torch(
     value: Mapping[str, Any], device: Device | None = None
 ) -> Mapping[str, Any]:
-    """Converts a mapping of Jax DeviceArrays into a Dictionary of PyTorch Tensors."""
+    """Converts a mapping of Jax Arrays into a Dictionary of PyTorch Tensors."""
     return type(value)(**{k: numpy_to_torch(v, device) for k, v in value.items()})
 
 
@@ -83,7 +83,7 @@ def _numpy_mapping_to_torch(
 def _numpy_iterable_to_torch(
     value: Iterable[Any], device: Device | None = None
 ) -> Iterable[Any]:
-    """Converts an Iterable from Jax DeviceArrays to an iterable of PyTorch Tensors."""
+    """Converts an Iterable from Jax Arrays to an iterable of PyTorch Tensors."""
     return type(value)(numpy_to_torch(v, device) for v in value)
 
 

--- a/tests/experimental/wrappers/test_jax_to_numpy.py
+++ b/tests/experimental/wrappers/test_jax_to_numpy.py
@@ -72,7 +72,7 @@ def jax_reset_func(self, seed=None, options=None):
 
 def jax_step_func(self, action):
     """A jax-based step function."""
-    assert isinstance(action, jnp.DeviceArray), type(action)
+    assert isinstance(action, jnp.Array), type(action)
     return (
         jnp.array([1, 2, 3]),
         jnp.array(5.0),
@@ -88,16 +88,16 @@ def test_jax_to_numpy_wrapper():
 
     # Check that the reset and step for jax environment are as expected
     obs, info = jax_env.reset()
-    assert isinstance(obs, jnp.DeviceArray)
-    assert isinstance(info, dict) and isinstance(info["data"], jnp.DeviceArray)
+    assert isinstance(obs, jnp.Array)
+    assert isinstance(info, dict) and isinstance(info["data"], jnp.Array)
 
     obs, reward, terminated, truncated, info = jax_env.step(jnp.array([1, 2]))
-    assert isinstance(obs, jnp.DeviceArray)
-    assert isinstance(reward, jnp.DeviceArray)
-    assert isinstance(terminated, jnp.DeviceArray) and isinstance(
-        truncated, jnp.DeviceArray
+    assert isinstance(obs, jnp.Array)
+    assert isinstance(reward, jnp.Array)
+    assert isinstance(terminated, jnp.Array) and isinstance(
+        truncated, jnp.Array
     )
-    assert isinstance(info, dict) and isinstance(info["data"], jnp.DeviceArray)
+    assert isinstance(info, dict) and isinstance(info["data"], jnp.Array)
 
     # Check that the wrapped version is correct.
     numpy_env = JaxToNumpyV0(jax_env)

--- a/tests/experimental/wrappers/test_jax_to_torch.py
+++ b/tests/experimental/wrappers/test_jax_to_torch.py
@@ -73,7 +73,7 @@ def _jax_reset_func(self, seed=None, options=None):
 
 
 def _jax_step_func(self, action):
-    assert isinstance(action, jnp.DeviceArray), type(action)
+    assert isinstance(action, jnp.Array), type(action)
     return (
         jnp.array([1, 2, 3]),
         jnp.array(5.0),
@@ -89,16 +89,16 @@ def test_jax_to_torch_wrapper():
 
     # Check that the reset and step for jax environment are as expected
     obs, info = env.reset()
-    assert isinstance(obs, jnp.DeviceArray)
-    assert isinstance(info, dict) and isinstance(info["data"], jnp.DeviceArray)
+    assert isinstance(obs, jnp.Array)
+    assert isinstance(info, dict) and isinstance(info["data"], jnp.Array)
 
     obs, reward, terminated, truncated, info = env.step(jnp.array([1, 2]))
-    assert isinstance(obs, jnp.DeviceArray)
-    assert isinstance(reward, jnp.DeviceArray)
-    assert isinstance(terminated, jnp.DeviceArray) and isinstance(
-        truncated, jnp.DeviceArray
+    assert isinstance(obs, jnp.Array)
+    assert isinstance(reward, jnp.Array)
+    assert isinstance(terminated, jnp.Array) and isinstance(
+        truncated, jnp.Array
     )
-    assert isinstance(info, dict) and isinstance(info["data"], jnp.DeviceArray)
+    assert isinstance(info, dict) and isinstance(info["data"], jnp.Array)
 
     # Check that the wrapped version is correct.
     wrapped_env = JaxToTorchV0(env)


### PR DESCRIPTION
we recently updated to jax 0.4, however several cases of `DeviceArray` were not updated and warnings were raised in testing, thus are being updated