### PR TITLE
Add recursive info support for both list of info to dict and dict of info to list

### DIFF
--- a/gymnasium/wrappers/vector/common.py
+++ b/gymnasium/wrappers/vector/common.py
@@ -78,11 +78,9 @@ class RecordEpisodeStatistics(VectorWrapper):
         """Resets the environment using kwargs and resets the episode returns and lengths."""
         obs, info = super().reset(seed=seed, options=options)
 
-        self.episode_start_times = np.full(
-            self.num_envs, time.perf_counter(), dtype=np.float32
-        )
-        self.episode_returns = np.zeros(self.num_envs, dtype=np.float32)
-        self.episode_lengths = np.zeros(self.num_envs, dtype=np.int32)
+        self.episode_start_times = np.full(self.num_envs, time.perf_counter())
+        self.episode_returns = np.zeros(self.num_envs)
+        self.episode_lengths = np.zeros(self.num_envs)
 
         return obs, info
 
@@ -100,7 +98,7 @@ class RecordEpisodeStatistics(VectorWrapper):
 
         assert isinstance(
             infos, dict
-        ), f"`info` dtype is {type(infos)} while supported dtype is `dict`. This may be due to usage of other wrappers in the wrong order."
+        ), f"`vector.RecordEpisodeStatistics` requires `info` type to be `dict`, its actual type is {type(infos)}. This may be due to usage of other wrappers in the wrong order."
 
         self.episode_returns += rewards
         self.episode_lengths += 1

--- a/gymnasium/wrappers/vector/dict_info_to_list.py
+++ b/gymnasium/wrappers/vector/dict_info_to_list.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
+
 from gymnasium.core import ActType, ObsType
 from gymnasium.vector.vector_env import ArrayType, VectorEnv, VectorWrapper
 
@@ -61,7 +63,7 @@ class DictInfoToList(VectorWrapper):
 
         return obs, list_info
 
-    def _convert_info_to_list(self, infos: dict) -> list[dict[str, Any]]:
+    def _convert_info_to_list(self, vector_infos: dict) -> list[dict[str, Any]]:
         """Convert the dict info to list.
 
         Convert the dict info of the vectorized environment
@@ -69,52 +71,26 @@ class DictInfoToList(VectorWrapper):
         has the info of the i-th environment.
 
         Args:
-            infos (dict): info dict coming from the env.
+            vector_infos (dict): info dict coming from the env.
 
         Returns:
             list_info (list): converted info.
-
         """
         list_info = [{} for _ in range(self.num_envs)]
-        list_info = self._process_episode_statistics(infos, list_info)
-        for k in infos:
-            if k.startswith("_"):
+
+        for key, value in vector_infos.items():
+            if key.startswith("_"):
                 continue
-            for i, has_info in enumerate(infos[f"_{k}"]):
-                if has_info:
-                    list_info[i][k] = infos[k][i]
-        return list_info
 
-    # todo - I think this function should be more general for any information
-    def _process_episode_statistics(self, infos: dict, list_info: list) -> list[dict]:
-        """Process episode statistics.
-
-        `RecordEpisodeStatistics` wrapper add extra
-        information to the info. This information are in
-        the form of a dict of dict. This method process these
-        information and add them to the info.
-        `RecordEpisodeStatistics` info contains the keys
-        "r", "l", "t" which represents "cumulative reward",
-        "episode length", "elapsed time since instantiation of wrapper".
-
-        Args:
-            infos (dict): infos coming from `RecordEpisodeStatistics`.
-            list_info (list): info of the current vectorized environment.
-
-        Returns:
-            list_info (list): updated info.
-
-        """
-        episode_statistics = infos.pop("episode", False)
-        if not episode_statistics:
-            return list_info
-
-        episode_statistics_mask = infos.pop("_episode")
-        for i, has_info in enumerate(episode_statistics_mask):
-            if has_info:
-                list_info[i]["episode"] = {}
-                list_info[i]["episode"]["r"] = episode_statistics["r"][i]
-                list_info[i]["episode"]["l"] = episode_statistics["l"][i]
-                list_info[i]["episode"]["t"] = episode_statistics["t"][i]
+            if isinstance(value, dict):
+                value_list_info = self._convert_info_to_list(value)
+                for env_num, (env_info, has_info) in enumerate(zip(value_list_info, vector_infos[f'_{key}'])):
+                    if has_info:
+                        list_info[env_num][key] = env_info
+            else:
+                assert isinstance(value, np.ndarray)
+                for env_num, has_info in enumerate(vector_infos[f"_{key}"]):
+                    if has_info:
+                        list_info[env_num][key] = value[env_num]
 
         return list_info

