### PR TITLE
ENH: Add NormalizeReward & NormalizeObservation vector wrappers

### DIFF
--- a/gymnasium/experimental/wrappers/stateful_observation.py
+++ b/gymnasium/experimental/wrappers/stateful_observation.py
@@ -417,7 +417,9 @@ class NormalizeObservationV0(
         gym.utils.RecordConstructorArgs.__init__(self, epsilon=epsilon)
         gym.ObservationWrapper.__init__(self, env)
 
-        self.obs_rms = RunningMeanStd(shape=self.observation_space.shape)
+        self.obs_rms = RunningMeanStd(
+            shape=self.observation_space.shape, dtype=self.observation_space.dtype
+        )
         self.epsilon = epsilon
         self._update_running_mean = True
 

--- a/gymnasium/experimental/wrappers/utils.py
+++ b/gymnasium/experimental/wrappers/utils.py
@@ -28,10 +28,10 @@ class RunningMeanStd:
     """Tracks the mean, variance and count of values."""
 
     # https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm
-    def __init__(self, epsilon=1e-4, shape=()):
+    def __init__(self, epsilon=1e-4, shape=(), dtype=np.float64):
         """Tracks the mean, variance and count of values."""
-        self.mean = np.zeros(shape, "float64")
-        self.var = np.ones(shape, "float64")
+        self.mean = np.zeros(shape, dtype=dtype)
+        self.var = np.ones(shape, dtype=dtype)
         self.count = epsilon
 
     def update(self, x):

--- a/gymnasium/experimental/wrappers/vector/__init__.py
+++ b/gymnasium/experimental/wrappers/vector/__init__.py
@@ -8,6 +8,10 @@ from gymnasium.experimental.wrappers.vector.dict_info_to_list import DictInfoToL
 from gymnasium.experimental.wrappers.vector.record_episode_statistics import (
     RecordEpisodeStatisticsV0,
 )
+from gymnasium.experimental.wrappers.vector.stateful_observation import (
+    NormalizeObservationV0,
+)
+from gymnasium.experimental.wrappers.vector.stateful_reward import NormalizeRewardV1
 from gymnasium.experimental.wrappers.vector.vectorize_action import (
     ClipActionV0,
     LambdaActionV0,
@@ -47,8 +51,8 @@ __all__ = [
     "ReshapeObservationV0",
     "RescaleObservationV0",
     "DtypeObservationV0",
+    "NormalizeObservationV0",
     # "PixelObservationV0",
-    # "NormalizeObservationV0",
     # "TimeAwareObservationV0",
     # "FrameStackObservationV0",
     # "DelayObservationV0",
@@ -59,7 +63,7 @@ __all__ = [
     # --- Reward wrappers ---
     "LambdaRewardV0",
     "ClipRewardV0",
-    # "NormalizeRewardV1",
+    "NormalizeRewardV1",
     # --- Common ---
     "RecordEpisodeStatisticsV0",
     # --- Rendering ---

--- a/gymnasium/experimental/wrappers/vector/stateful_observation.py
+++ b/gymnasium/experimental/wrappers/vector/stateful_observation.py
@@ -1,0 +1,84 @@
+"""A collection of stateful observation wrappers.
+
+* ``NormalizeObservationV0`` - Normalize the observations
+"""
+from __future__ import annotations
+
+import numpy as np
+
+import gymnasium as gym
+from gymnasium.core import ActType, ObsType
+from gymnasium.experimental.vector.vector_env import VectorObservationWrapper
+from gymnasium.experimental.wrappers.utils import RunningMeanStd
+
+
+__all__ = ["NormalizeObservationV0"]
+
+
+class NormalizeObservationV0(VectorObservationWrapper, gym.utils.RecordConstructorArgs):
+    """This wrapper will normalize observations s.t. each coordinate is centered with unit variance.
+
+    The property `_update_running_mean` allows to freeze/continue the running mean calculation of the observation
+    statistics. If `True` (default), the `RunningMeanStd` will get updated every step and reset call.
+    If `False`, the calculated statistics are used but not updated anymore; this may be used during evaluation.
+
+    Note:
+        The normalization depends on past trajectories and observations will not be normalized correctly if the wrapper was
+        newly instantiated or the policy was changed recently.
+    """
+
+    def __init__(self, env: gym.Env[ObsType, ActType], epsilon: float = 1e-8):
+        """This wrapper will normalize observations s.t. each coordinate is centered with unit variance.
+
+        Args:
+            env (Env): The environment to apply the wrapper
+            epsilon: A stability parameter that is used when scaling the observations.
+        """
+        gym.utils.RecordConstructorArgs.__init__(self, epsilon=epsilon)
+        gym.ObservationWrapper.__init__(self, env)
+
+        self.obs_rms = RunningMeanStd(
+            shape=self.single_observation_space.shape,
+            dtype=self.single_observation_space.dtype,
+        )
+        self.epsilon = epsilon
+        self._update_running_mean = True
+
+    @property
+    def update_running_mean(self) -> bool:
+        """Property to freeze/continue the running mean calculation of the observation statistics."""
+        return self._update_running_mean
+
+    @update_running_mean.setter
+    def update_running_mean(self, setting: bool):
+        """Sets the property to freeze/continue the running mean calculation of the observation statistics."""
+        self._update_running_mean = setting
+
+    def vector_observation(self, observation: ObsType) -> ObsType:
+        """Defines the vector observation normalization function.
+
+        Args:
+            observation: A vector observation from the environment
+
+        Returns:
+            the normalized observation
+        """
+        return self._normalize_observations(observation)
+
+    def single_observation(self, observation: ObsType) -> ObsType:
+        """Defines the single observation normalization function.
+
+        Args:
+            observation: A single observation from the environment
+
+        Returns:
+            The normalized observation
+        """
+        return self._normalize_observations(observation[None])
+
+    def _normalize_observations(self, observations: ObsType) -> ObsType:
+        if self._update_running_mean:
+            self.obs_rms.update(observations)
+        return (observations - self.obs_rms.mean) / np.sqrt(
+            self.obs_rms.var + self.epsilon
+        )

--- a/gymnasium/experimental/wrappers/vector/stateful_reward.py
+++ b/gymnasium/experimental/wrappers/vector/stateful_reward.py
@@ -1,0 +1,80 @@
+"""A collection of wrappers for modifying the reward with an internal state.
+
+* ``NormalizeRewardV0`` - Normalizes the rewards to a mean and standard deviation
+"""
+from __future__ import annotations
+
+from typing import Any, SupportsFloat
+
+import numpy as np
+
+import gymnasium as gym
+from gymnasium.core import ActType, ObsType
+from gymnasium.experimental.vector.vector_env import VectorEnv, VectorWrapper
+from gymnasium.experimental.wrappers.utils import RunningMeanStd
+
+
+__all__ = ["NormalizeRewardV1"]
+
+
+class NormalizeRewardV1(VectorWrapper, gym.utils.RecordConstructorArgs):
+    r"""This wrapper will normalize immediate rewards s.t. their exponential moving average has a fixed variance.
+
+    The exponential moving average will have variance :math:`(1 - \gamma)^2`.
+
+    The property `_update_running_mean` allows to freeze/continue the running mean calculation of the reward
+    statistics. If `True` (default), the `RunningMeanStd` will get updated every time `self.normalize()` is called.
+    If False, the calculated statistics are used but not updated anymore; this may be used during evaluation.
+
+    Note:
+        The scaling depends on past trajectories and rewards will not be scaled correctly if the wrapper was newly
+        instantiated or the policy was changed recently.
+    """
+
+    def __init__(
+        self,
+        env: VectorEnv,
+        gamma: float = 0.99,
+        epsilon: float = 1e-8,
+    ):
+        """This wrapper will normalize immediate rewards s.t. their exponential moving average has a fixed variance.
+
+        Args:
+            env (env): The environment to apply the wrapper
+            epsilon (float): A stability parameter
+            gamma (float): The discount factor that is used in the exponential moving average.
+        """
+        gym.utils.RecordConstructorArgs.__init__(self, gamma=gamma, epsilon=epsilon)
+        gym.Wrapper.__init__(self, env)
+
+        self.rewards_running_means = RunningMeanStd(shape=())
+        self.discounted_reward: np.array = np.zeros((self.num_envs,), dtype=np.float32)
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self._update_running_mean = True
+
+    @property
+    def update_running_mean(self) -> bool:
+        """Property to freeze/continue the running mean calculation of the reward statistics."""
+        return self._update_running_mean
+
+    @update_running_mean.setter
+    def update_running_mean(self, setting: bool):
+        """Sets the property to freeze/continue the running mean calculation of the reward statistics."""
+        self._update_running_mean = setting
+
+    def step(
+        self, action: ActType
+    ) -> tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]:
+        """Steps through the environment, normalizing the reward returned."""
+        obs, reward, terminated, truncated, info = super().step(action)
+        self.discounted_reward = (
+            self.discounted_reward * self.gamma * (1 - terminated) + reward
+        )
+        return obs, self.normalize(reward), terminated, truncated, info
+
+    def normalize(self, reward: SupportsFloat):
+        """Normalizes the rewards with the running mean rewards and their variance."""
+        if self._update_running_mean:
+            self.rewards_running_means.update(self.discounted_reward)
+        return reward / np.sqrt(self.rewards_running_means.var + self.epsilon)

--- a/tests/experimental/wrappers/test_normalize_observation.py
+++ b/tests/experimental/wrappers/test_normalize_observation.py
@@ -11,7 +11,8 @@ def test_running_mean_normalize_observation_wrapper():
     # Default value is True
     assert wrapped_env.update_running_mean
 
-    wrapped_env.reset()
+    obs, _ = wrapped_env.reset()
+    assert obs in env.observation_space
     rms_var_init = wrapped_env.obs_rms.var
     rms_mean_init = wrapped_env.obs_rms.mean
 

--- a/tests/experimental/wrappers/vector/test_normalize_observation.py
+++ b/tests/experimental/wrappers/vector/test_normalize_observation.py
@@ -1,0 +1,51 @@
+"""Test suite for NormalizeObservationV0."""
+import numpy as np
+import pytest
+
+from gymnasium import spaces
+from gymnasium.experimental.vector import AsyncVectorEnv, SyncVectorEnv
+from gymnasium.experimental.wrappers.vector import NormalizeObservationV0
+from tests.testing_env import GenericTestEnv
+
+
+@pytest.mark.parametrize("class_", [AsyncVectorEnv, SyncVectorEnv])
+def test_normalize_obs(class_):
+    def thunk():
+        return GenericTestEnv(
+            observation_space=spaces.Box(
+                np.full((10,), fill_value=-100),
+                np.full((10,), fill_value=10),
+                dtype=np.float32,
+            )
+        )
+
+    env_fns = [thunk for _ in range(16)]
+    env = class_(env_fns)
+    env = NormalizeObservationV0(env)
+
+    # Default value is True
+    assert env.update_running_mean
+
+    obs, _ = env.reset()
+    assert obs in env.observation_space
+    for _ in range(100):
+        action = env.action_space.sample()
+        env.step(action)
+
+    env.update_running_mean = False
+    rms_var = env.obs_rms.var
+    rms_mean = env.obs_rms.mean
+
+    val_step = 25
+    obs_buffer = np.empty(
+        (val_step,) + env.observation_space.shape, dtype=env.observation_space.dtype
+    )
+    for i in range(val_step):
+        action = env.action_space.sample()
+        obs, _, _, _, _ = env.step(action)
+        obs_buffer[i] = obs
+
+    assert np.all(rms_var == env.obs_rms.var)
+    assert np.all(rms_mean == env.obs_rms.mean)
+    assert np.allclose(np.std(obs_buffer, axis=0), 1, atol=1)
+    assert np.allclose(np.mean(obs_buffer, axis=0), 0, atol=1)

--- a/tests/experimental/wrappers/vector/test_normalize_reward.py
+++ b/tests/experimental/wrappers/vector/test_normalize_reward.py
@@ -1,0 +1,53 @@
+"""Test suite for NormalizeRewardV1."""
+from typing import Optional
+
+import numpy as np
+import pytest
+
+from gymnasium.core import ActType
+from gymnasium.experimental.vector import AsyncVectorEnv, SyncVectorEnv
+from gymnasium.experimental.wrappers.vector import NormalizeRewardV1
+from tests.testing_env import GenericTestEnv
+
+
+def make_env():
+    def reset_func(self, seed: Optional[int] = None, options: Optional[dict] = None):
+        self.step_id = 0
+        return self.observation_space.sample(), {}
+
+    def step_func(self, action: ActType):
+        self.step_id += 1
+        done = self.step_id == 10
+        return self.observation_space.sample(), float(done), done, False, {}
+
+    def thunk():
+        return GenericTestEnv(step_func=step_func, reset_func=reset_func)
+
+    return thunk
+
+
+@pytest.mark.parametrize("class_", [AsyncVectorEnv, SyncVectorEnv])
+def test_normalize_rew(class_):
+    env_fns = [make_env() for _ in range(8)]
+    env = class_(env_fns)
+    env = NormalizeRewardV1(env)
+
+    env.reset()
+    for _ in range(100):
+        action = env.action_space.sample()
+        env.step(action)
+
+    env.reset()
+    forward_rets = []
+    accumulated_rew = 0
+    for _ in range(10):
+        action = env.action_space.sample()
+        _, rew, ter, tru, _ = env.step(action)
+        dones = np.logical_or(ter, tru)
+        accumulated_rew = accumulated_rew * 0.9 * dones + rew
+        forward_rets.append(accumulated_rew)
+
+    env.close()
+
+    forward_rets = np.asarray(forward_rets)
+    assert np.allclose(np.std(forward_rets), 1, atol=0.2)


### PR DESCRIPTION
# Description

Add `NormalizeObservationV0` and `NormalizeRewardV1` wrappers.

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

