### PR TITLE
Rename `AsyncVectorEnv` or `SyncVectorEnv` attributes

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -38,6 +38,7 @@ __all__ = ["AsyncVectorEnv", "AsyncState"]
 
 
 class AsyncState(Enum):
+    """The AsyncVectorEnv possible states given the different actions."""
     DEFAULT = "default"
     WAITING_RESET = "reset"
     WAITING_STEP = "step"
@@ -381,11 +382,8 @@ class AsyncVectorEnv(VectorEnv):
                 self.observations,
             )
 
-        if self.copy:
-            self.observations = deepcopy(self.observations)
-
         return (
-            self.observations,
+            deepcopy(self.observations) if self.copy else self.observations,
             np.array(rewards, dtype=np.float64),
             np.array(terminateds, dtype=np.bool_),
             np.array(truncateds, dtype=np.bool_),

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -73,6 +73,7 @@ class SyncVectorEnv(VectorEnv):
         # Define core attributes using the sub-environments
         self.num_envs = len(self.envs)
         self.metadata = self.envs[0].metadata
+        self.spec = self.envs[0].spec
 
         # Initialises the single spaces from the sub-environments
         self.single_observation_space = self.envs[0].observation_space
@@ -95,9 +96,10 @@ class SyncVectorEnv(VectorEnv):
 
     def reset(
         self,
+        *,
         seed: int | list[int] | None = None,
-        options: dict | None = None,
-    ):
+        options: dict[str, Any] | None = None,
+    ) -> tuple[ObsType, dict[str, Any]]:
         """Resets each of the sub-environments and concatenate the results together.
 
         Args:

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -73,7 +73,6 @@ class SyncVectorEnv(VectorEnv):
         # Define core attributes using the sub-environments
         self.num_envs = len(self.envs)
         self.metadata = self.envs[0].metadata
-        self.spec = self.envs[0].spec
 
         # Initialises the single spaces from the sub-environments
         self.single_observation_space = self.envs[0].observation_space
@@ -119,7 +118,7 @@ class SyncVectorEnv(VectorEnv):
 
         observations, infos = [], {}
         for i, (env, single_seed) in enumerate(zip(self.envs, seed)):
-            env_obs, env_info = env.reset(single_seed, options)
+            env_obs, env_info = env.reset(seed=single_seed, options=options)
 
             observations.append(env_obs)
             infos = self._add_info(infos, env_info, i)

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -1,4 +1,4 @@
-"""A synchronous vector environment."""
+"""Implementation of a synchronous (for loop) vectorization method of any environment."""
 from __future__ import annotations
 
 from copy import deepcopy
@@ -64,24 +64,29 @@ class SyncVectorEnv(VectorEnv):
             RuntimeError: If the observation space of some sub-environment does not match observation_space
                 (or, by default, the observation space of the first sub-environment).
         """
-        super().__init__()
-        self.env_fns = env_fns
-        self.envs = [env_fn() for env_fn in env_fns]
-        self.num_envs = len(self.envs)
         self.copy = copy
-        self.metadata = self.envs[0].metadata
+        self.env_fns = env_fns
 
+        # Initialise all sub-environments
+        self.envs = [env_fn() for env_fn in env_fns]
+
+        # Define core attributes using the sub-environments
+        self.num_envs = len(self.envs)
+        self.metadata = self.envs[0].metadata
         self.spec = self.envs[0].spec
 
+        # Initialises the single spaces from the sub-environments
         self.single_observation_space = self.envs[0].observation_space
         self.single_action_space = self.envs[0].action_space
+        self._check_spaces()
 
+        # Initialise the obs and action space based on the single versions and num of sub-environments
         self.observation_space = batch_space(
             self.single_observation_space, self.num_envs
         )
         self.action_space = batch_space(self.single_action_space, self.num_envs)
 
-        self._check_spaces()
+        # Initialise attributes used in `step` and `reset`
         self._observations = create_empty_array(
             self.single_observation_space, n=self.num_envs, fn=np.zeros
         )
@@ -94,44 +99,43 @@ class SyncVectorEnv(VectorEnv):
         seed: int | list[int] | None = None,
         options: dict | None = None,
     ):
-        """Waits for the calls triggered by :meth:`reset_async` to finish and returns the results.
+        """Resets each of the sub-environments and concatenate the results together.
 
         Args:
-            seed: The reset environment seed
-            options: Option information for the environment reset
+            seed: Seeds used to reset the sub-environments, either ``None`` (random seeds for all environment), ``int`` (seed, seed+1, ..., seed+n), or a list of ints or None (``List[int | None]``)
+            options: Option information used for each sub-environment
 
         Returns:
-            The reset observation of the environment and reset information
+            Concatenated observations and info from each sub-environment
         """
         if seed is None:
             seed = [None for _ in range(self.num_envs)]
-        if isinstance(seed, int):
+        elif isinstance(seed, int):
             seed = [seed + i for i in range(self.num_envs)]
         assert len(seed) == self.num_envs
 
-        self._terminations[:] = False
-        self._truncations[:] = False
-        observations = []
-        infos = {}
+        self._terminations = np.zeros((self.num_envs,), dtype=np.bool_)
+        self._truncations = np.zeros((self.num_envs,), dtype=np.bool_)
+
+        observations, infos = [], {}
         for i, (env, single_seed) in enumerate(zip(self.envs, seed)):
-            kwargs = {}
-            if single_seed is not None:
-                kwargs["seed"] = single_seed
-            if options is not None:
-                kwargs["options"] = options
+            env_obs, env_info = env.reset(single_seed, options)
 
-            observation, info = env.reset(**kwargs)
-            observations.append(observation)
-            infos = self._add_info(infos, info, i)
+            observations.append(env_obs)
+            infos = self._add_info(infos, env_info, i)
 
+        # Concatenate the observations
         self._observations = concatenate(
             self.single_observation_space, observations, self._observations
         )
-        return (deepcopy(self._observations) if self.copy else self._observations), infos
+        if self.copy:
+            self._observations = deepcopy(self._observations)
+
+        return self._observations, infos
 
     def step(
         self, actions: ActType
-    ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, dict]:
+    ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, dict[str, Any]]:
         """Steps through each of the environments returning the batched results.
 
         Returns:
@@ -142,26 +146,33 @@ class SyncVectorEnv(VectorEnv):
         observations, infos = [], {}
         for i, (env, action) in enumerate(zip(self.envs, actions)):
             (
-                observation,
+                env_obs,
                 self._rewards[i],
                 self._terminations[i],
                 self._truncations[i],
-                info,
+                env_info,
             ) = env.step(action)
 
+            # If sub-environments terminates or truncates then save the obs and info to the batched info
             if self._terminations[i] or self._truncations[i]:
-                old_observation, old_info = observation, info
-                observation, info = env.reset()
-                info["final_observation"] = old_observation
-                info["final_info"] = old_info
-            observations.append(observation)
-            infos = self._add_info(infos, info, i)
+                old_observation, old_info = env_obs, env_info
+                env_obs, env_info = env.reset()
+
+                env_info["final_observation"] = old_observation
+                env_info["final_info"] = old_info
+
+            observations.append(env_obs)
+            infos = self._add_info(infos, env_info, i)
+
+        # Concatenate the observations
         self._observations = concatenate(
             self.single_observation_space, observations, self._observations
         )
+        if self.copy:
+            self._observations = deepcopy(self._observations)
 
         return (
-            deepcopy(self._observations) if self.copy else self._observations,
+            self._observations,
             np.copy(self._rewards),
             np.copy(self._terminations),
             np.copy(self._truncations),
@@ -169,7 +180,7 @@ class SyncVectorEnv(VectorEnv):
         )
 
     def call(self, name: str, *args: Any, **kwargs: Any) -> tuple[Any, ...]:
-        """Calls the method with name and applies args and kwargs.
+        """Calls a sub-environment method with name and applies args and kwargs.
 
         Args:
             name: The method name
@@ -182,6 +193,7 @@ class SyncVectorEnv(VectorEnv):
         results = []
         for env in self.envs:
             function = env.get_wrapper_attr(name)
+
             if callable(function):
                 results.append(function(*args, **kwargs))
             else:
@@ -214,11 +226,11 @@ class SyncVectorEnv(VectorEnv):
         """
         if not isinstance(values, (list, tuple)):
             values = [values for _ in range(self.num_envs)]
+
         if len(values) != self.num_envs:
             raise ValueError(
-                "Values must be a list or tuple with length equal to the "
-                f"number of environments. Got `{len(values)}` values for "
-                f"{self.num_envs} environments."
+                "Values must be a list or tuple with length equal to the number of environments. "
+                f"Got `{len(values)}` values for {self.num_envs} environments."
             )
 
         for env, value in zip(self.envs, values):
@@ -229,19 +241,18 @@ class SyncVectorEnv(VectorEnv):
         [env.close() for env in self.envs]
 
     def _check_spaces(self) -> bool:
+        """Check that each of the environments obs and action spaces are equivalent to the single obs and action space."""
         for env in self.envs:
             if not (env.observation_space == self.single_observation_space):
                 raise RuntimeError(
-                    "Some environments have an observation space different from "
-                    f"`{self.single_observation_space}`. In order to batch observations, "
-                    "the observation spaces from all environments must be equal."
+                    f"Some environments have an observation space different from `{self.single_observation_space}`. "
+                    "In order to batch observations, the observation spaces from all environments must be equal."
                 )
 
             if not (env.action_space == self.single_action_space):
                 raise RuntimeError(
-                    "Some environments have an action space different from "
-                    f"`{self.single_action_space}`. In order to batch actions, the "
-                    "action spaces from all environments must be equal."
+                    f"Some environments have an action space different from `{self.single_action_space}`. "
+                    "In order to batch actions, the action spaces from all environments must be equal."
                 )
 
         return True

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -137,7 +137,7 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
 
     def step(
         self, actions: ActType
-    ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, dict]:
+    ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, dict[str, Any]]:
         """Take an action for each parallel environment.
 
         Args:

--- a/gymnasium/wrappers/lambda_observation.py
+++ b/gymnasium/wrappers/lambda_observation.py
@@ -475,8 +475,12 @@ class RescaleObservationV0(
         self.max_obs = max_obs
 
         # Imagine the x-axis between the old Box and the y-axis being the new Box
-        high_low_diff = np.array(env.observation_space.high, dtype=np.float128) - np.array(env.observation_space.low, dtype=np.float128)
-        gradient = np.array((max_obs - min_obs) / high_low_diff, dtype=env.observation_space.dtype)
+        high_low_diff = np.array(
+            env.observation_space.high, dtype=np.float128
+        ) - np.array(env.observation_space.low, dtype=np.float128)
+        gradient = np.array(
+            (max_obs - min_obs) / high_low_diff, dtype=env.observation_space.dtype
+        )
 
         intercept = gradient * -env.observation_space.low + min_obs
 


### PR DESCRIPTION
# Description

* Rename `SyncVectorEnv` `observations` to `_observations`, `_terminates` to `_terminations`, `_truncates` to `_truncations`
* Improved the documentation and formatting of `reset` and `step` functions for `AsyncVectorEnv` and `SyncVectorEnv`
* Change return type hint for `AsyncVectorEnv.call` from `list[Any]` to `tuple[Any, ...]`