--- a/tests/vector/test_vector_env_info.py
+++ b/tests/vector/test_vector_env_info.py
@@ -3,6 +3,9 @@ import numpy as np
 import pytest
 
 import gymnasium as gym
+from gymnasium.spaces import Discrete
+from gymnasium.utils.env_checker import data_equivalence
+from gymnasium.vector import VectorEnv
 from gymnasium.vector.sync_vector_env import SyncVectorEnv
 from tests.vector.testing_utils import make_env
 
@@ -25,15 +28,15 @@ def test_vector_env_info(vectorization_mode: str):
     for _ in range(ENV_STEPS):
         env.action_space.seed(SEED)
         action = env.action_space.sample()
-        _, _, terminateds, truncateds, infos = env.step(action)
-        if any(terminateds) or any(truncateds):
+        _, _, terminations, truncations, infos = env.step(action)
+        if any(terminations) or any(truncations):
             assert len(infos["final_observation"]) == NUM_ENVS
             assert len(infos["_final_observation"]) == NUM_ENVS
 
             assert isinstance(infos["final_observation"], np.ndarray)
             assert isinstance(infos["_final_observation"], np.ndarray)
 
-            for i, (terminated, truncated) in enumerate(zip(terminateds, truncateds)):
+            for i, (terminated, truncated) in enumerate(zip(terminations, truncations)):
                 if terminated or truncated:
                     assert infos["_final_observation"][i]
                 else:
@@ -50,9 +53,9 @@ def test_vector_env_info_concurrent_termination(concurrent_ends):
     envs = SyncVectorEnv(envs)
 
     for _ in range(ENV_STEPS):
-        _, _, terminateds, truncateds, infos = envs.step(actions)
-        if any(terminateds) or any(truncateds):
-            for i, (terminated, truncated) in enumerate(zip(terminateds, truncateds)):
+        _, _, terminations, truncations, infos = envs.step(actions)
+        if any(terminations) or any(truncations):
+            for i, (terminated, truncated) in enumerate(zip(terminations, truncations)):
                 if i < concurrent_ends:
                     assert terminated or truncated
                     assert infos["_final_observation"][i]
@@ -60,3 +63,107 @@ def test_vector_env_info_concurrent_termination(concurrent_ends):
                     assert not infos["_final_observation"][i]
                     assert infos["final_observation"][i] is None
             return
+
+
+def test_examples():
+    env = VectorEnv()
+
+    # Test num-envs==1 then expand_dims(sub-env-info) == vector-infos
+    env.num_envs = 1
+    sub_env_info = {"a": 0, "b": 0.0, "c": None, "d": np.zeros((2,)), "e": Discrete(1)}
+    vector_infos = env._add_info({}, sub_env_info, 0)
+    expected_vector_infos = {
+        "a": np.array([0]),
+        "b": np.array([0.0]),
+        "c": np.array([None], dtype=object),
+        "d": np.zeros(
+            (
+                1,
+                2,
+            )
+        ),
+        "e": np.array([Discrete(1)], dtype=object),
+        "_a": np.array([True]),
+        "_b": np.array([True]),
+        "_c": np.array([True]),
+        "_d": np.array([True]),
+        "_e": np.array([True]),
+    }
+    assert data_equivalence(vector_infos, expected_vector_infos)
+
+    # Thought: num-envs>1 then vector-infos should have the same structure as sub-env-info
+    env.num_envs = 3
+    sub_env_infos = [
+        {"a": 0, "b": 0.0, "c": None, "d": np.zeros((2,)), "e": Discrete(1)},
+        {"a": 1, "b": 1.0, "c": None, "d": np.zeros((2,)), "e": Discrete(2)},
+        {"a": 2, "b": 2.0, "c": None, "d": np.zeros((2,)), "e": Discrete(3)},
+    ]
+
+    vector_infos = {}
+    for i, info in enumerate(sub_env_infos):
+        vector_infos = env._add_info(vector_infos, info, i)
+
+    expected_vector_infos = {
+        "a": np.array([0, 1, 2]),
+        "b": np.array([0.0, 1.0, 2.0]),
+        "c": np.array([None, None, None], dtype=object),
+        "d": np.zeros((3, 2)),
+        "e": np.array([Discrete(1), Discrete(2), Discrete(3)], dtype=object),
+        "_a": np.array([True, True, True]),
+        "_b": np.array([True, True, True]),
+        "_c": np.array([True, True, True]),
+        "_d": np.array([True, True, True]),
+        "_e": np.array([True, True, True]),
+    }
+    assert data_equivalence(vector_infos, expected_vector_infos)
+
+    # Test different structures of sub-infos
+    env.num_envs = 3
+    sub_env_infos = [
+        {"a": 1, "b": 1.0},
+        {"c": None, "d": np.zeros((2,))},
+        {"e": Discrete(3)},
+    ]
+
+    vector_infos = {}
+    for i, info in enumerate(sub_env_infos):
+        vector_infos = env._add_info(vector_infos, info, i)
+
+    expected_vector_infos = {
+        "a": np.array([1, 0, 0]),
+        "b": np.array([1.0, 0.0, 0.0]),
+        "c": np.array([None, None, None], dtype=object),
+        "d": np.zeros((3, 2)),
+        "e": np.array([None, None, Discrete(3)], dtype=object),
+        "_a": np.array([True, False, False]),
+        "_b": np.array([True, False, False]),
+        "_c": np.array([False, True, False]),
+        "_d": np.array([False, True, False]),
+        "_e": np.array([False, False, True]),
+    }
+    assert data_equivalence(vector_infos, expected_vector_infos)
+
+    # Test recursive structure
+    env.num_envs = 3
+    sub_env_infos = [
+        {"episode": {"a": 1, "b": 1.0}},
+        {"episode": {"a": 2, "b": 2.0}, "a": 1},
+        {"a": 2},
+    ]
+
+    vector_infos = {}
+    for i, info in enumerate(sub_env_infos):
+        vector_infos = env._add_info(vector_infos, info, i)
+
+    expected_vector_infos = {
+        "episode": {
+            "a": np.array([1, 2, 0]),
+            "b": np.array([1.0, 2.0, 0.0]),
+            "_a": np.array([True, True, False]),
+            "_b": np.array([True, True, False]),
+        },
+        "_episode": np.array([True, True, False]),
+        "a": np.array([0, 1, 2]),
+        "_a": np.array([False, True, True])
+    }
+    assert data_equivalence(vector_infos, expected_vector_infos)

