### PR TITLE
[Fix] reset buffer of stateful env MaxAndSkipObservationV0

### DIFF
--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -499,3 +499,11 @@ class MaxAndSkipObservationV0(
         max_frame = self._obs_buffer.max(axis=0)
 
         return max_frame, total_reward, terminated, truncated, info
+
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[ObsType, dict[str, Any]]:
+        self._obs_buffer = np.zeros(
+            (2, *self.env.observation_space.shape), dtype=self.env.observation_space.dtype
+        )
+        return super().reset(seed=seed, options=options)


### PR DESCRIPTION
# Description

Observation buffer should be reset in the stateful observation wrapper `MaxAndSkipObservationV0`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

