### PR TITLE
Avoid alpha versions from being the latest version in the docs

### DIFF
--- a/.github/workflows/docs-versioning.yml
+++ b/.github/workflows/docs-versioning.yml
@@ -18,10 +18,6 @@ jobs:
         with:
             python-version: '3.9'
 
-      - name: Get tag
-        id: tag
-        uses: dawidd6/action-get-tag@v1
-
       - name: Install dependencies
         run: pip install -r docs/requirements.txt
 
@@ -47,11 +43,12 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: _build
-          target-folder: ${{steps.tag.outputs.tag}}
+          target-folder: ${{github.ref_name}}
           clean: false
 
       - name: Upload to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4
+        if: ${{ !contains(github.ref_name, 'a') }}
         with:
           folder: _build
           clean-exclude: |


### PR DESCRIPTION
Added an if statement to the docs versioning workflow that only builds the latest version of the docs if the version name doesn't contain an "a".