--- a/tests/wrappers/vector/test_dict_info_to_list.py
+++ b/tests/wrappers/vector/test_dict_info_to_list.py
@@ -1,9 +1,16 @@
 """Test suite for DictInfoTolist wrapper."""
+from __future__ import annotations
+
+from typing import Any
 
 import numpy as np
 import pytest
 
 import gymnasium as gym
+from gymnasium.core import ObsType
+from gymnasium.spaces import Discrete
+from gymnasium.utils.env_checker import data_equivalence
+from gymnasium.vector import VectorEnv
 from gymnasium.wrappers.vector import DictInfoToList, RecordEpisodeStatistics
 
 
@@ -33,8 +40,8 @@ def test_info_to_list():
 
     for _ in range(ENV_STEPS):
         action = wrapped_env.action_space.sample()
-        _, _, terminateds, truncateds, list_info = wrapped_env.step(action)
-        for i, (terminated, truncated) in enumerate(zip(terminateds, truncateds)):
+        _, _, terminations, truncations, list_info = wrapped_env.step(action)
+        for i, (terminated, truncated) in enumerate(zip(terminations, truncations)):
             if terminated or truncated:
                 assert "final_observation" in list_info[i]
             else:
@@ -51,8 +58,8 @@ def test_info_to_list_statistics():
 
     for _ in range(ENV_STEPS):
         action = wrapped_env.action_space.sample()
-        _, _, terminateds, truncateds, list_info = wrapped_env.step(action)
-        for i, (terminated, truncated) in enumerate(zip(terminateds, truncateds)):
+        _, _, terminations, truncations, list_info = wrapped_env.step(action)
+        for i, (terminated, truncated) in enumerate(zip(terminations, truncations)):
             if terminated or truncated:
                 assert "episode" in list_info[i]
                 for stats in ["r", "l", "t"]:
@@ -60,3 +67,115 @@ def test_info_to_list_statistics():
                     assert np.isscalar(list_info[i]["episode"][stats])
             else:
                 assert "episode" not in list_info[i]
