### PR TITLE
Update `mujoco_py` environment initialization deprecation warning

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -215,7 +215,7 @@ class MuJocoPyEnv(BaseMujocoEnv):
         logger.deprecation(
             "This version of the mujoco environments depends "
             "on the mujoco-py bindings, which are no longer maintained "
-            "and may stop working. Please upgrade to the v4 versions of "
+            "and may stop working. Please upgrade to the v5 or v4 versions of "
             "the environments (which depend on the mujoco python bindings instead), unless "
             "you are trying to precisely replicate previous works)."
         )


### PR DESCRIPTION
Mentions that `v5` is available when `v2` or `v3` are initialized

