### PR TITLE
Remove `Autoreset.spec`, add type hints to `TimeLimit`, correct type hint in `RecordEpisodeStatistics`

### DIFF
--- a/gymnasium/wrappers/common.py
+++ b/gymnasium/wrappers/common.py
@@ -13,8 +13,6 @@ from collections import deque
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, SupportsFloat
 
-import numpy as np
-
 import gymnasium as gym
 from gymnasium import logger
 from gymnasium.core import ActType, ObsType, RenderFrame
@@ -41,7 +39,9 @@ __all__ = [
 ]
 
 
-class TimeLimit(gym.Wrapper, gym.utils.RecordConstructorArgs):
+class TimeLimit(
+    gym.Wrapper[ObsType, ActType, ObsType, ActType], gym.utils.RecordConstructorArgs
+):
     """Limits the number of steps for an environment through truncating the environment if a maximum number of timesteps is exceeded.
 
     If a truncation is not defined inside the environment itself, this is the only place that the truncation signal is issued.
@@ -72,7 +72,9 @@ class TimeLimit(gym.Wrapper, gym.utils.RecordConstructorArgs):
         self._max_episode_steps = max_episode_steps
         self._elapsed_steps = None
 
-    def step(self, action):
+    def step(
+        self, action: ActType
+    ) -> tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]:
         """Steps through the environment and if the number of steps elapsed exceeds ``max_episode_steps`` then truncate.
 
         Args:
@@ -186,20 +188,6 @@ class Autoreset(
             info = new_info
 
         return obs, reward, terminated, truncated, info
-
-    @property
-    def spec(self) -> EnvSpec | None:
-        """Modifies the environment spec to specify the `autoreset=True`."""
-        if self._cached_spec is not None:
-            return self._cached_spec
-
-        env_spec = self.env.spec
-        if env_spec is not None:
-            env_spec = deepcopy(env_spec)
-            env_spec.autoreset = True
-
-        self._cached_spec = env_spec
-        return env_spec
 
 
 class PassiveEnvChecker(
@@ -435,7 +423,7 @@ class RecordEpisodeStatistics(
         self.episode_returns: float = 0.0
         self.episode_lengths: int = 0
 
-        self.time_queue: deque[int] = deque(maxlen=buffer_length)
+        self.time_queue: deque[float] = deque(maxlen=buffer_length)
         self.return_queue: deque[float] = deque(maxlen=buffer_length)
         self.length_queue: deque[int] = deque(maxlen=buffer_length)
 
@@ -451,7 +439,7 @@ class RecordEpisodeStatistics(
         if terminated or truncated:
             assert self._stats_key not in info
 
-            episode_time_length = np.round(
+            episode_time_length = round(
                 time.perf_counter() - self.episode_start_time, 6
             )
             info[self._stats_key] = {


### PR DESCRIPTION
# Description

* As `autoreset` is no longer an attribute of `EnvSpec`, we need to remove `Autoreset.spec` from when this was true
* Add type hints to `TimeLimit.step` and `TimeLimit.reset`
* Correct the type hints of `RecordEpisodeStatistics` for `time_queue` and use `round` rather than `np.round` since these are scalar values 
