### PR TITLE
Add more examples to docs for wrappers

### DIFF
--- a/gymnasium/wrappers/atari_preprocessing.py
+++ b/gymnasium/wrappers/atari_preprocessing.py
@@ -19,13 +19,19 @@ class AtariPreprocessingV0(gym.Wrapper, gym.utils.RecordConstructorArgs):
     Specifically, the following preprocess stages applies to the atari environment:
 
     - Noop Reset: Obtains the initial state by taking a random number of no-ops on reset, default max 30 no-ops.
-    - Frame skipping: The number of frames skipped between steps, 4 by default
-    - Max-pooling: Pools over the most recent two observations from the frame skips
+    - Frame skipping: The number of frames skipped between steps, 4 by default.
+    - Max-pooling: Pools over the most recent two observations from the frame skips.
     - Termination signal when a life is lost: When the agent losses a life during the environment, then the environment is terminated.
         Turned off by default. Not recommended by Machado et al. (2018).
-    - Resize to a square image: Resizes the atari environment original observation shape from 210x180 to 84x84 by default
-    - Grayscale observation: If the observation is colour or greyscale, by default, greyscale.
-    - Scale observation: If to scale the observation between [0, 1) or [0, 255), by default, not scaled.
+    - Resize to a square image: Resizes the atari environment original observation shape from 210x180 to 84x84 by default.
+    - Grayscale observation: Makes the observation greyscale, enabled by default.
+    - Grayscale new axis: Extends the last channel of the observation such that the image is 3-dimensional, not enabled by default.
+    - Scale observation: Whether to scale the observation between [0, 1) or [0, 255), not scaled by default.
+
+    Example:
+        >>> import gymnasium as gym
+        >>> env = gym.make("ALE/Adventure-v5")
+        >>> env = AtariPreprocessingV0(env, noop_max=10, frame_skip=0, screen_size=84, terminal_on_life_loss=True, grayscale_obs=False, grayscale_newaxis=False)
     """
 
     def __init__(
@@ -45,7 +51,7 @@ class AtariPreprocessingV0(gym.Wrapper, gym.utils.RecordConstructorArgs):
             env (Env): The environment to apply the preprocessing
             noop_max (int): For No-op reset, the max number no-ops actions are taken at reset, to turn off, set to 0.
             frame_skip (int): The number of frames between new observation the agents observations effecting the frequency at which the agent experiences the game.
-            screen_size (int): resize Atari frame
+            screen_size (int): resize Atari frame.
             terminal_on_life_loss (bool): `if True`, then :meth:`step()` returns `terminated=True` whenever a
                 life is lost.
             grayscale_obs (bool): if True, then gray scale observation is returned, otherwise, RGB observation

--- a/gymnasium/wrappers/atari_preprocessing.py
+++ b/gymnasium/wrappers/atari_preprocessing.py
@@ -29,9 +29,9 @@ class AtariPreprocessingV0(gym.Wrapper, gym.utils.RecordConstructorArgs):
     - Scale observation: Whether to scale the observation between [0, 1) or [0, 255), not scaled by default.
 
     Example:
-        >>> import gymnasium as gym
-        >>> env = gym.make("ALE/Adventure-v5")
-        >>> env = AtariPreprocessingV0(env, noop_max=10, frame_skip=0, screen_size=84, terminal_on_life_loss=True, grayscale_obs=False, grayscale_newaxis=False)
+        >>> import gymnasium as gym # doctest: +SKIP
+        >>> env = gym.make("ALE/Adventure-v5") # doctest: +SKIP
+        >>> env = AtariPreprocessingV0(env, noop_max=10, frame_skip=0, screen_size=84, terminal_on_life_loss=True, grayscale_obs=False, grayscale_newaxis=False) # doctest: +SKIP
     """
 
     def __init__(

--- a/gymnasium/wrappers/jax_to_numpy.py
+++ b/gymnasium/wrappers/jax_to_numpy.py
@@ -103,6 +103,29 @@ class JaxToNumpyV0(
     Notes:
         The Jax To Numpy and Numpy to Jax conversion does not guarantee a roundtrip (jax -> numpy -> jax) and vice versa.
         The reason for this is jax does not support non-array values, therefore numpy ``int_32(5) -> DeviceArray([5], dtype=jnp.int23)``
+
+    Example:
+        >>> import gymnasium as gym
+        >>> env = gym.make("JaxEnv-vx")
+        >>> env = JaxToNumpyV0(env)
+        >>> obs, _ = env.reset(seed=123)
+        >>> type(obs)
+        <class 'numpy.ndarray'>
+
+        >>> action = env.action_space.sample()
+        >>> obs, reward, terminated, truncated, info = env.step(action)
+        >>> type(obs)
+        <class 'numpy.ndarray'>
+
+        >>> type(reward)
+        <class 'float'>
+
+        >>> type(terminated)
+        <class 'bool'>
+
+        >>> type(truncated)
+        <class 'bool'>
+
     """
 
     def __init__(self, env: gym.Env[ObsType, ActType]):

--- a/gymnasium/wrappers/jax_to_numpy.py
+++ b/gymnasium/wrappers/jax_to_numpy.py
@@ -111,21 +111,16 @@ class JaxToNumpyV0(
         >>> obs, _ = env.reset(seed=123)
         >>> type(obs)
         <class 'numpy.ndarray'>
-
         >>> action = env.action_space.sample()
         >>> obs, reward, terminated, truncated, info = env.step(action)
         >>> type(obs)
         <class 'numpy.ndarray'>
-
         >>> type(reward)
         <class 'float'>
-
         >>> type(terminated)
         <class 'bool'>
-
         >>> type(truncated)
         <class 'bool'>
-
     """
 
     def __init__(self, env: gym.Env[ObsType, ActType]):

--- a/gymnasium/wrappers/jax_to_numpy.py
+++ b/gymnasium/wrappers/jax_to_numpy.py
@@ -105,21 +105,21 @@ class JaxToNumpyV0(
         The reason for this is jax does not support non-array values, therefore numpy ``int_32(5) -> DeviceArray([5], dtype=jnp.int23)``
 
     Example:
-        >>> import gymnasium as gym                                     # doctest: SKIP
-        >>> env = gym.make("JaxEnv-vx")                                 # doctest: SKIP
-        >>> env = JaxToNumpyV0(env)                                     # doctest: SKIP
-        >>> obs, _ = env.reset(seed=123)                                # doctest: SKIP
-        >>> type(obs)                                                   # doctest: SKIP
+        >>> import gymnasium as gym                                     # doctest: +SKIP
+        >>> env = gym.make("JaxEnv-vx")                                 # doctest: +SKIP
+        >>> env = JaxToNumpyV0(env)                                     # doctest: +SKIP
+        >>> obs, _ = env.reset(seed=123)                                # doctest: +SKIP
+        >>> type(obs)                                                   # doctest: +SKIP
         <class 'numpy.ndarray'>
-        >>> action = env.action_space.sample()                          # doctest: SKIP
-        >>> obs, reward, terminated, truncated, info = env.step(action) # doctest: SKIP
-        >>> type(obs)                                                   # doctest: SKIP
+        >>> action = env.action_space.sample()                          # doctest: +SKIP
+        >>> obs, reward, terminated, truncated, info = env.step(action) # doctest: +SKIP
+        >>> type(obs)                                                   # doctest: +SKIP
         <class 'numpy.ndarray'>
-        >>> type(reward)                                                # doctest: SKIP
+        >>> type(reward)                                                # doctest: +SKIP
         <class 'float'>
-        >>> type(terminated)                                            # doctest: SKIP
+        >>> type(terminated)                                            # doctest: +SKIP
         <class 'bool'>
-        >>> type(truncated)                                             # doctest: SKIP
+        >>> type(truncated)                                             # doctest: +SKIP
         <class 'bool'>
     """
 

--- a/gymnasium/wrappers/jax_to_numpy.py
+++ b/gymnasium/wrappers/jax_to_numpy.py
@@ -105,21 +105,21 @@ class JaxToNumpyV0(
         The reason for this is jax does not support non-array values, therefore numpy ``int_32(5) -> DeviceArray([5], dtype=jnp.int23)``
 
     Example:
-        >>> import gymnasium as gym
-        >>> env = gym.make("JaxEnv-vx")
-        >>> env = JaxToNumpyV0(env)
-        >>> obs, _ = env.reset(seed=123)
-        >>> type(obs)
+        >>> import gymnasium as gym                                     # doctest: SKIP
+        >>> env = gym.make("JaxEnv-vx")                                 # doctest: SKIP
+        >>> env = JaxToNumpyV0(env)                                     # doctest: SKIP
+        >>> obs, _ = env.reset(seed=123)                                # doctest: SKIP
+        >>> type(obs)                                                   # doctest: SKIP
         <class 'numpy.ndarray'>
-        >>> action = env.action_space.sample()
-        >>> obs, reward, terminated, truncated, info = env.step(action)
-        >>> type(obs)
+        >>> action = env.action_space.sample()                          # doctest: SKIP
+        >>> obs, reward, terminated, truncated, info = env.step(action) # doctest: SKIP
+        >>> type(obs)                                                   # doctest: SKIP
         <class 'numpy.ndarray'>
-        >>> type(reward)
+        >>> type(reward)                                                # doctest: SKIP
         <class 'float'>
-        >>> type(terminated)
+        >>> type(terminated)                                            # doctest: SKIP
         <class 'bool'>
-        >>> type(truncated)
+        >>> type(truncated)                                             # doctest: SKIP
         <class 'bool'>
     """
 

--- a/gymnasium/wrappers/jax_to_torch.py
+++ b/gymnasium/wrappers/jax_to_torch.py
@@ -121,6 +121,30 @@ class JaxToTorchV0(gym.Wrapper, gym.utils.RecordConstructorArgs):
 
     Note:
         For ``rendered`` this is returned as a NumPy array not a pytorch Tensor.
+
+    Example:
+        >>> import torch
+        >>> import gymnasium as gym
+        >>> env = gym.make("JaxEnv-vx")
+        >>> env = JaxtoTorchV0(env)
+        >>> obs, _ = env.reset(seed=123)
+        >>> type(obs)
+        <class 'torch.Tensor'>
+
+        >>> action = torch.tensor(env.action_space.sample())
+        >>> obs, reward, terminated, truncated, info = env.step(action)
+        >>> type(obs)
+        <class 'torch.Tensor'>
+
+        >>> type(reward)
+        <class 'float'>
+
+        >>> type(terminated)
+        <class 'bool'>
+
+        >>> type(truncated)
+        <class 'bool'>
+
     """
 
     def __init__(self, env: gym.Env, device: Device | None = None):

--- a/gymnasium/wrappers/jax_to_torch.py
+++ b/gymnasium/wrappers/jax_to_torch.py
@@ -123,22 +123,22 @@ class JaxToTorchV0(gym.Wrapper, gym.utils.RecordConstructorArgs):
         For ``rendered`` this is returned as a NumPy array not a pytorch Tensor.
 
     Example:
-        >>> import torch
-        >>> import gymnasium as gym
-        >>> env = gym.make("JaxEnv-vx")
-        >>> env = JaxtoTorchV0(env)
-        >>> obs, _ = env.reset(seed=123)
-        >>> type(obs)
+        >>> import torch                                                # doctest: SKIP
+        >>> import gymnasium as gym                                     # doctest: SKIP
+        >>> env = gym.make("JaxEnv-vx")                                 # doctest: SKIP
+        >>> env = JaxtoTorchV0(env)                                     # doctest: SKIP
+        >>> obs, _ = env.reset(seed=123)                                # doctest: SKIP
+        >>> type(obs)                                                   # doctest: SKIP
         <class 'torch.Tensor'>
-        >>> action = torch.tensor(env.action_space.sample())
-        >>> obs, reward, terminated, truncated, info = env.step(action)
-        >>> type(obs)
+        >>> action = torch.tensor(env.action_space.sample())            # doctest: SKIP
+        >>> obs, reward, terminated, truncated, info = env.step(action) # doctest: SKIP
+        >>> type(obs)                                                   # doctest: SKIP
         <class 'torch.Tensor'>
-        >>> type(reward)
+        >>> type(reward)                                                # doctest: SKIP
         <class 'float'>
-        >>> type(terminated)
+        >>> type(terminated)                                            # doctest: SKIP
         <class 'bool'>
-        >>> type(truncated)
+        >>> type(truncated)                                             # doctest: SKIP
         <class 'bool'>
     """
 

--- a/gymnasium/wrappers/jax_to_torch.py
+++ b/gymnasium/wrappers/jax_to_torch.py
@@ -130,21 +130,16 @@ class JaxToTorchV0(gym.Wrapper, gym.utils.RecordConstructorArgs):
         >>> obs, _ = env.reset(seed=123)
         >>> type(obs)
         <class 'torch.Tensor'>
-
         >>> action = torch.tensor(env.action_space.sample())
         >>> obs, reward, terminated, truncated, info = env.step(action)
         >>> type(obs)
         <class 'torch.Tensor'>
-
         >>> type(reward)
         <class 'float'>
-
         >>> type(terminated)
         <class 'bool'>
-
         >>> type(truncated)
         <class 'bool'>
-
     """
 
     def __init__(self, env: gym.Env, device: Device | None = None):

--- a/gymnasium/wrappers/jax_to_torch.py
+++ b/gymnasium/wrappers/jax_to_torch.py
@@ -123,22 +123,22 @@ class JaxToTorchV0(gym.Wrapper, gym.utils.RecordConstructorArgs):
         For ``rendered`` this is returned as a NumPy array not a pytorch Tensor.
 
     Example:
-        >>> import torch                                                # doctest: SKIP
-        >>> import gymnasium as gym                                     # doctest: SKIP
-        >>> env = gym.make("JaxEnv-vx")                                 # doctest: SKIP
-        >>> env = JaxtoTorchV0(env)                                     # doctest: SKIP
-        >>> obs, _ = env.reset(seed=123)                                # doctest: SKIP
-        >>> type(obs)                                                   # doctest: SKIP
+        >>> import torch                                                # doctest: +SKIP
+        >>> import gymnasium as gym                                     # doctest: +SKIP
+        >>> env = gym.make("JaxEnv-vx")                                 # doctest: +SKIP
+        >>> env = JaxtoTorchV0(env)                                     # doctest: +SKIP
+        >>> obs, _ = env.reset(seed=123)                                # doctest: +SKIP
+        >>> type(obs)                                                   # doctest: +SKIP
         <class 'torch.Tensor'>
-        >>> action = torch.tensor(env.action_space.sample())            # doctest: SKIP
-        >>> obs, reward, terminated, truncated, info = env.step(action) # doctest: SKIP
-        >>> type(obs)                                                   # doctest: SKIP
+        >>> action = torch.tensor(env.action_space.sample())            # doctest: +SKIP
+        >>> obs, reward, terminated, truncated, info = env.step(action) # doctest: +SKIP
+        >>> type(obs)                                                   # doctest: +SKIP
         <class 'torch.Tensor'>
-        >>> type(reward)                                                # doctest: SKIP
+        >>> type(reward)                                                # doctest: +SKIP
         <class 'float'>
-        >>> type(terminated)                                            # doctest: SKIP
+        >>> type(terminated)                                            # doctest: +SKIP
         <class 'bool'>
-        >>> type(truncated)                                             # doctest: SKIP
+        >>> type(truncated)                                             # doctest: +SKIP
         <class 'bool'>
     """
 

--- a/gymnasium/wrappers/lambda_action.py
+++ b/gymnasium/wrappers/lambda_action.py
@@ -24,15 +24,19 @@ class LambdaActionV0(
     """Applies a function to the ``action`` before passing the modified value to the environment ``step`` function.
 
     Example:
+        >>> import numpy as np
         >>> import gymnasium as gym
-        >>> from gymnasium.wrappers import LambdaRewardV0
-        >>> env = gym.make("CartPole-v1")
-        >>> env = LamdaAction(env, lambda a: 0.5 * a + 0.1)
-        >>> _ = env.reset()
-        >>> _, rew, _, _, _ = env.step(0)
-        >>> rew
-        1.0
-
+        >>> env = gym.make("MountainCarContinuous-v0")
+        >>> _ = env.reset(seed=123)
+        >>> obs, *_= env.step(np.array([0.0, 1.0]))
+        >>> obs
+        array([-4.6397772e-01, -4.4808415e-04], dtype=float32)
+        >>> env = gym.make("MountainCarContinuous-v0")
+        >>> env = LambdaActionV0(env, lambda a: 0.5 * a + 0.1, env.action_space)
+        >>> _ = env.reset(seed=123)
+        >>> obs, *_= env.step(np.array([0.0, 1.0]))
+        >>> obs
+        array([-4.6382770e-01, -2.9808417e-04], dtype=float32)
     """
 
     def __init__(

--- a/gymnasium/wrappers/lambda_action.py
+++ b/gymnasium/wrappers/lambda_action.py
@@ -21,7 +21,19 @@ __all__ = ["LambdaActionV0", "ClipActionV0", "RescaleActionV0"]
 class LambdaActionV0(
     gym.ActionWrapper[ObsType, WrapperActType, ActType], gym.utils.RecordConstructorArgs
 ):
-    """Applies a function to the ``action`` before passing the modified value to the environment ``step`` function."""
+    """Applies a function to the ``action`` before passing the modified value to the environment ``step`` function.
+
+    Example:
+        >>> import gymnasium as gym
+        >>> from gymnasium.wrappers import LambdaRewardV0
+        >>> env = gym.make("CartPole-v1")
+        >>> env = LamdaAction(env, lambda a: 0.5 * a + 0.1)
+        >>> _ = env.reset()
+        >>> _, rew, _, _, _ = env.step(0)
+        >>> rew
+        1.0
+
+    """
 
     def __init__(
         self,

--- a/gymnasium/wrappers/lambda_observation.py
+++ b/gymnasium/wrappers/lambda_observation.py
@@ -567,28 +567,28 @@ class RenderObservationV0(
        This was previously called ``PixelObservationWrapper``.
 
     Example:
-    Replace the observation with the rendered image:
-    >>> import gymnasium as gym
-    >>> env = gym.make("CartPole-v1", render_mode="rgb_array")
-    >>> env = RenderObservationV0(env, render_only=True)
-    >>> obs, _ = env.reset(seed=123)
-    >>> image = env.render()
-    >>> (obs == image).all()
-    True
+        Replace the observation with the rendered image:
+        >>> import gymnasium as gym
+        >>> env = gym.make("CartPole-v1", render_mode="rgb_array")
+        >>> env = RenderObservationV0(env, render_only=True)
+        >>> obs, _ = env.reset(seed=123)
+        >>> image = env.render()
+        >>> (obs == image).all()
+        True
 
-    Add the rendered image to the original observation as a dictionary item:
-    >>> import gymnasium as gym
-    >>> env = gym.make("CartPole-v1", render_mode="rgb_array")
-    >>> env = RenderObservationV0(env, render_only=False)
-    >>> obs, _ = env.reset(seed=123)
-    >>> obs.keys()
-    dict_keys(['state', 'pixels'])
+        Add the rendered image to the original observation as a dictionary item:
+        >>> import gymnasium as gym
+        >>> env = gym.make("CartPole-v1", render_mode="rgb_array")
+        >>> env = RenderObservationV0(env, render_only=False)
+        >>> obs, _ = env.reset(seed=123)
+        >>> obs.keys()
+        dict_keys(['state', 'pixels'])
 
-    >>> obs["state"]
-    array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32)
+        >>> obs["state"]
+        array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32)
 
-    >>> (obs["pixels"] == env.render()).all()
-    True
+        >>> (obs["pixels"] == env.render()).all()
+        True
 
     """
 

--- a/gymnasium/wrappers/lambda_observation.py
+++ b/gymnasium/wrappers/lambda_observation.py
@@ -53,7 +53,6 @@ class LambdaObservationV0(
         >>> env = LambdaObservationV0(env, lambda obs: obs + 0.1 * np.random.random(obs.shape), env.observation_space)
         >>> env.reset(seed=42)
         (array([0.08227695, 0.06540678, 0.09613613, 0.07422512]), {})
-
     """
 
     def __init__(
@@ -583,13 +582,10 @@ class RenderObservationV0(
         >>> obs, _ = env.reset(seed=123)
         >>> obs.keys()
         dict_keys(['state', 'pixels'])
-
         >>> obs["state"]
         array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32)
-
         >>> (obs["pixels"] == env.render()).all()
         True
-
     """
 
     def __init__(

--- a/gymnasium/wrappers/lambda_observation.py
+++ b/gymnasium/wrappers/lambda_observation.py
@@ -53,6 +53,7 @@ class LambdaObservationV0(
         >>> env = LambdaObservationV0(env, lambda obs: obs + 0.1 * np.random.random(obs.shape), env.observation_space)
         >>> env.reset(seed=42)
         (array([0.08227695, 0.06540678, 0.09613613, 0.07422512]), {})
+
     """
 
     def __init__(
@@ -564,6 +565,31 @@ class RenderObservationV0(
 
     Notes:
        This was previously called ``PixelObservationWrapper``.
+
+    Example:
+    Replace the observation with the rendered image:
+    >>> import gymnasium as gym
+    >>> env = gym.make("CartPole-v1", render_mode="rgb_array")
+    >>> env = RenderObservationV0(env, render_only=True)
+    >>> obs, _ = env.reset(seed=123)
+    >>> image = env.render()
+    >>> (obs == image).all()
+    True
+
+    Add the rendered image to the original observation as a dictionary item:
+    >>> import gymnasium as gym
+    >>> env = gym.make("CartPole-v1", render_mode="rgb_array")
+    >>> env = RenderObservationV0(env, render_only=False)
+    >>> obs, _ = env.reset(seed=123)
+    >>> obs.keys()
+    dict_keys(['state', 'pixels'])
+
+    >>> obs["state"]
+    array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32)
+
+    >>> (obs["pixels"] == env.render()).all()
+    True
+
     """
 
     def __init__(

--- a/gymnasium/wrappers/lambda_observation.py
+++ b/gymnasium/wrappers/lambda_observation.py
@@ -477,8 +477,12 @@ class RescaleObservationV0(
         self.max_obs = max_obs
 
         # Imagine the x-axis between the old Box and the y-axis being the new Box
-        high_low_diff = np.array(env.observation_space.high, dtype=np.float128) - np.array(env.observation_space.low, dtype=np.float128)
-        gradient = np.array((max_obs - min_obs) / high_low_diff, dtype=env.observation_space.dtype)
+        high_low_diff = np.array(
+            env.observation_space.high, dtype=np.float128
+        ) - np.array(env.observation_space.low, dtype=np.float128)
+        gradient = np.array(
+            (max_obs - min_obs) / high_low_diff, dtype=env.observation_space.dtype
+        )
 
         intercept = gradient * -env.observation_space.low + min_obs
 

--- a/gymnasium/wrappers/lambda_observation.py
+++ b/gymnasium/wrappers/lambda_observation.py
@@ -45,10 +45,12 @@ class LambdaObservationV0(
     If the observations from :attr:`func` are outside the bounds of the ``env``'s observation space, provide an :attr:`observation_space`.
 
     Example:
-        >>> import gymnasium as gym
-        >>> from gymnasium.wrappers import LambdaObservationV0
         >>> import numpy as np
+        >>> import gymnasium as gym
         >>> np.random.seed(0)
+        >>> env = gym.make("CartPole-v1")
+        >>> env.reset(seed=42)
+        (array([ 0.0273956 , -0.00611216,  0.03585979,  0.0197368 ], dtype=float32), {})
         >>> env = gym.make("CartPole-v1")
         >>> env = LambdaObservationV0(env, lambda obs: obs + 0.1 * np.random.random(obs.shape), env.observation_space)
         >>> env.reset(seed=42)

--- a/gymnasium/wrappers/lambda_observation.py
+++ b/gymnasium/wrappers/lambda_observation.py
@@ -572,21 +572,33 @@ class RenderObservationV0(
         >>> import gymnasium as gym
         >>> env = gym.make("CartPole-v1", render_mode="rgb_array")
         >>> env = RenderObservationV0(env, render_only=True)
+        >>> env.observation_space
+        Box(0, 255, (400, 600, 3), uint8)
         >>> obs, _ = env.reset(seed=123)
         >>> image = env.render()
-        >>> (obs == image).all()
+        >>> np.all(obs == image)
+        True
+        >>> obs, *_ = env.step(env.action_space.sample())
+        >>> image = env.render()
+        >>> np.all(obs == image)
         True
 
         Add the rendered image to the original observation as a dictionary item:
         >>> import gymnasium as gym
         >>> env = gym.make("CartPole-v1", render_mode="rgb_array")
         >>> env = RenderObservationV0(env, render_only=False)
+        >>> env.observation_space
+        Dict('pixels': Box(0, 255, (400, 600, 3), uint8), 'state': Box([-4.8000002e+00 -3.4028235e+38 -4.1887903e-01 -3.4028235e+38], [4.8000002e+00 3.4028235e+38 4.1887903e-01 3.4028235e+38], (4,), float32))
         >>> obs, _ = env.reset(seed=123)
         >>> obs.keys()
         dict_keys(['state', 'pixels'])
         >>> obs["state"]
         array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32)
-        >>> (obs["pixels"] == env.render()).all()
+        >>> np.all(obs["pixels"] == env.render())
+        True
+        >>> obs, *_ = env.step(env.action_space.sample())
+        >>> image = env.render()
+        >>> np.all(obs["pixels"] == image)
         True
     """
 

--- a/gymnasium/wrappers/lambda_reward.py
+++ b/gymnasium/wrappers/lambda_reward.py
@@ -31,6 +31,7 @@ class LambdaRewardV0(
         >>> _, rew, _, _, _ = env.step(0)
         >>> rew
         3.0
+
     """
 
     def __init__(

--- a/gymnasium/wrappers/numpy_to_torch.py
+++ b/gymnasium/wrappers/numpy_to_torch.py
@@ -95,6 +95,30 @@ class NumpyToTorchV0(gym.Wrapper, gym.utils.RecordConstructorArgs):
 
     Note:
         For ``rendered`` this is returned as a NumPy array not a pytorch Tensor.
+
+    Example:
+        >>> import torch
+        >>> import gymnasium as gym
+        >>> env = gym.make("CartPole-v1")
+        >>> env = NumpyToTorchV0(env)
+        >>> obs, _ = env.reset(seed=123)
+        >>> type(obs)
+        <class 'torch.Tensor'>
+
+        >>> action = torch.tensor(env.action_space.sample())
+        >>> obs, reward, terminated, truncated, info = env.step(action)
+        >>> type(obs)
+        <class 'torch.Tensor'>
+
+        >>> type(reward)
+        <class 'float'>
+
+        >>> type(terminated)
+        <class 'bool'>
+
+        >>> type(truncated)
+        <class 'bool'>
+
     """
 
     def __init__(self, env: gym.Env, device: Device | None = None):

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -170,15 +170,16 @@ class RecordVideoV0(
         >>> import gymnasium as gym
         >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
         >>> trigger = lambda t: t % 10 == 0
-        >>> env = RecordVideoV0(env, video_folder="./save_videos", episode_trigger=trigger)
+        >>> env = RecordVideoV0(env, video_folder="./save_videos1", episode_trigger=trigger)
         >>> for i in range(50): # doctest: +ELLIPSIS
         ...     termination, truncation = False, False
         ...     _ = env.reset(seed=123)
         ...     while not (termination or truncation):
         ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
         ...
+        Moviepy ... mp4
         >>> env.close()
-        >>> len(os.listdir("./save_videos"))
+        >>> len(os.listdir("./save_videos1"))
         5
 
         Run the environment for 3 episodes, save each episode starting from step 10:
@@ -186,30 +187,32 @@ class RecordVideoV0(
         >>> import gymnasium as gym
         >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
         >>> trigger = lambda t: t == 10
-        >>> env = RecordVideoV0(env, video_folder="./save_videos", step_trigger=trigger)
+        >>> env = RecordVideoV0(env, video_folder="./save_videos2", step_trigger=trigger)
         >>> for i in range(3): # doctest: +ELLIPSIS
         ...     termination, truncation = False, False
         ...     _ = env.reset(seed=123)
         ...     while not (termination or truncation):
         ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
         ...
+        Moviepy ... mp4
         >>> env.close()
-        >>> len(os.listdir("./save_videos"))
+        >>> len(os.listdir("./save_videos2"))
         3
 
         Run 3 episodes, record everything, but in chunks of 1000 frames:
         >>> import os
         >>> import gymnasium as gym
         >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
-        >>> env = RecordVideoV0(env, video_folder="./save_videos", video_length=1000)
+        >>> env = RecordVideoV0(env, video_folder="./save_videos3", video_length=1000)
         >>> for i in range(3): # doctest: +ELLIPSIS
         ...     termination, truncation = False, False
         ...     _ = env.reset(seed=123)
         ...     while not (termination or truncation):
         ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
         ...
+        Moviepy ... mp4
         >>> env.close()
-        >>> len(os.listdir("./save_videos"))
+        >>> len(os.listdir("./save_videos3"))
         2
 
     """

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -195,7 +195,7 @@ class RecordVideoV0(
         ...
         >>> env.close()
         >>> len(os.listdir("./save_videos2"))
-        3
+        1
 
         Run 3 episodes, record everything, but in chunks of 1000 frames:
         >>> import os

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -177,7 +177,7 @@ class RecordVideoV0(
         ...     while not (termination or truncation):
         ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
         ...
-        Moviepy ... mp4
+        ...
         >>> env.close()
         >>> len(os.listdir("./save_videos1"))
         5
@@ -194,7 +194,7 @@ class RecordVideoV0(
         ...     while not (termination or truncation):
         ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
         ...
-        Moviepy ... mp4
+        ...
         >>> env.close()
         >>> len(os.listdir("./save_videos2"))
         3
@@ -210,7 +210,7 @@ class RecordVideoV0(
         ...     while not (termination or truncation):
         ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
         ...
-        Moviepy ... mp4
+        ...
         >>> env.close()
         >>> len(os.listdir("./save_videos3"))
         2

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -183,21 +183,22 @@ class RecordVideoV0(
         >>> len(os.listdir("./save_videos1"))
         5
 
-        Run the environment for 5 episodes, start the recording at the 100th step and record for 100 frames.
+        Run the environment for 5 episodes, start a recording every 200th step, making sure each video is 100 frames long:
         >>> import os
         >>> import gymnasium as gym
         >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
-        >>> trigger = lambda t: t == 100
+        >>> trigger = lambda t: t % 200 == 0
         >>> env = RecordVideoV0(env, video_folder="./save_videos2", step_trigger=trigger, video_length=100, disable_logger=True)
         >>> for i in range(5):
         ...     termination, truncation = False, False
         ...     _ = env.reset(seed=123)
+        ...     _ = env.action_space.seed(123)
         ...     while not (termination or truncation):
         ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
         ...
         >>> env.close()
         >>> len(os.listdir("./save_videos2"))
-        1
+        2
 
         Run 3 episodes, record everything, but in chunks of 1000 frames:
         >>> import os

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -170,13 +170,12 @@ class RecordVideoV0(
         >>> import gymnasium as gym
         >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
         >>> trigger = lambda t: t % 10 == 0
-        >>> env = RecordVideoV0(env, video_folder="./save_videos1", episode_trigger=trigger)
-        >>> for i in range(50): # doctest: +ELLIPSIS
+        >>> env = RecordVideoV0(env, video_folder="./save_videos1", episode_trigger=trigger, disable_logger=True)
+        >>> for i in range(50):
         ...     termination, truncation = False, False
         ...     _ = env.reset(seed=123)
         ...     while not (termination or truncation):
         ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
-        ...
         ...
         >>> env.close()
         >>> len(os.listdir("./save_videos1"))
@@ -187,13 +186,12 @@ class RecordVideoV0(
         >>> import gymnasium as gym
         >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
         >>> trigger = lambda t: t == 10
-        >>> env = RecordVideoV0(env, video_folder="./save_videos2", step_trigger=trigger)
-        >>> for i in range(3): # doctest: +ELLIPSIS
+        >>> env = RecordVideoV0(env, video_folder="./save_videos2", step_trigger=trigger, disable_logger=True)
+        >>> for i in range(3):
         ...     termination, truncation = False, False
         ...     _ = env.reset(seed=123)
         ...     while not (termination or truncation):
         ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
-        ...
         ...
         >>> env.close()
         >>> len(os.listdir("./save_videos2"))
@@ -203,13 +201,12 @@ class RecordVideoV0(
         >>> import os
         >>> import gymnasium as gym
         >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
-        >>> env = RecordVideoV0(env, video_folder="./save_videos3", video_length=1000)
-        >>> for i in range(3): # doctest: +ELLIPSIS
+        >>> env = RecordVideoV0(env, video_folder="./save_videos3", video_length=1000, disable_logger=True)
+        >>> for i in range(3):
         ...     termination, truncation = False, False
         ...     _ = env.reset(seed=123)
         ...     while not (termination or truncation):
         ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
-        ...
         ...
         >>> env.close()
         >>> len(os.listdir("./save_videos3"))

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -154,15 +154,17 @@ class RecordVideoV0(
 
     .. py:currentmodule:: gymnasium.utils.save_video
 
-    Usually, you only want to record episodes intermittently, say every hundredth episode.
+    Usually, you only want to record episodes intermittently, say every hundredth episode or at every thousandth environment step.
     To do this, you can specify ``episode_trigger`` or ``step_trigger``.
     They should be functions returning a boolean that indicates whether a recording should be started at the
     current episode or step, respectively.
-    If neither :attr:`episode_trigger` nor ``step_trigger`` is passed, a default ``episode_trigger`` will be employed,
-    i.e. :func:`capped_cubic_video_schedule`. This function starts a video at every episode that is a power of 3 until 1000 and
-    then every 1000 episodes.
-    By default, the recording will be stopped once reset is called. However, you can also create recordings of fixed
-    length (possibly spanning several episodes) by passing a strictly positive value for ``video_length``.
+    The ``episode_trigger`` should return ``True`` on the episode when recording should start.
+    The ``step_trigger`` should return ``True`` on the n-th environment step that the recording should be started, where n sums over all previous episodes.
+    If neither :attr:`episode_trigger` nor ``step_trigger`` is passed, a default ``episode_trigger`` will be employed, i.e. :func:`capped_cubic_video_schedule`.
+    This function starts a video at every episode that is a power of 3 until 1000 and then every 1000 episodes.
+    By default, the recording will be stopped once reset is called.
+    However, you can also create recordings of fixed length (possibly spanning several episodes)
+    by passing a strictly positive value for ``video_length``.
 
     Example:
         Run the environment for 50 episodes, and save the video every 10 episodes starting from the 0th:
@@ -181,13 +183,13 @@ class RecordVideoV0(
         >>> len(os.listdir("./save_videos1"))
         5
 
-        Run the environment for 3 episodes, save each episode starting from step 10:
+        Run the environment for 5 episodes, start the recording at the 100th step and record for 100 frames.
         >>> import os
         >>> import gymnasium as gym
         >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
-        >>> trigger = lambda t: t == 10
-        >>> env = RecordVideoV0(env, video_folder="./save_videos2", step_trigger=trigger, disable_logger=True)
-        >>> for i in range(3):
+        >>> trigger = lambda t: t == 100
+        >>> env = RecordVideoV0(env, video_folder="./save_videos2", step_trigger=trigger, video_length=100, disable_logger=True)
+        >>> for i in range(5):
         ...     termination, truncation = False, False
         ...     _ = env.reset(seed=123)
         ...     while not (termination or truncation):

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -28,7 +28,61 @@ __all__ = [
 class RenderCollectionV0(
     gym.Wrapper[ObsType, ActType, ObsType, ActType], gym.utils.RecordConstructorArgs
 ):
-    """Collect rendered frames of an environment such ``render`` returns a ``list[RenderedFrame]``."""
+    """Collect rendered frames of an environment such ``render`` returns a ``list[RenderedFrame]``.
+
+    Example:
+        Return the list of frames for the number of steps ``render`` wasn't called.
+        >>> import gymnasium as gym
+        >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
+        >>> env = RenderCollectionV0(env)
+        >>> _ = env.reset(seed=123)
+        >>> for _ in range(5):
+        ...     _ = env.step(env.action_space.sample())
+        ...
+        >>> frames = env.render()
+        >>> len(frames)
+        6
+
+        >>> frames = env.render()
+        >>> len(frames)
+        0
+
+        Return the list of frames for the number of steps the episode was running.
+        >>> import gymnasium as gym
+        >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
+        >>> env = RenderCollectionV0(env, pop_frames=False)
+        >>> _ = env.reset(seed=123)
+        >>> for _ in range(5):
+        ...     _ = env.step(env.action_space.sample())
+        ...
+        >>> frames = env.render()
+        >>> len(frames)
+        6
+
+        >>> frames = env.render()
+        >>> len(frames)
+        6
+
+        Collect all frames for all episodes, without clearing them when render is called
+        >>> import gymnasium as gym
+        >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
+        >>> env = RenderCollectionV0(env, pop_frames=False, reset_clean=False)
+        >>> _ = env.reset(seed=123)
+        >>> for _ in range(5):
+        ...     _ = env.step(env.action_space.sample())
+        ...
+        >>> _ = env.reset(seed=123)
+        >>> for _ in range(5):
+        ...     _ = env.step(env.action_space.sample())
+        ...
+        >>> frames = env.render()
+        >>> len(frames)
+        12
+
+        >>> frames = env.render()
+        >>> len(frames)
+        12
+    """
 
     def __init__(
         self,
@@ -109,6 +163,55 @@ class RecordVideoV0(
     then every 1000 episodes.
     By default, the recording will be stopped once reset is called. However, you can also create recordings of fixed
     length (possibly spanning several episodes) by passing a strictly positive value for ``video_length``.
+
+    Example:
+        Run the environment for 50 episodes, and save the video every 10 episodes starting from the 0th:
+        >>> import os
+        >>> import gymnasium as gym
+        >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
+        >>> trigger = lambda t: t % 10 == 0
+        >>> env = RecordVideoV0(env, video_folder="./save_videos", episode_trigger=trigger)
+        >>> for i in range(50):
+        ...     termination, truncation = False, False
+        ...     _ = env.reset(seed=123)
+        ...     while not (termination or truncation):
+        ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
+        ...
+        >>> env.close()
+        >>> len(os.listdir("./save_videos"))
+        5
+
+        Run the environment for 3 episodes, save each episode starting from step 10:
+        >>> import os
+        >>> import gymnasium as gym
+        >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
+        >>> trigger = lambda t: t == 10
+        >>> env = RecordVideoV0(env, video_folder="./save_videos", step_trigger=trigger)
+        >>> for i in range(3):
+        ...     termination, truncation = False, False
+        ...     _ = env.reset(seed=123)
+        ...     while not (termination or truncation):
+        ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
+        ...
+        >>> env.close()
+        >>> len(os.listdir("./save_videos"))
+        3
+
+        Run 3 episodes, record everything, but in chunks of 1000 frames:
+        >>> import os
+        >>> import gymnasium as gym
+        >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
+        >>> env = RecordVideoV0(env, video_folder="./save_videos", video_length=1000)
+        >>> for i in range(3):
+        ...     termination, truncation = False, False
+        ...     _ = env.reset(seed=123)
+        ...     while not (termination or truncation):
+        ...         obs, rew, termination, truncation, info = env.step(env.action_space.sample())
+        ...
+        >>> env.close()
+        >>> len(os.listdir("./save_videos"))
+        2
+
     """
 
     def __init__(
@@ -335,6 +438,7 @@ class HumanRenderingV0(
         >>> obs, _ = wrapped.reset()
         >>> env.render() # env.render() will always return an empty list!
         []
+
     """
 
     def __init__(self, env: gym.Env[ObsType, ActType]):

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -171,7 +171,7 @@ class RecordVideoV0(
         >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
         >>> trigger = lambda t: t % 10 == 0
         >>> env = RecordVideoV0(env, video_folder="./save_videos", episode_trigger=trigger)
-        >>> for i in range(50):
+        >>> for i in range(50): # doctest: +ELLIPSIS
         ...     termination, truncation = False, False
         ...     _ = env.reset(seed=123)
         ...     while not (termination or truncation):
@@ -187,7 +187,7 @@ class RecordVideoV0(
         >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
         >>> trigger = lambda t: t == 10
         >>> env = RecordVideoV0(env, video_folder="./save_videos", step_trigger=trigger)
-        >>> for i in range(3):
+        >>> for i in range(3): # doctest: +ELLIPSIS
         ...     termination, truncation = False, False
         ...     _ = env.reset(seed=123)
         ...     while not (termination or truncation):
@@ -202,7 +202,7 @@ class RecordVideoV0(
         >>> import gymnasium as gym
         >>> env = gym.make("LunarLander-v2", render_mode="rgb_array")
         >>> env = RecordVideoV0(env, video_folder="./save_videos", video_length=1000)
-        >>> for i in range(3):
+        >>> for i in range(3): # doctest: +ELLIPSIS
         ...     termination, truncation = False, False
         ...     _ = env.reset(seed=123)
         ...     while not (termination or truncation):

--- a/gymnasium/wrappers/stateful_action.py
+++ b/gymnasium/wrappers/stateful_action.py
@@ -36,7 +36,7 @@ class StickyActionV0(
         (array([ 0.02728892,  0.5420062 , -0.04794393, -0.9380709 ], dtype=float32), 1.0, False, False, {})
 
         >>> env.step(0)
-        (array([ 0.03812904,  0.34756234, -0.06670535, -0.6608303 ], dtype=float32), 1.0, False, alse, {})
+        (array([ 0.03812904,  0.34756234, -0.06670535, -0.6608303 ], dtype=float32), 1.0, False, False, {})
     """
 
     def __init__(

--- a/gymnasium/wrappers/stateful_action.py
+++ b/gymnasium/wrappers/stateful_action.py
@@ -22,22 +22,6 @@ class StickyActionV0(
     Example:
         >>> import gymnasium as gym
         >>> env = gym.make("CartPole-v1")
-        >>> env.reset(seed=123)
-        (array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32), {})
-
-        >>> env.step(1)
-        (array([ 0.01734283,  0.15089367, -0.02859527, -0.33293587], dtype=float32), 1.0, False, False, {})
-
-        >>> env.step(0)
-        (array([ 0.0203607 , -0.04380985, -0.03525399, -0.04940585], dtype=float32), 1.0, False, False, {})
-
-        >>> env.step(1)
-        (array([ 0.01948451,  0.15179941, -0.03624211, -0.35299996], dtype=float32), 1.0, False, False, {})
-
-        >>> env.step(0)
-        (array([ 0.02252049, -0.04278894, -0.0433021 , -0.07196194], dtype=float32), 1.0, False, False, {})
-
-        >>> env = gym.make("CartPole-v1")
         >>> env = StickyActionV0(env, repeat_action_probability=0.9)
         >>> env.reset(seed=123)
         (array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32), {})

--- a/gymnasium/wrappers/stateful_action.py
+++ b/gymnasium/wrappers/stateful_action.py
@@ -18,6 +18,42 @@ class StickyActionV0(
 
     This wrapper follows the implementation proposed by `Machado et al., 2018 <https://arxiv.org/pdf/1709.06009.pdf>`_
     in Section 5.2 on page 12.
+
+    Example:
+        >>> import gymnasium as gym
+        >>> env = gym.make("CartPole-v1")
+        >>> env.reset(seed=123)
+        (array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32), {})
+
+        >>> env.step(1)
+        (array([ 0.01734283,  0.15089367, -0.02859527, -0.33293587], dtype=float32), 1.0, False, False, {})
+
+        >>> env.step(0)
+        (array([ 0.0203607 , -0.04380985, -0.03525399, -0.04940585], dtype=float32), 1.0, False, False, {})
+
+        >>> env.step(1)
+        (array([ 0.01948451,  0.15179941, -0.03624211, -0.35299996], dtype=float32), 1.0, False, False, {})
+
+        >>> env.step(0)
+        (array([ 0.02252049, -0.04278894, -0.0433021 , -0.07196194], dtype=float32), 1.0, False, False, {})
+
+        >>> env = gym.make("CartPole-v1")
+        >>> env = StickyActionV0(env, repeat_action_probability=0.9)
+        >>> env.reset(seed=123)
+        (array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32), {})
+
+        >>> env.step(1)
+        (array([ 0.01734283,  0.15089367, -0.02859527, -0.33293587], dtype=float32), 1.0, False, False, {})
+
+        >>> env.step(0)
+        (array([ 0.0203607 ,  0.34641072, -0.03525399, -0.6344974 ], dtype=float32), 1.0, False, False, {})
+
+        >>> env.step(1)
+        (array([ 0.02728892,  0.5420062 , -0.04794393, -0.9380709 ], dtype=float32), 1.0, False, False, {})
+
+        >>> env.step(0)
+        (array([ 0.03812904,  0.73774064, -0.06670535, -1.2454252 ], dtype=float32), 1.0, False, False, {})
+
     """
 
     def __init__(

--- a/gymnasium/wrappers/stateful_action.py
+++ b/gymnasium/wrappers/stateful_action.py
@@ -37,7 +37,6 @@ class StickyActionV0(
 
         >>> env.step(0)
         (array([ 0.03812904,  0.73774064, -0.06670535, -1.2454252 ], dtype=float32), 1.0, False, False, {})
-
     """
 
     def __init__(

--- a/gymnasium/wrappers/stateful_action.py
+++ b/gymnasium/wrappers/stateful_action.py
@@ -36,7 +36,7 @@ class StickyActionV0(
         (array([ 0.02728892,  0.5420062 , -0.04794393, -0.9380709 ], dtype=float32), 1.0, False, False, {})
 
         >>> env.step(0)
-        (array([ 0.03812904,  0.73774064, -0.06670535, -1.2454252 ], dtype=float32), 1.0, False, False, {})
+        (array([ 0.03812904,  0.34756234, -0.06670535, -0.6608303 ], dtype=float32), 1.0, False, alse, {})
     """
 
     def __init__(

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -411,7 +411,7 @@ class NormalizeObservationV0(
         >>> obs, info
         (array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32), {})
         >>> np.var(obs)
-        0.0008606825
+        0.00056409097
         >>> env = NormalizeObservationV0(env, delay=2)
         >>> obs, info = env.reset(seed=123)
         >>> obs, info

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -408,16 +408,21 @@ class NormalizeObservationV0(
         >>> import gymnasium as gym
         >>> env = gym.make("CartPole-v1")
         >>> obs, info = env.reset(seed=123)
-        >>> obs, info
-        (array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32), {})
-        >>> np.var(obs)
-        0.00056409097
+        >>> term, trunc = False, False
+        >>> while not (term or trunc):
+        ...     obs, _, term, trunc, _ = env.step(1)
+        ...
+        >>> obs
+        array([ 0.1511158 ,  1.7183299 , -0.25533703, -2.8914354 ], dtype=float32)
+        >>> env = gym.make("CartPole-v1")
         >>> env = NormalizeObservationV0(env)
         >>> obs, info = env.reset(seed=123)
-        >>> obs, info
-        (array([ 1.6538188 , -0.9636979 , -0.27014682, -0.42001915], dtype=float32), {})
-        >>> np.var(obs)
-        0.9783064
+        >>> term, trunc = False, False
+        >>> while not (term or trunc):
+        ...     obs, _, term, trunc, _ = env.step(1)
+        ...
+        >>> obs
+        array([ 2.0059888,  1.5676788, -1.9944268, -1.6120394], dtype=float32)
     """
 
     def __init__(self, env: gym.Env[ObsType, ActType], epsilon: float = 1e-8):

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -470,7 +470,6 @@ class MaxAndSkipObservationV0(
     Example:
         >>> import gymnasium as gym
         >>> env = gym.make("CartPole-v1")
-        >>> action_space = env.action_space
         >>> obs0, *_ = env.reset(seed=123)
         >>> obs1, *_ = env.step(1)
         >>> obs2, *_ = env.step(1)

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -402,6 +402,25 @@ class NormalizeObservationV0(
     Note:
         The normalization depends on past trajectories and observations will not be normalized correctly if the wrapper was
         newly instantiated or the policy was changed recently.
+
+    Example:
+        >>> import numpy as np
+        >>> import gymnasium as gym
+        >>> env = gym.make("CartPole-v1")
+        >>> obs, info = env.reset(seed=123)
+        >>> obs, info
+        (array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32), {})
+
+        >>> np.var(obs)
+        >>> 0.0008606825
+
+        >>> env = NormalizeObservationV0(env, delay=2)
+        >>> obs, info = env.reset(seed=123)
+        >>> obs, info
+        (array([ 1.6538188 , -0.9636979 , -0.27014682, -0.42001915], dtype=float32), {})
+
+        >>> np.var(obs)
+        >>> 0.9783064
     """
 
     def __init__(self, env: gym.Env[ObsType, ActType], epsilon: float = 1e-8):
@@ -447,6 +466,27 @@ class MaxAndSkipObservationV0(
 
     Note:
         This wrapper is based on the wrapper from [stable-baselines3](https://stable-baselines3.readthedocs.io/en/master/_modules/stable_baselines3/common/atari_wrappers.html#MaxAndSkipEnv)
+
+    Example:
+        >>> import gymnasium as gym
+        >>> env = gym.make("CartPole-v1")
+        >>> action_space = env.action_space
+        >>> obs0, *_ = env.reset(seed=123)
+        >>> obs1, *_ = env.step(1)
+        >>> obs2, *_ = env.step(1)
+        >>> obs3, *_ = env.step(1)
+        >>> obs4, *_ = env.step(1)
+
+        >>> env = gym.make("CartPole-v1")
+        >>> wrapped_env = MaxAndSkipObservationV0(env)
+        >>> wrapped_obs0, *_ = wrapped_env.reset(seed=123)
+        >>> wrapped_obs1, *_ = wrapped_env.step(1)
+        >>> (wrapped_obs0 == obs0).all()
+        True
+
+        >>> (wrapped_obs0 == obs4).all()
+        True
+
     """
 
     def __init__(self, env: gym.Env[ObsType, ActType], skip: int = 4):

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -38,6 +38,9 @@ class DelayObservationV0(
     Before reaching the :attr:`delay` number of timesteps, returned observations is an array of zeros with
     the same shape as the observation space.
 
+    Note:
+        This does not support random delay values, if users are interested, please raise an issue or pull request to add this feature.
+
     Example:
         >>> import gymnasium as gym
         >>> env = gym.make("CartPole-v1")
@@ -51,9 +54,6 @@ class DelayObservationV0(
         (array([0., 0., 0., 0.], dtype=float32), 1.0, False, False, {})
         >>> env.step(env.action_space.sample())
         (array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32), 1.0, False, False, {})
-
-    Note:
-        This does not support random delay values, if users are interested, please raise an issue or pull request to add this feature.
     """
 
     def __init__(self, env: gym.Env[ObsType, ActType], delay: int):
@@ -410,17 +410,14 @@ class NormalizeObservationV0(
         >>> obs, info = env.reset(seed=123)
         >>> obs, info
         (array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32), {})
-
         >>> np.var(obs)
-        >>> 0.0008606825
-
+        0.0008606825
         >>> env = NormalizeObservationV0(env, delay=2)
         >>> obs, info = env.reset(seed=123)
         >>> obs, info
         (array([ 1.6538188 , -0.9636979 , -0.27014682, -0.42001915], dtype=float32), {})
-
         >>> np.var(obs)
-        >>> 0.9783064
+        0.9783064
     """
 
     def __init__(self, env: gym.Env[ObsType, ActType], epsilon: float = 1e-8):
@@ -475,17 +472,15 @@ class MaxAndSkipObservationV0(
         >>> obs2, *_ = env.step(1)
         >>> obs3, *_ = env.step(1)
         >>> obs4, *_ = env.step(1)
-
+        >>> skip_and_max_obs = np.max(np.stack([obs3, obs4], axis=0), axis=0)
         >>> env = gym.make("CartPole-v1")
         >>> wrapped_env = MaxAndSkipObservationV0(env)
         >>> wrapped_obs0, *_ = wrapped_env.reset(seed=123)
         >>> wrapped_obs1, *_ = wrapped_env.step(1)
-        >>> (wrapped_obs0 == obs0).all()
+        >>> np.all(obs0 == wrapped_obs0)
         True
-
-        >>> (wrapped_obs0 == obs4).all()
+        >>> np.all(wrapped_obs1 == skip_and_max_obs)
         True
-
     """
 
     def __init__(self, env: gym.Env[ObsType, ActType], skip: int = 4):

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -412,7 +412,7 @@ class NormalizeObservationV0(
         (array([ 0.01823519, -0.0446179 , -0.02796401, -0.03156282], dtype=float32), {})
         >>> np.var(obs)
         0.00056409097
-        >>> env = NormalizeObservationV0(env, delay=2)
+        >>> env = NormalizeObservationV0(env)
         >>> obs, info = env.reset(seed=123)
         >>> obs, info
         (array([ 1.6538188 , -0.9636979 , -0.27014682, -0.42001915], dtype=float32), {})

--- a/gymnasium/wrappers/stateful_reward.py
+++ b/gymnasium/wrappers/stateful_reward.py
@@ -62,8 +62,7 @@ class NormalizeRewardV1(
         ...
         >>> # will approach 0.99 with more episodes
         >>> np.var(episode_rewards)
-        0.0008876301247721108
-
+        0.010162116476634746
     """
 
     def __init__(

--- a/gymnasium/wrappers/stateful_reward.py
+++ b/gymnasium/wrappers/stateful_reward.py
@@ -51,7 +51,7 @@ class NormalizeRewardV1(
         0.0008876301247721108
 
         >>> env = gym.make('MountainCarContinuous-v0')
-        >>> env = NormalizeRewardV1(env, gamme=0.99, epsilon=1e-8)
+        >>> env = NormalizeRewardV1(env, gamma=0.99, epsilon=1e-8)
         >>> _ = env.reset(seed=123)
         >>> _ = env.action_space.seed(123)
         >>> episode_rewards = []

--- a/gymnasium/wrappers/stateful_reward.py
+++ b/gymnasium/wrappers/stateful_reward.py
@@ -28,12 +28,42 @@ class NormalizeRewardV1(
     If False, the calculated statistics are used but not updated anymore; this may be used during evaluation.
 
     Note:
-        In v0.27, NormalizeReward was updated as the forward discounted reward estimate was incorrect computed in Gym v0.25+.
+        In v0.27, NormalizeReward was updated as the forward discounted reward estimate was incorrectly computed in Gym v0.25+.
         For more detail, read [#3154](https://github.com/openai/gym/pull/3152).
 
     Note:
         The scaling depends on past trajectories and rewards will not be scaled correctly if the wrapper was newly
         instantiated or the policy was changed recently.
+
+    Example:
+        >>> import numpy as np
+        >>> import gymnasium as gym
+        >>> env = gym.make('MountainCarContinuous-v0')
+        >>> _ = env.reset(seed=123)
+        >>> _ = env.action_space.seed(123)
+        >>> episode_rewards = []
+        >>> terminated, truncated = False, False
+        >>> while not (terminated or truncated):
+        ...     observation, reward, terminated, truncated, info = env.step(env.action_space.sample())
+        ...     episode_rewards.append(reward)
+        ...
+        >>> np.var(episode_rewards)
+        0.0008876301247721108
+
+        >>> env = gym.make('MountainCarContinuous-v0')
+        >>> env = NormalizeRewardV1(env, gamme=0.99, epsilon=1e-8)
+        >>> _ = env.reset(seed=123)
+        >>> _ = env.action_space.seed(123)
+        >>> episode_rewards = []
+        >>> terminated, truncated = False, False
+        >>> while not (terminated or truncated):
+        ...     observation, reward, terminated, truncated, info = env.step(env.action_space.sample())
+        ...     episode_rewards.append(reward)
+        ...
+        >>> # will approach 0.99 with more episodes
+        >>> np.var(episode_rewards)
+        0.0008876301247721108
+
     """
 
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,4 +154,3 @@ reportUnboundVariable = "warning"
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning:gymnasium.*:"]
-addopts = "--ignore=gymnasium/wrappers/jax_to_numpy.py --ignore=gymnasium/wrappers/jax_to_torch.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,3 +154,4 @@ reportUnboundVariable = "warning"
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning:gymnasium.*:"]
+addopts = "--ignore=gymnasium/wrappers/jax_to_numpy.py --ignore=gymnasium/wrappers/jax_to_torch.py"


### PR DESCRIPTION
# Description

This adds more example code to the docs for the wrappers.

Todo:

- [x] atari_preprocessing.py
- [x] jax_to_numpy.py
- [x] jax_to_torch.py
- [x] lambda_action.py
- [x] lambda_observation.py
- [x] lambda_reward.py
- [x] numpy_to_torch.py
- [x] rendering.py
- [x] stateful_action.py
- [x] stateful_observation.py
- [x] stateful_reward.py