### PR TITLE
Limit cython version on mujoco-py option install

### DIFF
--- a/bin/all-py.Dockerfile
+++ b/bin/all-py.Dockerfile
@@ -20,7 +20,6 @@ ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/root/.mujoco/mujoco210/bin"
 
 # Build mujoco-py from source. Pypi installs wheel packages and Cython won't recompile old file versions in the Github Actions CI.
 # Thus generating the following error https://github.com/cython/cython/pull/4428
-RUN pip install "cython<3"
 RUN git clone https://github.com/openai/mujoco-py.git\
     && cd mujoco-py \
     && pip install -e .

--- a/bin/all-py.Dockerfile
+++ b/bin/all-py.Dockerfile
@@ -20,6 +20,7 @@ ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/root/.mujoco/mujoco210/bin"
 
 # Build mujoco-py from source. Pypi installs wheel packages and Cython won't recompile old file versions in the Github Actions CI.
 # Thus generating the following error https://github.com/cython/cython/pull/4428
+RUN pip install "cython<3"
 RUN git clone https://github.com/openai/mujoco-py.git\
     && cd mujoco-py \
     && pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ accept-rom-license = ["autorom[accept-rom-license] ~=0.4.2"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
-mujoco-py = ["mujoco-py >=2.1,<2.2"]
-mujoco_py = ["mujoco-py >=2.1,<2.2"]       # kept for backward compatibility
+mujoco-py = ["mujoco-py >=2.1,<2.2", "cython<3"]
+mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]       # kept for backward compatibility
 mujoco = ["mujoco >=2.3.3", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]         # kept for backward compatibility
@@ -65,6 +65,7 @@ all = [
     "pygame >=2.1.3",
     # mujoco-py
     "mujoco-py >=2.1,<2.2",
+    "cython<3",
     # mujoco
     "mujoco >=2.3.3",
     "imageio >=2.14.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ accept-rom-license = ["autorom[accept-rom-license] ~=0.4.2"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
-mujoco-py = ["mujoco-py >=2.1,<2.2", "cython<3"]
-mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]       # kept for backward compatibility
+mujoco-py = ["mujoco-py >=2.1,<2.2"]
+mujoco_py = ["mujoco-py >=2.1,<2.2"]       # kept for backward compatibility
 mujoco = ["mujoco >=2.3.3", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]         # kept for backward compatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ accept-rom-license = ["autorom[accept-rom-license] ~=0.4.2"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
-mujoco-py = ["mujoco-py >=2.1,<2.2"]
-mujoco_py = ["mujoco-py >=2.1,<2.2"]       # kept for backward compatibility
+mujoco-py = ["mujoco-py >=2.1,<2.2", "cython<3"]
+mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]       # kept for backward compatibility
 mujoco = ["mujoco >=2.3.3", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]         # kept for backward compatibility


### PR DESCRIPTION
# Description

Our CI randomly started to fail, python was released today so we suspect that cython 3 with the introduction on nogail caused the issue 