### PR TITLE
refactor: EzPickle -> @ezpickle :recycle:

### DIFF
--- a/docs/tutorials/training_agents/reinforce_invpend_gym_v26.py
+++ b/docs/tutorials/training_agents/reinforce_invpend_gym_v26.py
@@ -193,32 +193,31 @@ class REINFORCE:
         """Updates the policy network's weights."""
         running_g = 0
         gs = []
-    
+
         # Discounted return (backwards) - [::-1] will return an array in reverse
         for R in self.rewards[::-1]:
             running_g = R + self.gamma * running_g
             gs.insert(0, running_g)
-    
+
         deltas = torch.tensor(gs)
-    
+
         log_probs = torch.stack(self.probs)
-    
+
         # Calculate the mean of log probabilities for all actions in the episode
         log_prob_mean = log_probs.mean()
-    
+
         # Update the loss with the mean log probability and deltas
         # Now, we compute the correct total loss by taking the sum of the element-wise products.
         loss = -torch.sum(log_prob_mean * deltas)
-    
+
         # Update the policy network
         self.optimizer.zero_grad()
         loss.backward()
         self.optimizer.step()
-    
+
         # Empty / zero out all episode-centric/related variables
         self.probs = []
         self.rewards = []
-
 
 
 # %%

--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -321,7 +321,7 @@ class Wrapper(
 
     @property
     def spec(self) -> EnvSpec | None:
-        """Returns the :attr:`Env` :attr:`spec` attribute with the `WrapperSpec` if the wrapper inherits from `EzPickle`."""
+        """Returns the :attr:`Env` :attr:`spec` attribute with the `WrapperSpec` if the wrapper is decorated with `@ezpickle`."""
         if self._cached_spec is not None:
             return self._cached_spec
 

--- a/gymnasium/envs/box2d/bipedal_walker.py
+++ b/gymnasium/envs/box2d/bipedal_walker.py
@@ -12,7 +12,7 @@ import gymnasium as gym
 from gymnasium import error, spaces
 from gymnasium.core import ActType, ObsType, RenderFrame
 from gymnasium.error import DependencyNotInstalled
-from gymnasium.utils import EzPickle
+from gymnasium.utils import ezpickle
 
 
 try:
@@ -105,7 +105,7 @@ class ContactDetector(contactListener):
                 leg.ground_contact = False
 
 
-class BipedalWalker(gym.Env, EzPickle):
+class BipedalWalker(gym.Env):
     """
     ## Description
     This is a simple 4-joint walker robot environment.
@@ -174,8 +174,8 @@ class BipedalWalker(gym.Env, EzPickle):
         "render_fps": FPS,
     }
 
+    @ezpickle
     def __init__(self, render_mode: str | None = None, hardcore: bool = False):
-        EzPickle.__init__(self, render_mode, hardcore)
         self.isopen = True
 
         self.world = Box2D.b2World()

--- a/gymnasium/envs/box2d/car_racing.py
+++ b/gymnasium/envs/box2d/car_racing.py
@@ -13,7 +13,7 @@ from gymnasium import spaces
 from gymnasium.core import ActType, ObsType, RenderFrame
 from gymnasium.envs.box2d.car_dynamics import Car
 from gymnasium.error import DependencyNotInstalled, InvalidAction
-from gymnasium.utils import EzPickle
+from gymnasium.utils import ezpickle
 
 
 try:
@@ -109,7 +109,7 @@ class FrictionDetector(contactListener):
             obj.tiles.remove(tile)
 
 
-class CarRacing(gym.Env, EzPickle):
+class CarRacing(gym.Env):
     """
     ## Description
     The easiest control task to learn from pixels - a top-down
@@ -205,6 +205,7 @@ class CarRacing(gym.Env, EzPickle):
         "render_fps": FPS,
     }
 
+    @ezpickle
     def __init__(
         self,
         render_mode: str | None = None,
@@ -213,14 +214,6 @@ class CarRacing(gym.Env, EzPickle):
         domain_randomize: bool = False,
         continuous: bool = True,
     ):
-        EzPickle.__init__(
-            self,
-            render_mode,
-            verbose,
-            lap_complete_percent,
-            domain_randomize,
-            continuous,
-        )
         self.continuous = continuous
         self.domain_randomize = domain_randomize
         self.lap_complete_percent = lap_complete_percent

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -13,7 +13,7 @@ import gymnasium as gym
 from gymnasium import error, spaces
 from gymnasium.core import ActType, ObsType, RenderFrame
 from gymnasium.error import DependencyNotInstalled
-from gymnasium.utils import EzPickle, colorize
+from gymnasium.utils import colorize, ezpickle
 from gymnasium.utils.step_api_compatibility import step_api_compatibility
 
 
@@ -82,7 +82,7 @@ class ContactDetector(contactListener):
                 self.env.legs[i].ground_contact = False
 
 
