### PR TITLE
refactor(hopper_v4): add forward/health reward and ctrl cost to step info

### DIFF
--- a/gymnasium/envs/mujoco/hopper_v4.py
+++ b/gymnasium/envs/mujoco/hopper_v4.py
@@ -273,6 +273,9 @@ class HopperEnv(MujocoEnv, utils.EzPickle):
         reward = rewards - costs
         terminated = self.terminated
         info = {
+            "reward_forward": forward_reward,
+            "reward_ctrl": -ctrl_cost,
+            "reward_survive": healthy_reward,
             "x_position": x_position_after,
             "x_velocity": x_velocity,
         }


### PR DESCRIPTION
# Description

This pull request adds the Forward and Health reward and control cost to the `info` dictionary that is returned by the `step` method of the `hopper_v4` environment.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
