### PR TITLE
Add `make(max_episode_steps=0)` to not apply a `TimeLimit` wrapper

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -645,8 +645,9 @@ def make(
     Args:
         id: A string for the environment id or a :class:`EnvSpec`. Optionally if using a string, a module to import can be included, e.g. ``'module:Env-v0'``.
             This is equivalent to importing the module first to register the environment followed by making the environment.
-        max_episode_steps: Maximum length of an episode, can override the registered :class:`EnvSpec` ``max_episode_steps``.
-            The value is used by :class:`gymnasium.wrappers.TimeLimit`.
+        max_episode_steps: Maximum length of an episode, can override the registered :class:`EnvSpec` ``max_episode_steps``
+            with the value being passed to :class:`gymnasium.wrappers.TimeLimit`.
+            Using ``max_episode_steps=0`` will not apply the wrapper to the environment.
         disable_env_checker: If to add :class:`gymnasium.wrappers.PassiveEnvChecker`, ``None`` will default to the
             :class:`EnvSpec` ``disable_env_checker`` value otherwise use this value will be used.
         kwargs: Additional arguments to pass to the environment constructor.
@@ -780,10 +781,11 @@ def make(
         env = gym.wrappers.OrderEnforcing(env)
 
     # Add the time limit wrapper
-    if max_episode_steps is not None:
-        env = gym.wrappers.TimeLimit(env, max_episode_steps)
-    elif env_spec.max_episode_steps is not None:
-        env = gym.wrappers.TimeLimit(env, env_spec.max_episode_steps)
+    if max_episode_steps != 0:
+        if max_episode_steps is not None:
+            env = gym.wrappers.TimeLimit(env, max_episode_steps)
+        elif env_spec.max_episode_steps is not None:
+            env = gym.wrappers.TimeLimit(env, env_spec.max_episode_steps)
 
     for wrapper_spec in env_spec.additional_wrappers[num_prior_wrappers:]:
         if wrapper_spec.kwargs is None:

--- a/tests/envs/registration/test_make.py
+++ b/tests/envs/registration/test_make.py
@@ -92,6 +92,18 @@ def test_max_episode_steps(register_parameter_envs):
         assert env.spec.max_episode_steps == 100
         assert has_wrapper(env, TimeLimit)
 
+    # Override max_episode_step to prevent applying the wrapper
+    for env_id in [
+        "CartPole-v1",
+        gym.spec("CartPole-v1"),
+        "NoMaxEpisodeStepsEnv-v0",
+        gym.spec("NoMaxEpisodeStepsEnv-v0"),
+    ]:
+        env = gym.make(env_id, max_episode_steps=0)
+        assert env.spec is not None
+        assert env.spec.max_episode_steps is None
+        assert has_wrapper(env, TimeLimit) is False
+
 
 @pytest.mark.parametrize(
     "registration_disabled, make_disabled, if_disabled",


### PR DESCRIPTION
# Description

If an environment spec has a `max_episode_steps` that is not `None` then there is no way of users to remove the `TimeLimit` wrapper from the environment stack (without setting an extremely high max episode steps limit)
Therefore, this PR adds a special cases to `max_episode_steps` for `0` (`None` was taken as the default value) in order to disable applying the max episode steps parameter. This is very helpful for async or sync vector environments where modifying the environment stack is highly difficult, in particular, async vector env.