-class LunarLander(gym.Env, EzPickle):
+class LunarLander(gym.Env):
     """
     ## Description
     This environment is a classic rocket trajectory optimization problem.
@@ -229,6 +229,7 @@ class LunarLander(gym.Env, EzPickle):
         "render_fps": FPS,
     }
 
+    @ezpickle
     def __init__(
         self,
         render_mode: str | None = None,
@@ -238,16 +239,6 @@ class LunarLander(gym.Env, EzPickle):
         wind_power: float = 15.0,
         turbulence_power: float = 1.5,
     ):
-        EzPickle.__init__(
-            self,
-            render_mode,
-            continuous,
-            gravity,
-            enable_wind,
-            wind_power,
-            turbulence_power,
-        )
-
         assert (
             -12.0 < gravity and gravity < 0.0
         ), f"gravity (current value: {gravity}) must be between -12 and 0"

--- a/gymnasium/envs/mujoco/ant.py
+++ b/gymnasium/envs/mujoco/ant.py
@@ -4,13 +4,13 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
-class AntEnv(MuJocoPyEnv, utils.EzPickle):
+class AntEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -20,6 +20,7 @@ class AntEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 20,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
         observation_space = Box(
             low=-np.inf, high=np.inf, shape=(111,), dtype=np.float64
@@ -27,7 +28,6 @@ class AntEnv(MuJocoPyEnv, utils.EzPickle):
         MuJocoPyEnv.__init__(
             self, "ant.xml", 5, observation_space=observation_space, **kwargs
         )
-        utils.EzPickle.__init__(self, **kwargs)
 
     def step(
         self, action: ActType

--- a/gymnasium/envs/mujoco/ant_v3.py
+++ b/gymnasium/envs/mujoco/ant_v3.py
@@ -4,10 +4,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -15,7 +15,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class AntEnv(MuJocoPyEnv, utils.EzPickle):
+class AntEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -25,6 +25,7 @@ class AntEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 20,
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file="ant.xml",
@@ -38,20 +39,6 @@ class AntEnv(MuJocoPyEnv, utils.EzPickle):
         exclude_current_positions_from_observation=True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            ctrl_cost_weight,
-            contact_cost_weight,
-            healthy_reward,
-            terminate_when_unhealthy,
-            healthy_z_range,
-            contact_force_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._ctrl_cost_weight = ctrl_cost_weight
         self._contact_cost_weight = contact_cost_weight
 

--- a/gymnasium/envs/mujoco/ant_v4.py
+++ b/gymnasium/envs/mujoco/ant_v4.py
@@ -4,10 +4,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -15,7 +15,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class AntEnv(MujocoEnv, utils.EzPickle):
+class AntEnv(MujocoEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -25,6 +25,7 @@ class AntEnv(MujocoEnv, utils.EzPickle):
         "render_fps": 20,
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file="ant.xml",
@@ -39,21 +40,6 @@ class AntEnv(MujocoEnv, utils.EzPickle):
         exclude_current_positions_from_observation=True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            ctrl_cost_weight,
-            use_contact_forces,
-            contact_cost_weight,
-            healthy_reward,
-            terminate_when_unhealthy,
-            healthy_z_range,
-            contact_force_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._ctrl_cost_weight = ctrl_cost_weight
         self._contact_cost_weight = contact_cost_weight
 

--- a/gymnasium/envs/mujoco/ant_v5.py
+++ b/gymnasium/envs/mujoco/ant_v5.py
@@ -7,10 +7,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -18,7 +18,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class AntEnv(MujocoEnv, utils.EzPickle):
+class AntEnv(MujocoEnv):
     r"""
     ## Description
     This environment is based on the environment introduced by Schulman,
@@ -244,6 +244,7 @@ class AntEnv(MujocoEnv, utils.EzPickle):
         ],
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file: str = "ant.xml",
@@ -262,25 +263,6 @@ class AntEnv(MujocoEnv, utils.EzPickle):
         include_cfrc_ext_in_observation: bool = True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            frame_skip,
-            default_camera_config,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            contact_cost_weight,
-            healthy_reward,
-            main_body,
-            terminate_when_unhealthy,
-            healthy_z_range,
-            contact_force_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            include_cfrc_ext_in_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
         self._ctrl_cost_weight = ctrl_cost_weight
         self._contact_cost_weight = contact_cost_weight

--- a/gymnasium/envs/mujoco/half_cheetah.py
+++ b/gymnasium/envs/mujoco/half_cheetah.py
@@ -4,13 +4,13 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
-class HalfCheetahEnv(MuJocoPyEnv, utils.EzPickle):
+class HalfCheetahEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -20,12 +20,12 @@ class HalfCheetahEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 20,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
         observation_space = Box(low=-np.inf, high=np.inf, shape=(17,), dtype=np.float64)
         MuJocoPyEnv.__init__(
             self, "half_cheetah.xml", 5, observation_space=observation_space, **kwargs
         )
