### PR TITLE
feat(make): add '_saved_make_kwargs' to unwrapped environment

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -726,6 +726,15 @@ def make(
     Raises:
         Error: If the ``id`` doesn't exist in the :attr:`registry`
     """
+    make_kwargs = dict(
+        id=id,
+        max_episode_steps=max_episode_steps,
+        autoreset=autoreset,
+        apply_api_compatibility=apply_api_compatibility,
+        disable_env_checker=disable_env_checker,
+        **kwargs,
+    )
+
     if isinstance(id, EnvSpec):
         env_spec = id
         if not hasattr(env_spec, "additional_wrappers"):
@@ -830,6 +839,9 @@ def make(
         additional_wrappers=(),
         vector_entry_point=env_spec.vector_entry_point,
     )
+
+    # Store make kwargs on the environment
+    env.unwrapped._saved_make_kwargs = make_kwargs
 
     # Check if pre-wrapped wrappers
     assert env.spec is not None


### PR DESCRIPTION
# Description

This pull request adds the '_saved_make_kwargs' to the unwrapped environment when an environment is created. This information is available in the environment class after the environment is created. This information can then be used to throw a warning if users pass the `max_episode_steps` argument while the environment should handle the truncation instead of the  [TimeLimit](https://github.com/Farama-Foundation/Gymnasium/blob/8a75f5a5cab9cca68ddfd7156bcf8639152e7625/gymnasium/wrappers/time_limit.py) wrapper.

Fixes #615

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

N/a

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
