### PR TITLE
refactor(walker2d_v4): add forward/health reward and ctrl cost to step info

### DIFF
--- a/gymnasium/envs/mujoco/walker2d_v4.py
+++ b/gymnasium/envs/mujoco/walker2d_v4.py
@@ -270,6 +270,9 @@ class Walker2dEnv(MujocoEnv, utils.EzPickle):
         reward = rewards - costs
         terminated = self.terminated
         info = {
+            "reward_forward": forward_reward,
+            "reward_ctrl": -ctrl_cost,
+            "reward_survive": healthy_reward,
             "x_position": x_position_after,
             "x_velocity": x_velocity,
         }


### PR DESCRIPTION
This pull request adds the Forward and Health reward and control cost to the `info` dictionary that is returned by the `step` method of the `walker2d_v4` environment. This was done to improve consistency with the other environments.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