-        utils.EzPickle.__init__(self, **kwargs)
 
     def step(
         self, action: ActType

--- a/gymnasium/envs/mujoco/half_cheetah_v3.py
+++ b/gymnasium/envs/mujoco/half_cheetah_v3.py
@@ -7,10 +7,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -18,7 +18,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class HalfCheetahEnv(MuJocoPyEnv, utils.EzPickle):
+class HalfCheetahEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -28,6 +28,7 @@ class HalfCheetahEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 20,
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file="half_cheetah.xml",
@@ -37,16 +38,6 @@ class HalfCheetahEnv(MuJocoPyEnv, utils.EzPickle):
         exclude_current_positions_from_observation=True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
 
         self._ctrl_cost_weight = ctrl_cost_weight

--- a/gymnasium/envs/mujoco/half_cheetah_v4.py
+++ b/gymnasium/envs/mujoco/half_cheetah_v4.py
@@ -7,10 +7,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -18,7 +18,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class HalfCheetahEnv(MujocoEnv, utils.EzPickle):
+class HalfCheetahEnv(MujocoEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -28,6 +28,7 @@ class HalfCheetahEnv(MujocoEnv, utils.EzPickle):
         "render_fps": 20,
     }
 
+    @ezpickle
     def __init__(
         self,
         forward_reward_weight=1.0,
@@ -36,15 +37,6 @@ class HalfCheetahEnv(MujocoEnv, utils.EzPickle):
         exclude_current_positions_from_observation=True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
 
         self._ctrl_cost_weight = ctrl_cost_weight

--- a/gymnasium/envs/mujoco/half_cheetah_v5.py
+++ b/gymnasium/envs/mujoco/half_cheetah_v5.py
@@ -7,10 +7,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -18,7 +18,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class HalfCheetahEnv(MujocoEnv, utils.EzPickle):
+class HalfCheetahEnv(MujocoEnv):
     r"""
     ## Description
     This environment is based on the work by P. Wawrzyński in
@@ -169,6 +169,7 @@ class HalfCheetahEnv(MujocoEnv, utils.EzPickle):
         ],
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file: str = "half_cheetah.xml",
@@ -180,18 +181,6 @@ class HalfCheetahEnv(MujocoEnv, utils.EzPickle):
         exclude_current_positions_from_observation: bool = True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            frame_skip,
-            default_camera_config,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
         self._ctrl_cost_weight = ctrl_cost_weight
 

--- a/gymnasium/envs/mujoco/hopper.py
+++ b/gymnasium/envs/mujoco/hopper.py
@@ -4,13 +4,13 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
-class HopperEnv(MuJocoPyEnv, utils.EzPickle):
+class HopperEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -20,12 +20,12 @@ class HopperEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 125,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
         observation_space = Box(low=-np.inf, high=np.inf, shape=(11,), dtype=np.float64)
         MuJocoPyEnv.__init__(
             self, "hopper.xml", 4, observation_space=observation_space, **kwargs
         )
-        utils.EzPickle.__init__(self, **kwargs)
 
     def step(
         self, action: ActType

--- a/gymnasium/envs/mujoco/hopper_v3.py
+++ b/gymnasium/envs/mujoco/hopper_v3.py
@@ -7,10 +7,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -21,7 +21,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class HopperEnv(MuJocoPyEnv, utils.EzPickle):
+class HopperEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -31,6 +31,7 @@ class HopperEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 125,
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file="hopper.xml",
@@ -45,21 +46,6 @@ class HopperEnv(MuJocoPyEnv, utils.EzPickle):
         exclude_current_positions_from_observation=True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            healthy_reward,
-            terminate_when_unhealthy,
-            healthy_state_range,
-            healthy_z_range,
-            healthy_angle_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
 
         self._ctrl_cost_weight = ctrl_cost_weight

--- a/gymnasium/envs/mujoco/hopper_v4.py
+++ b/gymnasium/envs/mujoco/hopper_v4.py
@@ -4,10 +4,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -18,7 +18,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class HopperEnv(MujocoEnv, utils.EzPickle):
+class HopperEnv(MujocoEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -28,6 +28,7 @@ class HopperEnv(MujocoEnv, utils.EzPickle):
         "render_fps": 125,
     }
 
+    @ezpickle
     def __init__(
         self,
         forward_reward_weight=1.0,
@@ -41,20 +42,6 @@ class HopperEnv(MujocoEnv, utils.EzPickle):
         exclude_current_positions_from_observation=True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            healthy_reward,
-            terminate_when_unhealthy,
-            healthy_state_range,
-            healthy_z_range,
-            healthy_angle_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
 
         self._ctrl_cost_weight = ctrl_cost_weight

--- a/gymnasium/envs/mujoco/hopper_v5.py
+++ b/gymnasium/envs/mujoco/hopper_v5.py
@@ -8,10 +8,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -22,7 +22,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class HopperEnv(MujocoEnv, utils.EzPickle):
+class HopperEnv(MujocoEnv):
     r"""
     ## Description
     This environment is based on the work done by Erez, Tassa, and Todorov in
@@ -187,6 +187,7 @@ class HopperEnv(MujocoEnv, utils.EzPickle):
         ],
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file: str = "hopper.xml",
@@ -203,23 +204,6 @@ class HopperEnv(MujocoEnv, utils.EzPickle):
         exclude_current_positions_from_observation: bool = True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            frame_skip,
-            default_camera_config,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            healthy_reward,
-            terminate_when_unhealthy,
-            healthy_state_range,
-            healthy_z_range,
-            healthy_angle_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
 
         self._ctrl_cost_weight = ctrl_cost_weight

--- a/gymnasium/envs/mujoco/humanoid.py
+++ b/gymnasium/envs/mujoco/humanoid.py
@@ -4,10 +4,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 def mass_center(model, sim):
@@ -16,7 +16,7 @@ def mass_center(model, sim):
     return (np.sum(mass * xpos, 0) / np.sum(mass))[0]
 
 
-class HumanoidEnv(MuJocoPyEnv, utils.EzPickle):
+class HumanoidEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -26,6 +26,7 @@ class HumanoidEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 67,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
         observation_space = Box(
             low=-np.inf, high=np.inf, shape=(376,), dtype=np.float64
@@ -33,7 +34,6 @@ class HumanoidEnv(MuJocoPyEnv, utils.EzPickle):
         MuJocoPyEnv.__init__(
             self, "humanoid.xml", 5, observation_space=observation_space, **kwargs
         )
-        utils.EzPickle.__init__(self, **kwargs)
 
     def _get_obs(self):
         data = self.sim.data

--- a/gymnasium/envs/mujoco/humanoid_v3.py
+++ b/gymnasium/envs/mujoco/humanoid_v3.py
@@ -4,10 +4,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -24,7 +24,7 @@ def mass_center(model, sim):
     return (np.sum(mass * xpos, axis=0) / np.sum(mass))[0:2].copy()
 
 
-class HumanoidEnv(MuJocoPyEnv, utils.EzPickle):
+class HumanoidEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -34,6 +34,7 @@ class HumanoidEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 67,
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file="humanoid.xml",
@@ -48,21 +49,6 @@ class HumanoidEnv(MuJocoPyEnv, utils.EzPickle):
         exclude_current_positions_from_observation=True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            contact_cost_weight,
-            contact_cost_range,
-            healthy_reward,
-            terminate_when_unhealthy,
-            healthy_z_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
         self._ctrl_cost_weight = ctrl_cost_weight
         self._contact_cost_weight = contact_cost_weight

--- a/gymnasium/envs/mujoco/humanoid_v4.py
+++ b/gymnasium/envs/mujoco/humanoid_v4.py
@@ -4,10 +4,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -24,7 +24,7 @@ def mass_center(model, data):
     return (np.sum(mass * xpos, axis=0) / np.sum(mass))[0:2].copy()
 
 
-class HumanoidEnv(MujocoEnv, utils.EzPickle):
+class HumanoidEnv(MujocoEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -34,6 +34,7 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
         "render_fps": 67,
     }
 
+    @ezpickle
     def __init__(
         self,
         forward_reward_weight=1.25,
@@ -45,18 +46,6 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
         exclude_current_positions_from_observation=True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            healthy_reward,
-            terminate_when_unhealthy,
-            healthy_z_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
         self._ctrl_cost_weight = ctrl_cost_weight
         self._healthy_reward = healthy_reward

--- a/gymnasium/envs/mujoco/humanoid_v5.py
+++ b/gymnasium/envs/mujoco/humanoid_v5.py
@@ -8,10 +8,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -28,7 +28,7 @@ def mass_center(model, data):
     return (np.sum(mass * xpos, axis=0) / np.sum(mass))[0:2].copy()
 
 
-class HumanoidEnv(MujocoEnv, utils.EzPickle):
+class HumanoidEnv(MujocoEnv):
     r"""
     ## Description
     This environment is based on the environment introduced by Tassa, Erez and Todorov
@@ -321,6 +321,7 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
         ],
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file: str = "humanoid.xml",
@@ -341,27 +342,6 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
         include_cfrc_ext_in_observation: bool = True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            frame_skip,
-            default_camera_config,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            contact_cost_weight,
-            contact_cost_range,
-            healthy_reward,
-            terminate_when_unhealthy,
-            healthy_z_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            include_cinert_in_observation,
-            include_cvel_in_observation,
-            include_qfrc_actuator_in_observation,
-            include_cfrc_ext_in_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
         self._ctrl_cost_weight = ctrl_cost_weight
         self._contact_cost_weight = contact_cost_weight

--- a/gymnasium/envs/mujoco/humanoidstandup.py
+++ b/gymnasium/envs/mujoco/humanoidstandup.py
@@ -4,13 +4,13 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
-class HumanoidStandupEnv(MuJocoPyEnv, utils.EzPickle):
+class HumanoidStandupEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -20,6 +20,7 @@ class HumanoidStandupEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 67,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
         observation_space = Box(
             low=-np.inf, high=np.inf, shape=(376,), dtype=np.float64
@@ -31,7 +32,6 @@ class HumanoidStandupEnv(MuJocoPyEnv, utils.EzPickle):
             observation_space=observation_space,
             **kwargs,
         )
-        utils.EzPickle.__init__(self, **kwargs)
 
     def _get_obs(self):
         data = self.sim.data

--- a/gymnasium/envs/mujoco/humanoidstandup_v4.py
+++ b/gymnasium/envs/mujoco/humanoidstandup_v4.py
@@ -4,10 +4,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -18,7 +18,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
+class HumanoidStandupEnv(MujocoEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -28,6 +28,7 @@ class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
         "render_fps": 67,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
         observation_space = Box(
             low=-np.inf, high=np.inf, shape=(376,), dtype=np.float64
@@ -40,7 +41,6 @@ class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
             default_camera_config=DEFAULT_CAMERA_CONFIG,
             **kwargs,
         )
-        utils.EzPickle.__init__(self, **kwargs)
 
     def _get_obs(self):
         data = self.data

--- a/gymnasium/envs/mujoco/humanoidstandup_v5.py
+++ b/gymnasium/envs/mujoco/humanoidstandup_v5.py
@@ -8,10 +8,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -22,7 +22,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
+class HumanoidStandupEnv(MujocoEnv):
     r"""
     ## Description
     This environment is based on the environment introduced by Tassa, Erez and Todorov
@@ -304,6 +304,7 @@ class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
         ],
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file: str = "humanoidstandup.xml",
@@ -321,24 +322,6 @@ class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
         include_cfrc_ext_in_observation: bool = True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            frame_skip,
-            default_camera_config,
-            uph_cost_weight,
-            ctrl_cost_weight,
-            impact_cost_weight,
-            impact_cost_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            include_cinert_in_observation,
-            include_cvel_in_observation,
-            include_qfrc_actuator_in_observation,
-            include_cfrc_ext_in_observation,
-            **kwargs,
-        )
-
         self._uph_cost_weight = uph_cost_weight
         self._ctrl_cost_weight = ctrl_cost_weight
         self._impact_cost_weight = impact_cost_weight

--- a/gymnasium/envs/mujoco/inverted_double_pendulum.py
+++ b/gymnasium/envs/mujoco/inverted_double_pendulum.py
@@ -4,13 +4,13 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
-class InvertedDoublePendulumEnv(MuJocoPyEnv, utils.EzPickle):
+class InvertedDoublePendulumEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -20,6 +20,7 @@ class InvertedDoublePendulumEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 20,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
         observation_space = Box(low=-np.inf, high=np.inf, shape=(11,), dtype=np.float64)
         MuJocoPyEnv.__init__(
@@ -29,7 +30,6 @@ class InvertedDoublePendulumEnv(MuJocoPyEnv, utils.EzPickle):
             observation_space=observation_space,
             **kwargs,
         )
-        utils.EzPickle.__init__(self, **kwargs)
 
     def step(
         self, action: ActType

--- a/gymnasium/envs/mujoco/inverted_double_pendulum_v4.py
+++ b/gymnasium/envs/mujoco/inverted_double_pendulum_v4.py
@@ -4,10 +4,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -17,7 +17,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class InvertedDoublePendulumEnv(MujocoEnv, utils.EzPickle):
+class InvertedDoublePendulumEnv(MujocoEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -27,6 +27,7 @@ class InvertedDoublePendulumEnv(MujocoEnv, utils.EzPickle):
         "render_fps": 20,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
         observation_space = Box(low=-np.inf, high=np.inf, shape=(11,), dtype=np.float64)
         MujocoEnv.__init__(
@@ -37,7 +38,6 @@ class InvertedDoublePendulumEnv(MujocoEnv, utils.EzPickle):
             default_camera_config=DEFAULT_CAMERA_CONFIG,
             **kwargs,
         )
-        utils.EzPickle.__init__(self, **kwargs)
 
     def step(
         self, action: ActType

--- a/gymnasium/envs/mujoco/inverted_double_pendulum_v5.py
+++ b/gymnasium/envs/mujoco/inverted_double_pendulum_v5.py
@@ -7,10 +7,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -20,7 +20,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class InvertedDoublePendulumEnv(MujocoEnv, utils.EzPickle):
+class InvertedDoublePendulumEnv(MujocoEnv):
     r"""
     ## Description
     This environment originates from control theory and builds on the cartpole
@@ -164,6 +164,7 @@ class InvertedDoublePendulumEnv(MujocoEnv, utils.EzPickle):
         ],
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file: str = "inverted_double_pendulum.xml",
@@ -172,8 +173,6 @@ class InvertedDoublePendulumEnv(MujocoEnv, utils.EzPickle):
         reset_noise_scale: float = 0.1,
         **kwargs,
     ):
-        utils.EzPickle.__init__(self, xml_file, frame_skip, reset_noise_scale, **kwargs)
-
         self._healthy_reward = healthy_reward
         self._reset_noise_scale = reset_noise_scale
 

--- a/gymnasium/envs/mujoco/inverted_pendulum.py
+++ b/gymnasium/envs/mujoco/inverted_pendulum.py
@@ -4,13 +4,13 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
-class InvertedPendulumEnv(MuJocoPyEnv, utils.EzPickle):
+class InvertedPendulumEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -20,8 +20,8 @@ class InvertedPendulumEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 25,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
-        utils.EzPickle.__init__(self, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(4,), dtype=np.float64)
         MuJocoPyEnv.__init__(
             self,

--- a/gymnasium/envs/mujoco/inverted_pendulum_v4.py
+++ b/gymnasium/envs/mujoco/inverted_pendulum_v4.py
@@ -4,10 +4,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -16,7 +16,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class InvertedPendulumEnv(MujocoEnv, utils.EzPickle):
+class InvertedPendulumEnv(MujocoEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -26,8 +26,8 @@ class InvertedPendulumEnv(MujocoEnv, utils.EzPickle):
         "render_fps": 25,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
-        utils.EzPickle.__init__(self, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(4,), dtype=np.float64)
         MujocoEnv.__init__(
             self,

--- a/gymnasium/envs/mujoco/inverted_pendulum_v5.py
+++ b/gymnasium/envs/mujoco/inverted_pendulum_v5.py
@@ -7,10 +7,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -19,7 +19,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class InvertedPendulumEnv(MujocoEnv, utils.EzPickle):
+class InvertedPendulumEnv(MujocoEnv):
     """
     ## Description
     This environment is the cartpole environment based on the work done by
@@ -142,6 +142,7 @@ class InvertedPendulumEnv(MujocoEnv, utils.EzPickle):
         ],
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file: str = "inverted_pendulum.xml",
@@ -149,7 +150,6 @@ class InvertedPendulumEnv(MujocoEnv, utils.EzPickle):
         reset_noise_scale: float = 0.01,
         **kwargs,
     ):
-        utils.EzPickle.__init__(self, xml_file, frame_skip, reset_noise_scale, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(4,), dtype=np.float64)
 
         self._reset_noise_scale = reset_noise_scale

--- a/gymnasium/envs/mujoco/pusher.py
+++ b/gymnasium/envs/mujoco/pusher.py
@@ -4,13 +4,13 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
-class PusherEnv(MuJocoPyEnv, utils.EzPickle):
+class PusherEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -20,8 +20,8 @@ class PusherEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 20,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
-        utils.EzPickle.__init__(self, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(23,), dtype=np.float64)
         MuJocoPyEnv.__init__(
             self, "pusher.xml", 5, observation_space=observation_space, **kwargs

--- a/gymnasium/envs/mujoco/pusher_v4.py
+++ b/gymnasium/envs/mujoco/pusher_v4.py
@@ -4,10 +4,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -16,7 +16,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class PusherEnv(MujocoEnv, utils.EzPickle):
+class PusherEnv(MujocoEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -26,8 +26,8 @@ class PusherEnv(MujocoEnv, utils.EzPickle):
         "render_fps": 20,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
-        utils.EzPickle.__init__(self, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(23,), dtype=np.float64)
         MujocoEnv.__init__(
             self,

--- a/gymnasium/envs/mujoco/pusher_v5.py
+++ b/gymnasium/envs/mujoco/pusher_v5.py
@@ -8,10 +8,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -20,7 +20,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class PusherEnv(MujocoEnv, utils.EzPickle):
+class PusherEnv(MujocoEnv):
     r"""
     ## Description
     "Pusher" is a multi-jointed robot arm which is very similar to that of a human.
@@ -176,6 +176,7 @@ class PusherEnv(MujocoEnv, utils.EzPickle):
         ],
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file: str = "pusher.xml",
@@ -186,16 +187,6 @@ class PusherEnv(MujocoEnv, utils.EzPickle):
         reward_control_weight: float = 0.1,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            frame_skip,
-            default_camera_config,
-            reward_near_weight,
-            reward_dist_weight,
-            reward_control_weight,
-            **kwargs,
-        )
         self._reward_near_weight = reward_near_weight
         self._reward_dist_weight = reward_dist_weight
         self._reward_control_weight = reward_control_weight

--- a/gymnasium/envs/mujoco/reacher.py
+++ b/gymnasium/envs/mujoco/reacher.py
@@ -4,13 +4,13 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
-class ReacherEnv(MuJocoPyEnv, utils.EzPickle):
+class ReacherEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -20,8 +20,8 @@ class ReacherEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 50,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
-        utils.EzPickle.__init__(self, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(11,), dtype=np.float64)
         MuJocoPyEnv.__init__(
             self, "reacher.xml", 2, observation_space=observation_space, **kwargs

--- a/gymnasium/envs/mujoco/reacher_v4.py
+++ b/gymnasium/envs/mujoco/reacher_v4.py
@@ -4,16 +4,16 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {"trackbodyid": 0}
 
 
-class ReacherEnv(MujocoEnv, utils.EzPickle):
+class ReacherEnv(MujocoEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -23,8 +23,8 @@ class ReacherEnv(MujocoEnv, utils.EzPickle):
         "render_fps": 50,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
-        utils.EzPickle.__init__(self, **kwargs)
         observation_space = Box(low=-np.inf, high=np.inf, shape=(11,), dtype=np.float64)
         MujocoEnv.__init__(
             self,

--- a/gymnasium/envs/mujoco/reacher_v5.py
+++ b/gymnasium/envs/mujoco/reacher_v5.py
@@ -8,16 +8,16 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {"trackbodyid": 0}
 
 
-class ReacherEnv(MujocoEnv, utils.EzPickle):
+class ReacherEnv(MujocoEnv):
     r"""
     ## Description
     "Reacher" is a two-jointed robot arm. The goal is to move the robot's end effector (called *fingertip*) close to a
@@ -155,6 +155,7 @@ class ReacherEnv(MujocoEnv, utils.EzPickle):
         ],
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file: str = "reacher.xml",
@@ -164,16 +165,6 @@ class ReacherEnv(MujocoEnv, utils.EzPickle):
         reward_control_weight: float = 1,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            frame_skip,
-            default_camera_config,
-            reward_dist_weight,
-            reward_control_weight,
-            **kwargs,
-        )
-
         self._reward_dist_weight = reward_dist_weight
         self._reward_control_weight = reward_control_weight
 

--- a/gymnasium/envs/mujoco/swimmer.py
+++ b/gymnasium/envs/mujoco/swimmer.py
@@ -4,13 +4,13 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
-class SwimmerEnv(MuJocoPyEnv, utils.EzPickle):
+class SwimmerEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -20,12 +20,12 @@ class SwimmerEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 25,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
         observation_space = Box(low=-np.inf, high=np.inf, shape=(8,), dtype=np.float64)
         MuJocoPyEnv.__init__(
             self, "swimmer.xml", 4, observation_space=observation_space, **kwargs
         )
-        utils.EzPickle.__init__(self, **kwargs)
 
     def step(
         self, action: ActType

--- a/gymnasium/envs/mujoco/swimmer_v3.py
+++ b/gymnasium/envs/mujoco/swimmer_v3.py
@@ -7,16 +7,16 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {}
 
 
-class SwimmerEnv(MuJocoPyEnv, utils.EzPickle):
+class SwimmerEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -26,6 +26,7 @@ class SwimmerEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 25,
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file="swimmer.xml",
@@ -35,16 +36,6 @@ class SwimmerEnv(MuJocoPyEnv, utils.EzPickle):
         exclude_current_positions_from_observation=True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
         self._ctrl_cost_weight = ctrl_cost_weight
 

--- a/gymnasium/envs/mujoco/swimmer_v4.py
+++ b/gymnasium/envs/mujoco/swimmer_v4.py
@@ -7,13 +7,13 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
-class SwimmerEnv(MujocoEnv, utils.EzPickle):
+class SwimmerEnv(MujocoEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -23,6 +23,7 @@ class SwimmerEnv(MujocoEnv, utils.EzPickle):
         "render_fps": 25,
     }
 
+    @ezpickle
     def __init__(
         self,
         forward_reward_weight=1.0,
@@ -31,15 +32,6 @@ class SwimmerEnv(MujocoEnv, utils.EzPickle):
         exclude_current_positions_from_observation=True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
         self._ctrl_cost_weight = ctrl_cost_weight
 

--- a/gymnasium/envs/mujoco/swimmer_v5.py
+++ b/gymnasium/envs/mujoco/swimmer_v5.py
@@ -7,13 +7,13 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
-class SwimmerEnv(MujocoEnv, utils.EzPickle):
+class SwimmerEnv(MujocoEnv):
     r"""
     ## Description
     This environment corresponds to the Swimmer environment described in Rémi Coulom's PhD thesis
@@ -167,6 +167,7 @@ class SwimmerEnv(MujocoEnv, utils.EzPickle):
         ],
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file: str = "swimmer.xml",
@@ -177,17 +178,6 @@ class SwimmerEnv(MujocoEnv, utils.EzPickle):
         exclude_current_positions_from_observation: bool = True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            frame_skip,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
         self._ctrl_cost_weight = ctrl_cost_weight
 

--- a/gymnasium/envs/mujoco/walker2d.py
+++ b/gymnasium/envs/mujoco/walker2d.py
@@ -4,13 +4,13 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
-class Walker2dEnv(MuJocoPyEnv, utils.EzPickle):
+class Walker2dEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -20,12 +20,12 @@ class Walker2dEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 125,
     }
 
+    @ezpickle
     def __init__(self, **kwargs):
         observation_space = Box(low=-np.inf, high=np.inf, shape=(17,), dtype=np.float64)
         MuJocoPyEnv.__init__(
             self, "walker2d.xml", 4, observation_space=observation_space, **kwargs
         )
-        utils.EzPickle.__init__(self, **kwargs)
 
     def step(
         self, action: ActType

--- a/gymnasium/envs/mujoco/walker2d_v3.py
+++ b/gymnasium/envs/mujoco/walker2d_v3.py
@@ -4,10 +4,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MuJocoPyEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -18,7 +18,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class Walker2dEnv(MuJocoPyEnv, utils.EzPickle):
+class Walker2dEnv(MuJocoPyEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -28,6 +28,7 @@ class Walker2dEnv(MuJocoPyEnv, utils.EzPickle):
         "render_fps": 125,
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file="walker2d.xml",
@@ -41,20 +42,6 @@ class Walker2dEnv(MuJocoPyEnv, utils.EzPickle):
         exclude_current_positions_from_observation=True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            healthy_reward,
-            terminate_when_unhealthy,
-            healthy_z_range,
-            healthy_angle_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
         self._ctrl_cost_weight = ctrl_cost_weight
 

--- a/gymnasium/envs/mujoco/walker2d_v4.py
+++ b/gymnasium/envs/mujoco/walker2d_v4.py
@@ -4,10 +4,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -18,7 +18,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class Walker2dEnv(MujocoEnv, utils.EzPickle):
+class Walker2dEnv(MujocoEnv):
     metadata = {
         "render_modes": [
             "human",
@@ -28,6 +28,7 @@ class Walker2dEnv(MujocoEnv, utils.EzPickle):
         "render_fps": 125,
     }
 
+    @ezpickle
     def __init__(
         self,
         forward_reward_weight=1.0,
@@ -40,19 +41,6 @@ class Walker2dEnv(MujocoEnv, utils.EzPickle):
         exclude_current_positions_from_observation=True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            healthy_reward,
-            terminate_when_unhealthy,
-            healthy_z_range,
-            healthy_angle_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
         self._ctrl_cost_weight = ctrl_cost_weight
 

--- a/gymnasium/envs/mujoco/walker2d_v5.py
+++ b/gymnasium/envs/mujoco/walker2d_v5.py
@@ -8,10 +8,10 @@ from typing import Any, SupportsFloat
 
 import numpy as np
 
-from gymnasium import utils
 from gymnasium.core import ActType, ObsType
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 
 
 DEFAULT_CAMERA_CONFIG = {
@@ -22,7 +22,7 @@ DEFAULT_CAMERA_CONFIG = {
 }
 
 
-class Walker2dEnv(MujocoEnv, utils.EzPickle):
+class Walker2dEnv(MujocoEnv):
     r"""
     ## Description
     This environment builds on the [hopper](https://gymnasium.farama.org/environments/mujoco/hopper/) environment
@@ -189,6 +189,7 @@ class Walker2dEnv(MujocoEnv, utils.EzPickle):
         ],
     }
 
+    @ezpickle
     def __init__(
         self,
         xml_file: str = "walker2d_v5.xml",
@@ -204,22 +205,6 @@ class Walker2dEnv(MujocoEnv, utils.EzPickle):
         exclude_current_positions_from_observation: bool = True,
         **kwargs,
     ):
-        utils.EzPickle.__init__(
-            self,
-            xml_file,
-            frame_skip,
-            default_camera_config,
-            forward_reward_weight,
-            ctrl_cost_weight,
-            healthy_reward,
-            terminate_when_unhealthy,
-            healthy_z_range,
-            healthy_angle_range,
-            reset_noise_scale,
-            exclude_current_positions_from_observation,
-            **kwargs,
-        )
-
         self._forward_reward_weight = forward_reward_weight
         self._ctrl_cost_weight = ctrl_cost_weight
 

--- a/gymnasium/envs/phys2d/cartpole.py
+++ b/gymnasium/envs/phys2d/cartpole.py
@@ -15,7 +15,7 @@ from gymnasium.experimental.functional_jax_env import (
     FunctionalJaxEnv,
     FunctionalJaxVectorEnv,
 )
-from gymnasium.utils import EzPickle
+from gymnasium.utils import ezpickle
 
 
 RenderStateType = Tuple["pygame.Surface", "pygame.time.Clock"]  # type: ignore  # noqa: F821
@@ -259,15 +259,14 @@ class CartPoleFunctional(
         pygame.quit()
 
 
-class CartPoleJaxEnv(FunctionalJaxEnv, EzPickle):
+class CartPoleJaxEnv(FunctionalJaxEnv):
     """Jax-based implementation of the CartPole environment."""
 
     metadata = {"render_modes": ["rgb_array"], "render_fps": 50}
 
+    @ezpickle
     def __init__(self, render_mode: str | None = None, **kwargs: Any):
         """Constructor for the CartPole where the kwargs are applied to the functional environment."""
-        EzPickle.__init__(self, render_mode=render_mode, **kwargs)
-
         env = CartPoleFunctional(**kwargs)
         env.transform(jax.jit)
 
@@ -279,11 +278,12 @@ class CartPoleJaxEnv(FunctionalJaxEnv, EzPickle):
         )
 
 
-class CartPoleJaxVectorEnv(FunctionalJaxVectorEnv, EzPickle):
+class CartPoleJaxVectorEnv(FunctionalJaxVectorEnv):
     """Jax-based implementation of the vectorized CartPole environment."""
 
     metadata = {"render_modes": ["rgb_array"], "render_fps": 50}
 
+    @ezpickle
     def __init__(
         self,
         num_envs: int,
@@ -292,14 +292,6 @@ class CartPoleJaxVectorEnv(FunctionalJaxVectorEnv, EzPickle):
         **kwargs: Any,
     ):
         """Constructor for the vectorized CartPole where the kwargs are applied to the functional environment."""
-        EzPickle.__init__(
-            self,
-            num_envs=num_envs,
-            render_mode=render_mode,
-            max_episode_steps=max_episode_steps,
-            **kwargs,
-        )
-
         env = CartPoleFunctional(**kwargs)
         env.transform(jax.jit)
 

--- a/gymnasium/envs/phys2d/pendulum.py
+++ b/gymnasium/envs/phys2d/pendulum.py
@@ -16,7 +16,7 @@ from gymnasium.experimental.functional_jax_env import (
     FunctionalJaxEnv,
     FunctionalJaxVectorEnv,
 )
-from gymnasium.utils import EzPickle
+from gymnasium.utils import ezpickle
 
 
 RenderStateType = Tuple["pygame.Surface", "pygame.time.Clock", Optional[float]]  # type: ignore  # noqa: F821
@@ -192,15 +192,14 @@ class PendulumFunctional(
         pygame.quit()
 
 
-class PendulumJaxEnv(FunctionalJaxEnv, EzPickle):
+class PendulumJaxEnv(FunctionalJaxEnv):
     """Jax-based pendulum environment using the functional version as base."""
 
     metadata = {"render_modes": ["rgb_array"], "render_fps": 30}
 
+    @ezpickle
     def __init__(self, render_mode: str | None = None, **kwargs: Any):
         """Constructor where the kwargs are passed to the base environment to modify the parameters."""
-        EzPickle.__init__(self, render_mode=render_mode, **kwargs)
-
         env = PendulumFunctional(**kwargs)
         env.transform(jax.jit)
 
@@ -211,11 +210,12 @@ class PendulumJaxEnv(FunctionalJaxEnv, EzPickle):
         )
 
 
-class PendulumJaxVectorEnv(FunctionalJaxVectorEnv, EzPickle):
+class PendulumJaxVectorEnv(FunctionalJaxVectorEnv):
     """Jax-based implementation of the vectorized CartPole environment."""
 
     metadata = {"render_modes": ["rgb_array"], "render_fps": 50}
 
+    @ezpickle
     def __init__(
         self,
         num_envs: int,
@@ -224,14 +224,6 @@ class PendulumJaxVectorEnv(FunctionalJaxVectorEnv, EzPickle):
         **kwargs: Any,
     ):
         """Constructor for the vectorized CartPole where the kwargs are applied to the functional environment."""
-        EzPickle.__init__(
-            self,
-            num_envs=num_envs,
-            render_mode=render_mode,
-            max_episode_steps=max_episode_steps,
-            **kwargs,
-        )
-
         env = PendulumFunctional(**kwargs)
         env.transform(jax.jit)
 

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -68,7 +68,8 @@ class WrapperSpec:
 
     * name: The name of the wrapper.
     * entry_point: The location of the wrapper to create from.
-    * kwargs: Additional keyword arguments passed to the wrapper. If the wrapper doesn't inherit from EzPickle then this is ``None``
+    * kwargs: Additional keyword arguments passed to the wrapper. If the wrapper
+    isn't decorated with `@ezpickle` then this is ``None``
     """
 
     name: str

--- a/gymnasium/envs/tabular/blackjack.py
+++ b/gymnasium/envs/tabular/blackjack.py
@@ -15,7 +15,7 @@ from gymnasium import spaces
 from gymnasium.error import DependencyNotInstalled
 from gymnasium.experimental.functional import ActType, FuncEnv, StateType
 from gymnasium.experimental.functional_jax_env import FunctionalJaxEnv
-from gymnasium.utils import EzPickle, seeding
+from gymnasium.utils import ezpickle, seeding
 from gymnasium.wrappers import HumanRendering
 
 
@@ -473,14 +473,14 @@ class BlackjackFunctional(
         pygame.quit()
 
 
-class BlackJackJaxEnv(FunctionalJaxEnv, EzPickle):
+class BlackJackJaxEnv(FunctionalJaxEnv):
     """A Gymnasium Env wrapper for the functional blackjack env."""
 
     metadata = {"render_modes": ["rgb_array"], "render_fps": 50}
 
+    @ezpickle
     def __init__(self, render_mode: Optional[str] = None, **kwargs):
         """Initializes Gym wrapper for blackjack functional env."""
-        EzPickle.__init__(self, render_mode=render_mode, **kwargs)
         env = BlackjackFunctional(**kwargs)
         env.transform(jax.jit)
 

--- a/gymnasium/envs/tabular/cliffwalking.py
+++ b/gymnasium/envs/tabular/cliffwalking.py
@@ -15,7 +15,7 @@ from gymnasium import spaces
 from gymnasium.error import DependencyNotInstalled
 from gymnasium.experimental.functional import ActType, FuncEnv, StateType
 from gymnasium.experimental.functional_jax_env import FunctionalJaxEnv
-from gymnasium.utils import EzPickle
+from gymnasium.utils import ezpickle
 from gymnasium.wrappers import HumanRendering
 
 
@@ -347,14 +347,14 @@ class CliffWalkingFunctional(
         pygame.quit()
 
 
-class CliffWalkingJaxEnv(FunctionalJaxEnv, EzPickle):
+class CliffWalkingJaxEnv(FunctionalJaxEnv):
     """A Gymnasium Env wrapper for the functional cliffwalking env."""
 
     metadata = {"render_modes": ["rgb_array"], "render_fps": 50}
 
+    @ezpickle
     def __init__(self, render_mode: str | None = None, **kwargs):
         """Initializes Gym wrapper for cliffwalking functional env."""
-        EzPickle.__init__(self, render_mode=render_mode, **kwargs)
         env = CliffWalkingFunctional(**kwargs)
         env.transform(jax.jit)
 

--- a/gymnasium/utils/__init__.py
+++ b/gymnasium/utils/__init__.py
@@ -7,8 +7,8 @@ These are not intended as API functions, and will not remain stable over time.
 # We want this since we use `utils` during our import-time sanity checks
 # that verify that our dependencies are actually present.
 from gymnasium.utils.colorize import colorize
-from gymnasium.utils.ezpickle import EzPickle
+from gymnasium.utils.ezpickle import ezpickle
 from gymnasium.utils.record_constructor import RecordConstructorArgs
 
 
-__all__ = ["colorize", "EzPickle", "RecordConstructorArgs"]
+__all__ = ["colorize", "ezpickle", "RecordConstructorArgs"]

--- a/gymnasium/utils/ezpickle.py
+++ b/gymnasium/utils/ezpickle.py
@@ -1,27 +1,29 @@
-"""Class for pickling and unpickling objects via their constructor arguments."""
+"""Decorator for pickling and unpickling objects via their constructor arguments."""
+from __future__ import annotations
+
 from typing import Any
 
 
-class EzPickle:
-    """Objects that are pickled and unpickled via their constructor arguments.
+def ezpickle(func):
+    """Decorator for pickling and unpickling objects via their constructor arguments.
 
     Example:
-        >>> class Animal: pass
-        >>> class Dog(Animal, EzPickle):
-        ...    def __init__(self, furcolor, tailkind="bushy"):
-        ...        Animal.__init__(self)
-        ...        EzPickle.__init__(self, furcolor, tailkind)
+        >>> class Animal:
+        ...     pass
 
-    When this object is unpickled, a new ``Dog`` will be constructed by passing the provided furcolor and tailkind into the constructor.
+        >>> class Dog(Animal):
+        ...    @ezpickle
+        ...    def __init__(self, furcolor, tailkind="bushy"):
+        ...        super.__init__()
+        ...
+
+    When this object is unpickled, a new ``Dog`` will be constructed by passing
+    the provided furcolor and tailkind into the constructor.
     However, philosophers are still not sure whether it is still the same dog.
 
-    This is generally needed only for environments which wrap C/C++ code, such as MuJoCo and Atari.
+    This is generally needed only for environments which wrap C/C++ code, such
+    as MuJoCo and Atari.
     """
-
-    def __init__(self, *args: Any, **kwargs: Any):
-        """Uses the ``args`` and ``kwargs`` from the object's constructor for pickling."""
-        self._ezpickle_args = args
-        self._ezpickle_kwargs = kwargs
 
     def __getstate__(self):
         """Returns the object pickle state with args and kwargs."""
@@ -34,3 +36,12 @@ class EzPickle:
         """Sets the object pickle state using d."""
         out = type(self)(*d["_ezpickle_args"], **d["_ezpickle_kwargs"])
         self.__dict__.update(out.__dict__)
+
+    def wrapper(self, *args: tuple[Any], **kwargs: dict[str, Any]):
+        self._ezpickle_args = args
+        self._ezpickle_kwargs = kwargs
+        self.__class__.__getstate__ = __getstate__
+        self.__class__.__setstate__ = __setstate__
+        return func(self, *args, **kwargs)
+
+    return wrapper

--- a/tests/envs/mujoco/test_mujoco_custom_env.py
+++ b/tests/envs/mujoco/test_mujoco_custom_env.py
@@ -6,14 +6,14 @@ import warnings
 import numpy as np
 import pytest
 
-from gymnasium import utils
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.error import Error
 from gymnasium.spaces import Box
+from gymnasium.utils import ezpickle
 from gymnasium.utils.env_checker import check_env
 
 
-class PointEnv(MujocoEnv, utils.EzPickle):
+class PointEnv(MujocoEnv):
     """
     A simple mujuco env to test third party mujoco env, using the `Gymansium.MujocoEnv` environment API.
     """
@@ -26,9 +26,8 @@ class PointEnv(MujocoEnv, utils.EzPickle):
         ],
     }
 
+    @ezpickle
     def __init__(self, xml_file="point.xml", frame_skip=1, **kwargs):
-        utils.EzPickle.__init__(self, xml_file, frame_skip, **kwargs)
-
         MujocoEnv.__init__(
             self,
             xml_file,


### PR DESCRIPTION
# Description

This commit changes EzPickle from being a class to being a decorator.

The edits are only internal, they don't change or break the existing APIs.

Pros:

- Removed every instance of multiple inherintance in the codebase.
- Automated serialization of constructor arguments, no need to manually copy/paste them and keep track of them in case the constructor changes.
- I discovered at least one instance of useless arguments, where such argument is only serialized and then never used anymore (`default_camera_config` in `ant_v5.py`).

Cons:

- none that I can think of
  
## Type of change

- [x] Refactor

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes