### PR TITLE
Improve the normalize vector wrapper tests

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -265,6 +265,7 @@ class Wrapper(
             env: The environment to wrap
         """
         self.env = env
+        assert isinstance(env, Env)
 
         self._action_space: spaces.Space[WrapperActType] | None = None
         self._observation_space: spaces.Space[WrapperObsType] | None = None

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -313,10 +313,10 @@ class VectorWrapper(VectorEnv):
         self.env = env
         assert isinstance(env, VectorEnv)
 
-        _observation_space: gym.Space | None = None
-        _action_space: gym.Space | None = None
-        _single_observation_space: gym.Space | None = None
-        _single_action_space: gym.Space | None = None
+        self._observation_space: gym.Space | None = None
+        self._action_space: gym.Space | None = None
+        self._single_observation_space: gym.Space | None = None
+        self._single_action_space: gym.Space | None = None
 
     def reset(
         self,

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -304,21 +304,19 @@ class VectorWrapper(VectorEnv):
         Don't forget to call `super().__init__(env)` if the subclass overrides :meth:`__init__`.
     """
 
-    _observation_space: gym.Space | None = None
-    _action_space: gym.Space | None = None
-    _single_observation_space: gym.Space | None = None
-    _single_action_space: gym.Space | None = None
-
     def __init__(self, env: VectorEnv):
         """Initialize the vectorized environment wrapper.
 
         Args:
             env: The environment to wrap
         """
-        super().__init__()
-
-        assert isinstance(env, VectorEnv)
         self.env = env
+        assert isinstance(env, VectorEnv)
+
+        _observation_space: gym.Space | None = None
+        _action_space: gym.Space | None = None
+        _single_observation_space: gym.Space | None = None
+        _single_action_space: gym.Space | None = None
 
     def reset(
         self,

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -433,7 +433,7 @@ class NormalizeObservationV0(
     def observation(self, observation: ObsType) -> WrapperObsType:
         """Normalises the observation using the running mean and variance of the observations."""
         if self._update_running_mean:
-            self.obs_rms.update(observation)
+            self.obs_rms.update(np.array([observation]))
         return (observation - self.obs_rms.mean) / np.sqrt(
             self.obs_rms.var + self.epsilon
         )

--- a/gymnasium/wrappers/stateful_reward.py
+++ b/gymnasium/wrappers/stateful_reward.py
@@ -75,9 +75,9 @@ class NormalizeRewardV1(
         obs, reward, terminated, truncated, info = super().step(action)
 
         # Using the `discounted_reward` rather than `reward` makes no sense but for backward compatibility, it is being kept
-        self.discounted_reward = float(reward) + self.discounted_reward * self.gamma * (
+        self.discounted_reward = self.discounted_reward * self.gamma * (
             1 - terminated
-        )
+        ) + float(reward)
         if self._update_running_mean:
             self.return_rms.update(self.discounted_reward)
 

--- a/gymnasium/wrappers/stateful_reward.py
+++ b/gymnasium/wrappers/stateful_reward.py
@@ -73,13 +73,14 @@ class NormalizeRewardV1(
     ) -> tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]:
         """Steps through the environment, normalizing the reward returned."""
         obs, reward, terminated, truncated, info = super().step(action)
-        self.discounted_reward = self.discounted_reward * self.gamma * (
-            1 - terminated
-        ) + float(reward)
-        return obs, self.normalize(float(reward)), terminated, truncated, info
 
-    def normalize(self, reward: SupportsFloat):
-        """Normalizes the rewards with the running mean rewards and their variance."""
+        # Using the `discounted_reward` rather than `reward` makes no sense but for backward compatibility, it is being kept
+        self.discounted_reward = float(reward) + self.discounted_reward * self.gamma * (
+            1 - terminated
+        )
         if self._update_running_mean:
             self.return_rms.update(self.discounted_reward)
-        return reward / np.sqrt(self.return_rms.var + self.epsilon)
+
+        # We don't (reward - self.return_rms.mean) see https://github.com/openai/baselines/issues/538
+        normalized_reward = reward / np.sqrt(self.return_rms.var + self.epsilon)
+        return obs, normalized_reward, terminated, truncated, info

--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 import numpy as np
 
 import gymnasium as gym
-from gymnasium.core import ActType, ObsType
-from gymnasium.vector.vector_env import VectorObservationWrapper
+from gymnasium.core import ObsType
+from gymnasium.vector.vector_env import VectorEnv, VectorObservationWrapper
 from gymnasium.wrappers.utils import RunningMeanStd
 
 
@@ -27,7 +27,7 @@ class NormalizeObservationV0(VectorObservationWrapper, gym.utils.RecordConstruct
         newly instantiated or the policy was changed recently.
     """
 
-    def __init__(self, env: gym.Env[ObsType, ActType], epsilon: float = 1e-8):
+    def __init__(self, env: VectorEnv, epsilon: float = 1e-8):
         """This wrapper will normalize observations s.t. each coordinate is centered with unit variance.
 
         Args:
@@ -35,7 +35,7 @@ class NormalizeObservationV0(VectorObservationWrapper, gym.utils.RecordConstruct
             epsilon: A stability parameter that is used when scaling the observations.
         """
         gym.utils.RecordConstructorArgs.__init__(self, epsilon=epsilon)
-        gym.ObservationWrapper.__init__(self, env)
+        VectorObservationWrapper.__init__(self, env)
 
         self.obs_rms = RunningMeanStd(
             shape=self.single_observation_space.shape,

--- a/gymnasium/wrappers/vector/stateful_reward.py
+++ b/gymnasium/wrappers/vector/stateful_reward.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import gymnasium as gym
 from gymnasium.core import ActType, ObsType
-from gymnasium.vector.vector_env import VectorEnv, VectorWrapper
+from gymnasium.vector.vector_env import ArrayType, VectorEnv, VectorWrapper
 from gymnasium.wrappers.utils import RunningMeanStd
 
 
@@ -45,7 +45,7 @@ class NormalizeRewardV1(VectorWrapper, gym.utils.RecordConstructorArgs):
             gamma (float): The discount factor that is used in the exponential moving average.
         """
         gym.utils.RecordConstructorArgs.__init__(self, gamma=gamma, epsilon=epsilon)
-        gym.Wrapper.__init__(self, env)
+        VectorWrapper.__init__(self, env)
 
         self.return_rms = RunningMeanStd(shape=())
         self.accumulated_reward: np.array = np.zeros((self.num_envs,), dtype=np.float32)
@@ -64,10 +64,10 @@ class NormalizeRewardV1(VectorWrapper, gym.utils.RecordConstructorArgs):
         self._update_running_mean = setting
 
     def step(
-        self, action: ActType
-    ) -> tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]:
+        self, actions: ActType
+    ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, dict[str, Any]]:
         """Steps through the environment, normalizing the reward returned."""
-        obs, reward, terminated, truncated, info = super().step(action)
+        obs, reward, terminated, truncated, info = super().step(actions)
         self.accumulated_reward = (
             self.accumulated_reward * self.gamma * (1 - terminated) + reward
         )

--- a/tests/wrappers/test_normalize_reward.py
+++ b/tests/wrappers/test_normalize_reward.py
@@ -54,27 +54,30 @@ def test_normalize_reward_wrapper():
 
 def reward_reset_func(self: gym.Env, seed=None, options=None):
     self.rewards = [0, 1, 2, 3, 4]
-    return np.array([self.rewards.pop(0)]), {}
+    reward = self.rewards.pop(0)
+    return np.array([reward]), {"reward": reward}
 
 
 def reward_step_func(self: gym.Env, action):
     reward = self.rewards.pop(0)
-    return np.array([reward]), reward, len(self.rewards), False, {}
+    return np.array([reward]), reward, len(self.rewards) == 0, False, {"reward": reward}
 
 
 def test_normalize_return():
     env = GenericTestEnv(reset_func=reward_reset_func, step_func=reward_step_func)
     env = NormalizeRewardV1(env)
     env.reset()
+
     env.step(env.action_space.sample())
     np.testing.assert_almost_equal(
         env.return_rms.mean,
         np.mean([1]),  # [first return]
         decimal=4,
     )
+
     env.step(env.action_space.sample())
     np.testing.assert_almost_equal(
         env.return_rms.mean,
-        np.mean([2 + env.gamma * 1, 1]),  # [second return, first return]
+        np.mean([2 + 1 * env.gamma, 1]),  # [second return, first return]
         decimal=4,
     )

--- a/tests/wrappers/vector/test_normalize_observation.py
+++ b/tests/wrappers/vector/test_normalize_observation.py
@@ -3,22 +3,44 @@ import numpy as np
 
 from gymnasium import spaces, wrappers
 from gymnasium.vector import SyncVectorEnv
+from gymnasium.vector.utils import create_empty_array
 from tests.testing_env import GenericTestEnv
 
 
 def thunk():
     return GenericTestEnv(
         observation_space=spaces.Box(
-            np.full((10,), fill_value=-100),
-            np.full((10,), fill_value=10),
-            dtype=np.float32,
+            low=np.array([0, -10, -5], dtype=np.float32),
+            high=np.array([10, -5, 10], dtype=np.float32),
         )
     )
 
 
-def test_normalize_obs():
-    env_fns = [thunk for _ in range(16)]
-    env = SyncVectorEnv(env_fns)
+def test_against_wrapper(
+    n_envs=3,
+    n_steps=250,
+    mean_rtol=np.array([0.1, 0.4, 0.25]),
+    var_rtol=np.array([0.15, 0.15, 0.18]),
+):
+    vec_env = SyncVectorEnv([thunk for _ in range(n_envs)])
+    vec_env = wrappers.vector.NormalizeObservationV0(vec_env)
+
+    vec_env.reset()
+    for _ in range(n_steps):
+        vec_env.step(vec_env.action_space.sample())
+
+    env = wrappers.AutoresetV0(thunk())
+    env = wrappers.NormalizeObservationV0(env)
+    env.reset()
+    for _ in range(n_envs * n_steps):
+        env.step(env.action_space.sample())
+
+    assert np.allclose(env.obs_rms.mean, vec_env.obs_rms.mean, rtol=mean_rtol)
+    assert np.allclose(env.obs_rms.var, vec_env.obs_rms.var, rtol=var_rtol)
+
+
+def test_update_running_mean():
+    env = SyncVectorEnv([thunk for _ in range(3)])
     env = wrappers.vector.NormalizeObservationV0(env)
 
     # Default value is True
@@ -30,44 +52,18 @@ def test_normalize_obs():
         action = env.action_space.sample()
         env.step(action)
 
+    # Disable
     env.update_running_mean = False
-    rms_var = env.obs_rms.var
-    rms_mean = env.obs_rms.mean
+    rms_var = np.copy(env.obs_rms.vec_var)
+    rms_mean = np.copy(env.obs_rms.vec_mean)
 
     val_step = 25
-    obs_buffer = np.empty(
-        (val_step,) + env.observation_space.shape, dtype=env.observation_space.dtype
-    )
+    obs_buffer = create_empty_array(env.observation_space, val_step)
     for i in range(val_step):
-        action = env.action_space.sample()
-        obs, _, _, _, _ = env.step(action)
+        obs, _, _, _, _ = env.step(env.action_space.sample())
         obs_buffer[i] = obs
 
     assert np.all(rms_var == env.obs_rms.var)
     assert np.all(rms_mean == env.obs_rms.mean)
-    assert np.allclose(np.std(obs_buffer, axis=0), 1, atol=1)
-    assert np.allclose(np.mean(obs_buffer, axis=0), 0, atol=1)
-
-
-def test_against_wrapper():
-    n_envs, n_steps = 16, 100
-    env_fns = [thunk for _ in range(n_envs)]
-    vec_env = SyncVectorEnv(env_fns)
-    vec_env = wrappers.vector.NormalizeObservationV0(vec_env)
-
-    vec_env.reset()
-    for _ in range(n_steps):
-        action = vec_env.action_space.sample()
-        vec_env.step(action)
-
-    env = thunk()
-    env = wrappers.NormalizeObservationV0(env)
-    env.reset()
-    for _ in range(n_envs * n_steps):
-        action = env.action_space.sample()
-        env.step(action)
-
-    rtol = 0.07
-    atol = 0
-    assert np.allclose(env.obs_rms.mean, vec_env.obs_rms.mean, rtol=rtol, atol=atol)
-    assert np.allclose(env.obs_rms.var, vec_env.obs_rms.var, rtol=rtol, atol=atol)
+    assert np.allclose(np.var(obs_buffer, axis=0), env.obs_rms.var, atol=1)
+    assert np.allclose(np.mean(obs_buffer, axis=0), env.obs_rms.mean, atol=1)

--- a/tests/wrappers/vector/test_normalize_reward.py
+++ b/tests/wrappers/vector/test_normalize_reward.py
@@ -49,7 +49,7 @@ def test_functionality(
     env.close()
 
     forward_rets = np.asarray(forward_rets)
-    assert np.allclose(np.std(forward_rets), 1, atol=0.2)
+    assert np.allclose(np.std(forward_rets, axis=0), 1.33, atol=0.1)
 
 
 def test_against_wrapper(n_envs=3, n_steps=100, rtol=0.01, atol=0):

--- a/tests/wrappers/vector/test_normalize_reward.py
+++ b/tests/wrappers/vector/test_normalize_reward.py
@@ -9,37 +9,37 @@ from gymnasium.vector import SyncVectorEnv
 from tests.testing_env import GenericTestEnv
 
 
-def make_env():
-    def reset_func(self, seed: Optional[int] = None, options: Optional[dict] = None):
-        self.step_id = 0
-        return self.observation_space.sample(), {}
-
-    def step_func(self, action: ActType):
-        self.step_id += 1
-        done = self.step_id == 10
-        print(self.step_id)
-        return self.observation_space.sample(), float(done), done, False, {}
-
-    def thunk():
-        return GenericTestEnv(step_func=step_func, reset_func=reset_func)
-
-    return thunk
+def reset_func(self, seed: Optional[int] = None, options: Optional[dict] = None):
+    self.step_id = 0
+    return self.observation_space.sample(), {}
 
 
-def test_normalize_rew():
-    env_fns = [make_env() for _ in range(8)]
-    env = SyncVectorEnv(env_fns)
+def step_func(self, action: ActType):
+    self.step_id += 1
+    terminated = self.step_id == 10
+    return self.observation_space.sample(), float(terminated), terminated, False, {}
+
+
+def thunk():
+    return GenericTestEnv(step_func=step_func, reset_func=reset_func)
+
+
+def test_functionality(
+    n_envs=3,
+    n_steps=100,
+):
+    env = SyncVectorEnv([thunk for _ in range(n_envs)])
     env = wrappers.vector.NormalizeRewardV1(env)
 
     env.reset()
-    for _ in range(100):
+    for _ in range(n_steps):
         action = env.action_space.sample()
         env.step(action)
 
     env.reset()
     forward_rets = []
     accumulated_rew = 0
-    for _ in range(10):
+    for _ in range(n_steps):
         action = env.action_space.sample()
         _, rew, ter, tru, _ = env.step(action)
         dones = np.logical_or(ter, tru)
@@ -52,24 +52,19 @@ def test_normalize_rew():
     assert np.allclose(np.std(forward_rets), 1, atol=0.2)
 
 
-def test_against_wrapper():
-    env_fns = [make_env() for _ in range(8)]
-    vec_env = SyncVectorEnv(env_fns)
+def test_against_wrapper(n_envs=3, n_steps=100, rtol=0.01, atol=0):
+    vec_env = SyncVectorEnv([thunk for _ in range(n_envs)])
     vec_env = wrappers.vector.NormalizeRewardV1(vec_env)
     vec_env.reset()
-    for _ in range(100):
+    for _ in range(n_steps):
         action = vec_env.action_space.sample()
         vec_env.step(action)
 
-    env = make_env()()
+    env = wrappers.AutoresetV0(thunk())
     env = wrappers.NormalizeRewardV1(env)
     env.reset()
-    for _ in range(100):
+    for _ in range(n_steps):
         action = env.action_space.sample()
         _, _, ter, tru, _ = env.step(action)
-        if ter or tru:
-            env.reset()
 
-    rtol = 0.01
-    atol = 0
     assert np.allclose(env.return_rms.var, vec_env.return_rms.var, rtol=rtol, atol=atol)


### PR DESCRIPTION
# Description

We include tests that the `wrappers.vector.NormalizeReward` and `wrappers.vector.NormalizeObservation` wrappers work similarly to `wrappers.NormalizeReward` and `wrappers.NormalizeObservation`. 
However, the bounds on similarity were too small and caused the tests to fail occur. 

As a result, we fix a bug in `wrappers.NormalizeObservation` where every dimension was equally normalize rather than individually normalized. 

For reference, the code used to test and evaluate this
```python
#!/usr/bin/env python
# coding: utf-8

# In[9]:


import numpy as np
from tqdm import tqdm
import matplotlib.pyplot as plt
import gymnasium as gym
from gymnasium.spaces import Box
from tests.testing_env import GenericTestEnv


# In[17]:


NUM_ENVS = 3
ENV_ID = "TestEnv-v0"
LENGTH = 500
REPEATS = 100

gym.register("TestEnv-v0", lambda: GenericTestEnv(observation_space=Box(low=np.array([0, -10, -5]), high=np.array([10, -5, 10]))))

obs_shape = gym.make(ENV_ID).observation_space.shape[0]


# In[18]:


vec_mean = np.zeros((REPEATS, LENGTH, obs_shape))
vec_var = np.zeros((REPEATS, LENGTH, obs_shape))

for i in tqdm(range(REPEATS)):
    envs = gym.make_vec(ENV_ID, NUM_ENVS, vectorization_mode="sync")
    envs = gym.wrappers.vector.NormalizeObservationV0(envs)

    envs.reset()
    for j in range(LENGTH):
        envs.step(envs.action_space.sample())

        vec_mean[i, j] = envs.obs_rms.mean
        vec_var[i, j] = envs.obs_rms.var

    envs.close()


# In[19]:


single_mean = np.zeros((REPEATS, LENGTH, obs_shape))
single_var = np.zeros((REPEATS, LENGTH, obs_shape))

for i in tqdm(range(REPEATS)):
    env = gym.wrappers.AutoresetV0(gym.make(ENV_ID))
    env = gym.wrappers.NormalizeObservationV0(env)

    env.reset()
    for j in range(LENGTH):
        env.step(env.action_space.sample())

        single_mean[i, j] = env.obs_rms.mean
        single_var[i, j] = env.obs_rms.var

    env.close()


# In[20]:


fig, axs = plt.subplots(nrows=2, ncols=obs_shape, figsize=(12, 6))
fig.suptitle("Obs Mean")

axs[0, 0].set_ylabel("Vec")
axs[1, 0].set_ylabel("Single")
for i in range(obs_shape):
    for row in range(REPEATS):
        axs[0, i].plot(np.arange(LENGTH), vec_mean[row, :, i])
        axs[1, i].plot(np.arange(LENGTH), single_mean[row, :, i])

plt.tight_layout()


# In[21]:


fig, axs = plt.subplots(nrows=2, ncols=obs_shape, figsize=(12, 6))
fig.suptitle("Obs Var")

axs[0, 0].set_ylabel("Vec")
axs[1, 0].set_ylabel("Single")
for i in range(obs_shape):
    for row in range(REPEATS):
        axs[0, i].plot(np.arange(LENGTH), vec_var[row, :, i])
        axs[1, i].plot(np.arange(LENGTH), single_var[row, :, i])

plt.tight_layout()


# In[3]:


## Testing with a seed
env = gym.wrappers.AutoresetV0(gym.make(ENV_ID))

env.action_space.seed(123)
actions = [env.action_space.sample() for _ in range(LENGTH)]

obs = np.zeros((LENGTH, obs_shape))
env.reset(seed=123)
for i, action in zip(range(LENGTH), actions):
    obs[i], _, _, _, _ = env.step(action)

env.reset(seed=123)
env = gym.wrappers.NormalizeObservationV0(env)
for action in actions:
    env.step(action)

print(f'Actual mean={np.mean(obs, axis=0)}, var={np.var(obs, axis=0)}')
print(f'Normalize mean={env.obs_rms.mean}, var={env.obs_rms.var}')


# In[29]:


from gymnasium.vector import SyncVectorEnv


def thunk():
    return GenericTestEnv(
        observation_space=Box(
            low=np.array([0, -10, -5], dtype=np.float32),
            high=np.array([10, -5, 10], dtype=np.float32),
        )
    )


rtols = np.zeros((250, 2, 3))
for i in tqdm(range(250)):
    vec_env = SyncVectorEnv([thunk for _ in range(NUM_ENVS)])
    vec_env = gym.wrappers.vector.NormalizeObservationV0(vec_env)

    vec_env.reset()
    for _ in range(250):
        vec_env.step(vec_env.action_space.sample())

    env = gym.wrappers.AutoresetV0(thunk())
    env = gym.wrappers.NormalizeObservationV0(env)
    env.reset()
    for _ in range(250 * 3):
        env.step(env.action_space.sample())

    mean_rtol = np.abs(env.obs_rms.mean - vec_env.obs_rms.mean) / np.abs(vec_env.obs_rms.mean)
    var_rtol = np.abs(env.obs_rms.var - vec_env.obs_rms.var) / np.abs(vec_env.obs_rms.var)
    # print(f'{mean_rtol=}, {var_rtol=}')
    rtols[i] = np.array([mean_rtol, var_rtol])

    # assert np.allclose(env.obs_rms.mean, vec_env.obs_rms.mean, rtol=0.07)
    # assert np.allclose(env.obs_rms.var, vec_env.obs_rms.var, rtol=0.07)


# In[30]:


fig, axs = plt.subplots(nrows=2, ncols=3)

axs[0, 0].set_ylabel("Mean")
axs[1, 0].set_ylabel("Var")
for i in range(3):
    axs[0, i].hist(rtols[:, 0, i], bins=25)
    axs[1, i].hist(rtols[:, 1, i], bins=25)
```
