### PR TITLE
optimize reinforce_invpend_gym_v26.py

### DIFF
--- a/docs/tutorials/training_agents/reinforce_invpend_gym_v26.py
+++ b/docs/tutorials/training_agents/reinforce_invpend_gym_v26.py
@@ -207,6 +207,10 @@ class REINFORCE:
         log_prob_mean = log_probs.mean()
     
         # Update the loss with the mean log probability and deltas
+        # Note: The multiplication here is not a standard element-wise multiplication.
+        # It is a scalar multiplication, where deltas.mean() calculates the mean of all
+        # the elements in the tensor deltas, and the scalar result is then multiplied
+        # element-wise with the tensor log_prob_mean.
         loss = -log_prob_mean * deltas.mean()
     
         # Update the policy network

--- a/docs/tutorials/training_agents/reinforce_invpend_gym_v26.py
+++ b/docs/tutorials/training_agents/reinforce_invpend_gym_v26.py
@@ -207,11 +207,8 @@ class REINFORCE:
         log_prob_mean = log_probs.mean()
     
         # Update the loss with the mean log probability and deltas
-        # Note: The multiplication here is not a standard element-wise multiplication.
-        # It is a scalar multiplication, where deltas.mean() calculates the mean of all
-        # the elements in the tensor deltas, and the scalar result is then multiplied
-        # element-wise with the tensor log_prob_mean.
-        loss = -log_prob_mean * deltas.mean()
+        # Now, we compute the correct total loss by taking the sum of the element-wise products.
+        loss = -torch.sum(log_prob_mean * deltas)
     
         # Update the policy network
         self.optimizer.zero_grad()
@@ -221,6 +218,7 @@ class REINFORCE:
         # Empty / zero out all episode-centric/related variables
         self.probs = []
         self.rewards = []
+
 
 
 # %%

--- a/docs/tutorials/training_agents/reinforce_invpend_gym_v26.py
+++ b/docs/tutorials/training_agents/reinforce_invpend_gym_v26.py
@@ -193,24 +193,27 @@ class REINFORCE:
         """Updates the policy network's weights."""
         running_g = 0
         gs = []
-
+    
         # Discounted return (backwards) - [::-1] will return an array in reverse
         for R in self.rewards[::-1]:
             running_g = R + self.gamma * running_g
             gs.insert(0, running_g)
-
+    
         deltas = torch.tensor(gs)
-
-        loss = 0
-        # minimize -1 * prob * reward obtained
-        for log_prob, delta in zip(self.probs, deltas):
-            loss += log_prob.mean() * delta * (-1)
-
+    
+        log_probs = torch.stack(self.probs)
+    
+        # Calculate the mean of log probabilities for all actions in the episode
+        log_prob_mean = log_probs.mean()
+    
+        # Update the loss with the mean log probability and deltas
+        loss = -log_prob_mean * deltas.mean()
+    
         # Update the policy network
         self.optimizer.zero_grad()
         loss.backward()
         self.optimizer.step()
-
+    
         # Empty / zero out all episode-centric/related variables
         self.probs = []
         self.rewards = []


### PR DESCRIPTION
Can we calculate the mean of log probabilities outside the loop and use the `torch.stack` function, to avoid redundant computations and make the update step more efficient? This should improve the performance of the update function and speed up the training process.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
