### PR TITLE
Fix rendering of examples

### DIFF
--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -430,6 +430,7 @@ def flatten_space(space: Space[Any]) -> Box | Dict | Sequence | Tuple | Graph:
 
     Example:
         Flatten spaces.Box:
+
         >>> from gymnasium.spaces import Box
         >>> box = Box(0.0, 1.0, shape=(3, 4, 5))
         >>> box
@@ -440,6 +441,7 @@ def flatten_space(space: Space[Any]) -> Box | Dict | Sequence | Tuple | Graph:
         True
 
         Flatten spaces.Discrete:
+
         >>> from gymnasium.spaces import Discrete
         >>> discrete = Discrete(5)
         >>> flatten_space(discrete)
@@ -448,6 +450,7 @@ def flatten_space(space: Space[Any]) -> Box | Dict | Sequence | Tuple | Graph:
         True
 
         Flatten spaces.Dict:
+
         >>> from gymnasium.spaces import Dict, Discrete, Box
         >>> space = Dict({"position": Discrete(2), "velocity": Box(0, 1, shape=(2, 2))})
         >>> flatten_space(space)
@@ -456,6 +459,7 @@ def flatten_space(space: Space[Any]) -> Box | Dict | Sequence | Tuple | Graph:
         True
 
         Flatten spaces.Graph:
+
         >>> from gymnasium.spaces import Graph, Discrete, Box
         >>> space = Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5))
         >>> flatten_space(space)


### PR DESCRIPTION
# Description

The HTML rendering of examples was garbled in this particular API documentation. This change fixes it.

- [v] Bug fix (non-breaking change which fixes an issue)


# Screenshots

| Before | After |
| ------ | ----- |
|![Screenshot 2023-08-30 at 13 11 36](https://github.com/Farama-Foundation/Gymnasium/assets/46875782/b8e4c899-abb2-4db9-9397-39698be84a2e)|![Screenshot 2023-08-30 at 13 11 18](https://github.com/Farama-Foundation/Gymnasium/assets/46875782/9d3f4fe2-585d-4908-a862-a25602b72a9b)|
| ------ | ----- |



# Checklist:

- [v] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [v] My changes generate no new warnings
