### PR TITLE
Update documentation build tooling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,8 +47,10 @@ To rebuild the documentation automatically every time a change is made:
 
 ```
 cd docs
-sphinx-autobuild -b dirhtml . _build
+sphinx-autobuild -b dirhtml --watch ../gymnasium --re-ignore "pickle$" . _build
 ```
+
+You can then open http://localhost:8000 in your browser to watch a live updated version of the documentation.
 
 ## Writing Tutorials
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,19 +8,21 @@
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-#
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+# documentation root, use os.path.abspath to make it absolute.
 
 # -- Project information -----------------------------------------------------
 import os
 import re
+import sys
 
 import sphinx_gallery.gen_rst
 
-import gymnasium
+
+# Path setup for building from source tree
+sys.path.insert(0, os.path.abspath("."))  # For building from root
+sys.path.insert(0, os.path.abspath(".."))  # For building from docs dir
+
+import gymnasium  # noqa: E402
 
 
 project = "Gymnasium"


### PR DESCRIPTION
# Description

This PR aims to solve the following issues:

- building the docs per directions in the ``docs/README.md``, the documentation was built using code of the installed package and thus not necessarily the code in the source tree. This can be confusing for people who have not installed ``gymnasium`` as editable through ``pip install -e .``
- the above is fixed by adding ``.`` and ``..`` in the pathdir in the sphinx ``conf.py``. Due to the executing python statements before the ``import gymnasium``, a ``noqa`` comment was necessary to prevent the linter from rejecting the import.

- the ``autobuild`` command did not work correctly it seems (at least not on my machine) as there were two issues:

1. a build of the documentation creates intermediate ``.pickle`` files in the docs directory, which were subsequently seen as file changes, retriggering a build... ad infinitum
2. when you execute the command  in the ``docs`` directory as specified by the README, only changes in that directory were monitored and not those in the ``gymnasium`` directory. This means that docstring changes in code did not retrigger builds.

The fix for (1) was to exclude files ending with ``pickle`` from the watch list using the ``--re-ignore`` flag
The fix for (2) was to include the gymnasium dir using the ``--watch`` flag

This should not break CI/CD but I was not able to test this.

## Type of change

- [v] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [v] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)