### PR TITLE
Remove `VectorWrapper.__getattr__`

### DIFF
--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -343,13 +343,6 @@ class VectorWrapper(VectorEnv):
         """Close all extra resources."""
         return self.env.close_extras(**kwargs)
 
-    # implicitly forward all other methods and attributes to self.env
-    def __getattr__(self, name: str) -> Any:
-        """Forward all other attributes to the base environment."""
-        if name.startswith("_"):
-            raise AttributeError(f"attempted to get missing private attribute '{name}'")
-        return getattr(self.env, name)
-
     @property
     def unwrapped(self):
         """Return the base non-wrapped environment."""

--- a/tests/vector/test_vector_wrapper.py
+++ b/tests/vector/test_vector_wrapper.py
@@ -33,7 +33,7 @@ def test_vector_env_wrapper_attributes():
     env = gym.make_vec("CartPole-v1", num_envs=3)
     wrapped = DummyVectorWrapper(gym.make_vec("CartPole-v1", num_envs=3))
 
-    assert np.allclose(wrapped.call("gravity"), env.call("gravity"))
+    assert np.allclose(wrapped.env.call("gravity"), env.call("gravity"))
     env.set_attr("gravity", [20.0, 20.0, 20.0])
-    wrapped.set_attr("gravity", [20.0, 20.0, 20.0])
-    assert np.allclose(wrapped.get_attr("gravity"), env.get_attr("gravity"))
+    wrapped.env.set_attr("gravity", [20.0, 20.0, 20.0])
+    assert np.allclose(wrapped.env.get_attr("gravity"), env.get_attr("gravity"))


### PR DESCRIPTION
# Description

As `Wrapper.__getattr__` has been removed to prevent attribute forwarding, we forgot to remove this from `VectorWrapper`, this PR now does this