### PR TITLE
Fixed `VectorizeTransformAction` and `VectorizeTransformObservation` with different action / obs spaces

### DIFF
--- a/gymnasium/wrappers/vector/vectorize_action.py
+++ b/gymnasium/wrappers/vector/vectorize_action.py
@@ -103,7 +103,7 @@ class VectorizeTransformAction(VectorActionWrapper):
                     self.single_action_space,
                     tuple(
                         self.wrapper.func(action)
-                        for action in iterate(self.action_space, actions)
+                        for action in iterate(self.env.action_space, actions)
                     ),
                     self.out,
                 )

--- a/gymnasium/wrappers/vector/vectorize_observation.py
+++ b/gymnasium/wrappers/vector/vectorize_observation.py
@@ -105,7 +105,7 @@ class VectorizeTransformObservation(VectorObservationWrapper):
                     self.single_observation_space,
                     tuple(
                         self.wrapper.func(obs)
-                        for obs in iterate(self.observation_space, observation)
+                        for obs in iterate(self.env.observation_space, observation)
                     ),
                     self.out,
                 )


### PR DESCRIPTION
# Description

 Fixes #685.