### PR TITLE
Add swig to installation instructions for Box2D

### DIFF
--- a/docs/environments/box2d.md
+++ b/docs/environments/box2d.md
@@ -22,5 +22,8 @@ These environments all involve toy games based around physics control, using [bo
 The unique dependencies for this set of environments can be installed via:
 
 ````bash
+pip install swig
 pip install gymnasium[box2d]
 ````
+
+[SWIG](https://swig.org/) is necessary for building the wheel for [box2d-py](https://pypi.org/project/box2d-py/), the Python package that provides bindings to box2d.


### PR DESCRIPTION
# Description

As discussed in #662 and #677, it appears that swig must be installed separately before the box2d environments can be installed. This PR updates the documentation to reflect this requirement.

Fixes #662

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

> This is more of a "bug" in the documentation.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [N/A] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [N/A] New and existing unit tests pass locally with my changes