+
+
+class ResetOptionAsInfo(VectorEnv):
+
+    def reset(
+        self,
+        *,
+        seed: int | list[int] | None = None,
+        options: dict[str, Any] | None = None,  # options are passed as the output info
+    ) -> tuple[ObsType, dict[str, Any]]:
+        return None, options
+
+
+def test_update_info():
+    env = DictInfoToList(ResetOptionAsInfo())
+
+    # Test num-envs==1 then expand_dims(sub-env-info) == vector-infos
+    env.unwrapped.num_envs = 1
+
+    vector_infos = {
+        "a": np.array([0]),
+        "b": np.array([0.0]),
+        "c": np.array([None], dtype=object),
+        "d": np.zeros(
+            (
+                1,
+                2,
+            )
+        ),
+        "e": np.array([Discrete(1)], dtype=object),
+        "_a": np.array([True]),
+        "_b": np.array([True]),
+        "_c": np.array([True]),
+        "_d": np.array([True]),
+        "_e": np.array([True]),
+    }
+    _, list_info = env.reset(options=vector_infos)
+    expected_list_info = [{"a": np.int64(0), "b": np.float64(0.0), "c": None, "d": np.zeros((2,)), "e": Discrete(1)}]
+
+    assert data_equivalence(list_info, expected_list_info)
+
+    # Thought: num-envs>1 then vector-infos should have the same structure as sub-env-info
+    env.unwrapped.num_envs = 3
+
+    vector_infos = {
+        "a": np.array([0, 1, 2]),
+        "b": np.array([0.0, 1.0, 2.0]),
+        "c": np.array([None, None, None], dtype=object),
+        "d": np.zeros((3, 2)),
+        "e": np.array([Discrete(1), Discrete(2), Discrete(3)], dtype=object),
+        "_a": np.array([True, True, True]),
+        "_b": np.array([True, True, True]),
+        "_c": np.array([True, True, True]),
+        "_d": np.array([True, True, True]),
+        "_e": np.array([True, True, True]),
+    }
+    _, list_info = env.reset(options=vector_infos)
+    expected_list_info = [
+        {"a": np.int64(0), "b": np.float64(0.0), "c": None, "d": np.zeros((2,)), "e": Discrete(1)},
+        {"a": np.int64(1), "b": np.float64(1.0), "c": None, "d": np.zeros((2,)), "e": Discrete(2)},
+        {"a": np.int64(2), "b": np.float64(2.0), "c": None, "d": np.zeros((2,)), "e": Discrete(3)},
+    ]
+
+    assert list_info[0].keys() == expected_list_info[0].keys()
+    for key in list_info[0].keys():
+        assert data_equivalence(list_info[0][key], expected_list_info[0][key])
+    assert data_equivalence(list_info, expected_list_info)
+
+    # Test different structures of sub-infos
+    env.unwrapped.num_envs = 3
+
+    vector_infos = {
+        "a": np.array([1, 0, 0]),
+        "b": np.array([1.0, 0.0, 0.0]),
+        "c": np.array([None, None, None], dtype=object),
+        "d": np.zeros((3, 2)),
+        "e": np.array([None, None, Discrete(3)], dtype=object),
+        "_a": np.array([True, False, False]),
+        "_b": np.array([True, False, False]),
+        "_c": np.array([False, True, False]),
+        "_d": np.array([False, True, False]),
+        "_e": np.array([False, False, True]),
+    }
+    _, list_info = env.reset(options=vector_infos)
+    expected_list_info = [
+        {"a": np.int64(1), "b": np.float64(1.0)},
+        {"c": None, "d": np.zeros((2,))},
+        {"e": Discrete(3)},
+    ]
+    assert data_equivalence(list_info, expected_list_info)
+
+    # Test recursive structure
+    env.unwrapped.num_envs = 3
+
+    vector_infos = {
+        "episode": {
+            "a": np.array([1, 2, 0]),
+            "b": np.array([1.0, 2.0, 0.0]),
+            "_a": np.array([True, True, False]),
+            "_b": np.array([True, True, False]),
+        },
+        "_episode": np.array([True, True, False]),
+        "a": np.array([0, 1, 2]),
+        "_a": np.array([False, True, True])
+    }
+    _, list_info = env.reset(options=vector_infos)
+    expected_list_info = [
+        {"episode": {"a": np.int64(1), "b": np.float64(1.0)}},
+        {"episode": {"a": np.int64(2), "b": np.float64(2.0)}, "a": np.int64(1)},
+        {"a": np.int64(2)},
+    ]
+    assert data_equivalence(list_info, expected_list_info)


### PR DESCRIPTION
# Description

In adding testing to `wrappers.vector.RecordEpisodeStatistics` I found that the `VectorEnv` couldn't handle the recursive structure of the episode statistics, `{"episode": {"r": # data, "t": # data}}`
Therefore, I have updated the structure however this has a breaking change on the standard vector environment wrapping a record episode statistics. 
Users should just need to change their code from `info["episode"][0]["r"]` to just `info["episode"]["r"]`