### PR TITLE
Update third party environments: CARL to gymnasium

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -22,7 +22,7 @@ many-agent RL ([MAgent2](https://magent2.farama.org/)),
 ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.27.1-blue)
 ![GitHub stars](https://img.shields.io/github/stars/automl/carl)
 
-Contextual extensions of popular reinforcement learning environments that enable training and test distributions for generalization, e.g. CartPole with variable pole lengths or Brax robots with different ground frictions. 
+Contextual extensions of popular reinforcement learning environments that enable training and test distributions for generalization, e.g. CartPole with variable pole lengths or Brax robots with different ground frictions.
 
 ### [DACBench: a benchmark for Dynamic Algorithm Configuration](https://github.com/automl/DACBench)
 


### PR DESCRIPTION
# Description

Updated the third party env page since CARL is now using gymnasium.
- removed CARL (and also DACBench) from gym list
- added CARL to gymnasium list

Fixes # (issue)

## Type of change
Documentation update

