### PR TITLE
Fix frameskip default value (=4) in v5.

### DIFF
--- a/docs/environments/atari.md
+++ b/docs/environments/atari.md
@@ -207,11 +207,11 @@ action space will be reduced to a subset.
 All Atari games are available in three versions. They differ in the default settings of the arguments above.
 The differences are listed in the following table:
 
-| Version | `frameskip=` | `repeat_action_probability=` | `full_action_space=` |
-|---------|--------------|------------------------------|----------------------|
-| v0      | `(2, 5,)`    | `0.25`                       | `False`              |
-| v4      | `(2, 5,)`    | `0.0`                        | `False`              |
-| v5      | `4`          | `0.25`                       | `False`              |
+| Version | `frameskip=`                        | `repeat_action_probability=` | `full_action_space=` |
+|---------|-------------------------------------|------------------------------|----------------------|
+| v0      | Varies with the suffix (see below). | `0.25`                       | `False`              |
+| v4      | Varies with the suffix (see below). | `0.0`                        | `False`              |
+| v5      | `4`                                 | `0.25`                       | `False`              |
 
 > Version v5 follows the best practices outlined in [[2]](#2). Thus, it is recommended to transition to v5 and
 customize the environment using the arguments above, if necessary.

--- a/docs/environments/atari.md
+++ b/docs/environments/atari.md
@@ -211,7 +211,7 @@ The differences are listed in the following table:
 |---------|--------------|------------------------------|----------------------|
 | v0      | `(2, 5,)`    | `0.25`                       | `False`              |
 | v4      | `(2, 5,)`    | `0.0`                        | `False`              |
-| v5      | `5`          | `0.25`                       | `False`              |
+| v5      | `4`          | `0.25`                       | `False`              |
 
 > Version v5 follows the best practices outlined in [[2]](#2). Thus, it is recommended to transition to v5 and
 customize the environment using the arguments above, if necessary.
@@ -234,8 +234,8 @@ are in the "ALE" namespace. The suffix "-ram" is still available. Thus, we get t
 
 | Name              | `obs_type=` | `frameskip=` | `repeat_action_probability=` |
 |-------------------|-------------|--------------|------------------------------|
-| ALE/Amidar-v5     | `"rgb"`     | `5`          | `0.25`                       |
-| ALE/Amidar-ram-v5 | `"ram"`     | `5`          | `0.25`                       |
+| ALE/Amidar-v5     | `"rgb"`     | `4`          | `0.25`                       |
+| ALE/Amidar-ram-v5 | `"ram"`     | `4`          | `0.25`                       |
 
 ## Flavors
 


### PR DESCRIPTION
# Description

Fix the default value of `frameskip` in the Atari v5 main documentation page. 

This can be quickly checked with:

```python
import gymnasium as gym

assert gym.make("ALE/Pong-v5").spec.kwargs["frameskip"] == 4
assert gym.make("ALE/Pong-v5", frameskip=6).spec.kwargs["frameskip"] == 6
```

Fixes #703 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings