### PR TITLE
`make_vec(vectorization_mode="vector_entry_point")`

### DIFF
--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -74,13 +74,29 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
 
     ## Arguments
 
-    ```python
-    import gymnasium as gym
-    gym.make('CartPole-v1')
-    ```
+    Cartpole only has ``render_mode`` as a keyword for ``gymnasium.make``.
+    On reset, the `options` parameter allows the user to change the bounds used to determine the new random state.
 
-    On reset, the `options` parameter allows the user to change the bounds used to determine
-    the new random state.
+    Examples:
+        >>> import gymnasium as gym
+        >>> env = gym.make("CartPole-v1", render_mode="rgb_array")
+        >>> env
+        <TimeLimit<OrderEnforcing<PassiveEnvChecker<CartPoleEnv<CartPole-v1>>>>>
+        >>> env.reset(seed=123, options={"low": 0, "high": 1})
+        (array([0.6823519 , 0.05382102, 0.22035988, 0.18437181], dtype=float32), {})
+
+    ## Vectorized environment
+
+    To increase steps per seconds, users can use a custom vector environment or with an environment vectorizor.
+
+    Examples:
+        >>> import gymnasium as gym
+        >>> envs = gym.make_vec("CartPole-v1", num_envs=3, vectorization_mode="vector_entry_point")
+        >>> envs
+        CartPoleVectorEnv(CartPole-v1, num_envs=3)
+        >>> envs = gym.make_vec("CartPole-v1", num_envs=3, vectorization_mode="sync")
+        >>> envs
+        SyncVectorEnv(CartPole-v1, num_envs=3)
     """
 
     metadata = {
@@ -328,8 +344,10 @@ class CartPoleVectorEnv(VectorEnv):
         max_episode_steps: int = 500,
         render_mode: Optional[str] = None,
     ):
-        super().__init__()
         self.num_envs = num_envs
+        self.max_episode_steps = max_episode_steps
+        self.render_mode = render_mode
+
         self.gravity = 9.8
         self.masscart = 1.0
         self.masspole = 0.1
@@ -339,7 +357,6 @@ class CartPoleVectorEnv(VectorEnv):
         self.force_mag = 10.0
         self.tau = 0.02  # seconds between state updates
         self.kinematics_integrator = "euler"
-        self.max_episode_steps = max_episode_steps
 
         self.steps = np.zeros(num_envs, dtype=np.int32)
 
@@ -366,8 +383,6 @@ class CartPoleVectorEnv(VectorEnv):
         self.action_space = batch_space(self.single_action_space, num_envs)
         self.single_observation_space = spaces.Box(-high, high, dtype=np.float32)
         self.observation_space = batch_space(self.single_observation_space, num_envs)
-
-        self.render_mode = render_mode
 
         self.screen_width = 600
         self.screen_height = 400

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -910,6 +910,8 @@ def make_vec(
     elif vectorization_mode == "vector_entry_point":
         if len(wrappers) > 0:
             raise error.Error("Cannot use custom vectorization mode with wrappers.")
+        if "max_episode_steps" not in vector_kwargs:
+            vector_kwargs["max_episode_steps"] = spec_.max_episode_steps
         env = env_creator(num_envs=num_envs, **vector_kwargs)
     else:
         raise error.Error(f"Invalid vectorization mode: {vectorization_mode}")

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -805,7 +805,7 @@ def make(
 def make_vec(
     id: str | EnvSpec,
     num_envs: int = 1,
-    vectorization_mode: str = "async",
+    vectorization_mode: str = "vector_entry_point",
     vector_kwargs: dict[str, Any] | None = None,
     wrappers: Sequence[Callable[[Env], Wrapper]] | None = None,
     **kwargs,
@@ -820,7 +820,7 @@ def make_vec(
     Args:
         id: Name of the environment. Optionally, a module to import can be included, eg. 'module:Env-v0'
         num_envs: Number of environments to create
-        vectorization_mode: How to vectorize the environment. Can be either "async", "sync" or "custom"
+        vectorization_mode: The vectorization method used, defaults to "vector_entry_point". Valid modes are "async", "sync" or "vector_entry_point"
         vector_kwargs: Additional arguments to pass to the vectorized environment constructor.
         wrappers: A sequence of wrapper functions to apply to the environment. Can only be used in "sync" or "async" mode.
         **kwargs: Additional arguments to pass to the environment constructor.
@@ -857,7 +857,7 @@ def make_vec(
                 f"Cannot create vectorized environment for {id} because it doesn't have an entry point defined."
             )
         entry_point = spec_.entry_point
-    elif vectorization_mode in ("custom",):
+    elif vectorization_mode in ("vector_entry_point",):
         if spec_.vector_entry_point is None:
             raise error.Error(
                 f"Cannot create vectorized environment for {id} because it doesn't have a vector entry point defined."
@@ -907,10 +907,9 @@ def make_vec(
             env_fns=[_create_env for _ in range(num_envs)],
             **vector_kwargs,
         )
-    elif vectorization_mode == "custom":
+    elif vectorization_mode == "vector_entry_point":
         if len(wrappers) > 0:
             raise error.Error("Cannot use custom vectorization mode with wrappers.")
-        vector_kwargs["max_episode_steps"] = spec_.max_episode_steps
         env = env_creator(num_envs=num_envs, **vector_kwargs)
     else:
         raise error.Error(f"Invalid vectorization mode: {vectorization_mode}")

--- a/tests/utils/test_save_video.py
+++ b/tests/utils/test_save_video.py
@@ -84,7 +84,7 @@ def test_record_video_within_vector():
     envs = gym.make_vec(
         "CartPole-v1",
         num_envs=2,
-        vectorization_mode="async",
+        vectorization_mode="sync",
         render_mode="rgb_array_list",
     )
     envs.reset()

--- a/tests/vector/test_vector_wrapper.py
+++ b/tests/vector/test_vector_wrapper.py
@@ -1,7 +1,12 @@
 """Tests the vector wrappers work as expected."""
+from __future__ import annotations
+
+from typing import Any
+
 import numpy as np
 
 import gymnasium as gym
+from gymnasium.core import ObsType
 from gymnasium.vector import VectorWrapper
 
 
@@ -11,18 +16,24 @@ class DummyVectorWrapper(VectorWrapper):
     def __init__(self, env):
         """Initialises the wrapper with the environment creating a counter variable."""
         super().__init__(env)
-        self.env = env
+
         self.counter = 0
 
-    def reset(self, **kwargs):
+    def reset(
+        self,
+        *,
+        seed: int | list[int] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[ObsType, dict[str, Any]]:
         """Updates the ``counter`` each time at ``reset`` is called."""
-        super().reset()
         self.counter += 1
+
+        return super().reset(seed=seed, options=options)
 
 
 def test_vector_env_wrapper_inheritance():
     """Test vector environment wrapper inheritance."""
-    env = gym.make_vec("FrozenLake-v1", vectorization_mode="async")
+    env = gym.make_vec("FrozenLake-v1", vectorization_mode="sync")
     wrapped = DummyVectorWrapper(env)
     wrapped.reset()
     assert wrapped.counter == 1
@@ -30,8 +41,10 @@ def test_vector_env_wrapper_inheritance():
 
 def test_vector_env_wrapper_attributes():
     """Test if `set_attr`, `call` methods for VecEnvWrapper get correctly forwarded to the vector env it is wrapping."""
-    env = gym.make_vec("CartPole-v1", num_envs=3)
-    wrapped = DummyVectorWrapper(gym.make_vec("CartPole-v1", num_envs=3))
+    env = gym.make_vec("CartPole-v1", num_envs=3, vectorization_mode="sync")
+    wrapped = DummyVectorWrapper(
+        gym.make_vec("CartPole-v1", num_envs=3, vectorization_mode="sync")
+    )
 
     assert np.allclose(wrapped.env.call("gravity"), env.call("gravity"))
     env.set_attr("gravity", [20.0, 20.0, 20.0])

--- a/tests/wrappers/vector/test_dict_info_to_list.py
+++ b/tests/wrappers/vector/test_dict_info_to_list.py
@@ -15,7 +15,7 @@ SEED = 42
 
 def test_usage_in_vector_env():
     env = gym.make(ENV_ID, disable_env_checker=True)
-    vector_env = gym.make_vec(ENV_ID, num_envs=NUM_ENVS)
+    vector_env = gym.make_vec(ENV_ID, num_envs=NUM_ENVS, vectorization_mode="sync")
 
     DictInfoToList(vector_env)
 
@@ -24,7 +24,7 @@ def test_usage_in_vector_env():
 
 
 def test_info_to_list():
-    env_to_wrap = gym.make_vec(ENV_ID, num_envs=NUM_ENVS)
+    env_to_wrap = gym.make_vec(ENV_ID, num_envs=NUM_ENVS, vectorization_mode="sync")
     wrapped_env = DictInfoToList(env_to_wrap)
     wrapped_env.action_space.seed(SEED)
     _, info = wrapped_env.reset(seed=SEED)
@@ -42,7 +42,7 @@ def test_info_to_list():
 
 
 def test_info_to_list_statistics():
-    env_to_wrap = gym.make_vec(ENV_ID, num_envs=NUM_ENVS)
+    env_to_wrap = gym.make_vec(ENV_ID, num_envs=NUM_ENVS, vectorization_mode="sync")
     wrapped_env = DictInfoToList(RecordEpisodeStatistics(env_to_wrap))
     _, info = wrapped_env.reset(seed=SEED)
     wrapped_env.action_space.seed(SEED)


### PR DESCRIPTION
# Description

Completion of https://github.com/Farama-Foundation/Gymnasium/pull/626

- [ ] Update default vectorization_mode="vector_entry_point"
- [ ] Update all of the tests to use the intended vectorization_mode
- [ ] Update the docs for environments with vector versions, i.e., cartpole (there aren't many) to note they exist and how to gym them
- [ ] A section on the website with a description of the vectorization modes with their advantages and disadvantages
- [ ] Add tests that thoroughly check the existing custom vector environments within gymnasium act basically equivalent to the non-vector versions.