### PR TITLE
Fix scoping of variables

### DIFF
--- a/docs/tutorials/training_agents/blackjack_tutorial.py
+++ b/docs/tutorials/training_agents/blackjack_tutorial.py
@@ -176,6 +176,7 @@ observation, reward, terminated, truncated, info = env.step(action)
 class BlackjackAgent:
     def __init__(
         self,
+        env,
         learning_rate: float,
         initial_epsilon: float,
         epsilon_decay: float,
@@ -203,7 +204,7 @@ class BlackjackAgent:
 
         self.training_error = []
 
-    def get_action(self, obs: tuple[int, int, bool]) -> int:
+    def get_action(self, env, obs: tuple[int, int, bool]) -> int:
         """
         Returns the best action with probability (1 - epsilon)
         otherwise a random action with probability epsilon to ensure exploration.
@@ -236,7 +237,7 @@ class BlackjackAgent:
         self.training_error.append(temporal_difference)
 
     def decay_epsilon(self):
-        self.epsilon = max(self.final_epsilon, self.epsilon - epsilon_decay)
+        self.epsilon = max(self.final_epsilon, self.epsilon - self.epsilon_decay)
 
 
 # %%
@@ -256,6 +257,7 @@ epsilon_decay = start_epsilon / (n_episodes / 2)  # reduce the exploration over 
 final_epsilon = 0.1
 
 agent = BlackjackAgent(
+    env=env,
     learning_rate=learning_rate,
     initial_epsilon=start_epsilon,
     epsilon_decay=epsilon_decay,
@@ -278,7 +280,7 @@ for episode in tqdm(range(n_episodes)):
 
     # play one episode
     while not done:
-        action = agent.get_action(obs)
+        action = agent.get_action(env, obs)
         next_obs, reward, terminated, truncated, info = env.step(action)
 
         # update the agent


### PR DESCRIPTION
# Description

Since the env and agent were defined in the same file, the BlackjackAgent's referencing to 'env' always worked, but technically it wasn't in the scope of the agent.

The same happend with reference to epsilon_decay value which was also initialized in the agents scope.

Specifying the env in the init and get_action functions makes the separation of the classes proper.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

