### PR TITLE
Add dtype check to `Box.__eq__` and `MultiDiscrete.__eq__`

### DIFF
--- a/gymnasium/spaces/box.py
+++ b/gymnasium/spaces/box.py
@@ -274,7 +274,7 @@ class Box(Space[NDArray[Any]]):
         return (
             isinstance(other, Box)
             and (self.shape == other.shape)
-            # and (self.dtype == other.dtype)
+            and (self.dtype == other.dtype)
             and np.allclose(self.low, other.low)
             and np.allclose(self.high, other.high)
         )

--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -206,6 +206,7 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
         """Check whether ``other`` is equivalent to this instance."""
         return bool(
             isinstance(other, MultiDiscrete)
+            and self.dtype == other.dtype
             and np.all(self.nvec == other.nvec)
             and np.all(self.start == other.start)
         )


### PR DESCRIPTION
# Description

Reported an issue with `wrappers.vector.DtypeObservation` which is caused by checking if two observation spaces however the `Box` space doesn't check the `dtype` in its equivalence functions (https://github.com/Farama-Foundation/Gymnasium/issues/705)
This PR updates the `Box` and `MultiDiscrete` spaces to check `dtype`
