### PR TITLE
More control over offscreen dimensions and scene geometries

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -354,6 +354,7 @@ class MujocoEnv(BaseMujocoEnv):
         camera_id: Optional[int] = None,
         camera_name: Optional[str] = None,
         default_camera_config: Optional[Dict[str, Union[float, int]]] = None,
+        max_geom: int = 1000,
     ):
         if MUJOCO_IMPORT_ERROR is not None:
             raise error.DependencyNotInstalled(
@@ -375,7 +376,12 @@ class MujocoEnv(BaseMujocoEnv):
         from gymnasium.envs.mujoco.mujoco_rendering import MujocoRenderer
 
         self.mujoco_renderer = MujocoRenderer(
-            self.model, self.data, default_camera_config, self.width, self.height
+            self.model,
+            self.data,
+            default_camera_config,
+            self.width,
+            self.height,
+            max_geom,
         )
 
     def _initialize_simulation(

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -147,35 +147,9 @@ class OffScreenViewer(BaseRender):
         height: Optional[int] = None,
         max_geom: int = 1000,
     ):
-        buffer_width = model.vis.global_.offwidth
-        buffer_height = model.vis.global_.offheight
-
-        width = width or buffer_width
-        height = height or buffer_height
-
-        # check if the framebuffer is large enough to handle the requested image dimensions.
-        # same check as in `mujoco.Renderer` class
-        if width > buffer_width:
-            raise ValueError(
-                f"""
-Image width {width} > framebuffer width {buffer_width}. Either reduce the image
-width or specify a larger offscreen framebuffer in the model XML using the
-clause:
-<visual>
-<global offwidth="my_width"/>
-</visual>""".lstrip()
-            )
-
-        if height > buffer_height:
-            raise ValueError(
-                f"""
-Image height {height} > framebuffer height {buffer_height}. Either reduce the
-image height or specify a larger offscreen framebuffer in the model XML using
-the clause:
-<visual>
-<global offheight="my_height"/>
-</visual>""".lstrip()
-            )
+        # set default buffer dimensions (as defined in the model) if no dims are given
+        width = width or model.vis.global_.offwidth
+        height = height or model.vis.global_.offheight
 
         # We must make GLContext before MjrContext
         self._get_opengl_backend(width, height)

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -143,14 +143,10 @@ class OffScreenViewer(BaseRender):
         self,
         model: "mujoco.MjMujoco",
         data: "mujoco.MjData",
-        width: Optional[int] = None,
-        height: Optional[int] = None,
+        width: int,
+        height: int,
         max_geom: int = 1000,
     ):
-        # set default buffer dimensions (as defined in the model) if no dims are given
-        width = width or model.vis.global_.offwidth
-        height = height or model.vis.global_.offheight
-
         # We must make GLContext before MjrContext
         self._get_opengl_backend(width, height)
 

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -717,12 +717,10 @@ class MujocoRenderer:
                 self.viewer = WindowViewer(
                     self.model, self.data, self.width, self.height, self.max_geom
                 )
-
             elif render_mode in {"rgb_array", "depth_array"}:
                 self.viewer = OffScreenViewer(
                     self.model, self.data, self.width, self.height, self.max_geom
                 )
-
             else:
                 raise AttributeError(
                     f"Unexpected mode: {render_mode}, expected modes: human, rgb_array, or depth_array"

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -740,17 +740,19 @@ class MujocoRenderer:
         self.viewer = self._viewers.get(render_mode)
         if self.viewer is None:
             if render_mode == "human":
-                viewer_class = WindowViewer
+                self.viewer = WindowViewer(
+                    self.model, self.data, self.width, self.height, self.max_geom
+                )
+
             elif render_mode in {"rgb_array", "depth_array"}:
-                viewer_class = OffScreenViewer
+                self.viewer = OffScreenViewer(
+                    self.model, self.data, self.width, self.height, self.max_geom
+                )
+
             else:
                 raise AttributeError(
                     f"Unexpected mode: {render_mode}, expected modes: human, rgb_array, or depth_array"
                 )
-            self.viewer = viewer_class(
-                self.model, self.data, self.width, self.height, self.max_geom
-            )
-
             # Add default camera parameters
             self._set_cam_config()
             self._viewers[render_mode] = self.viewer

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -43,7 +43,7 @@ class BaseRender:
         data: "mujoco.MjData",
         width: int,
         height: int,
-        max_geom: Optional[int] = None,
+        max_geom: int = 1000,
     ):
         """Render context superclass for offscreen and window rendering."""
         self.model = model
@@ -55,7 +55,7 @@ class BaseRender:
         self.viewport = mujoco.MjrRect(0, 0, width, height)
 
         # This goes to specific visualizer
-        self.scn = mujoco.MjvScene(self.model, max_geom or 1000)
+        self.scn = mujoco.MjvScene(self.model, max_geom)
         self.cam = mujoco.MjvCamera()
         self.vopt = mujoco.MjvOption()
         self.pert = mujoco.MjvPerturb()
@@ -145,7 +145,7 @@ class OffScreenViewer(BaseRender):
         data: "mujoco.MjData",
         width: Optional[int] = None,
         height: Optional[int] = None,
-        max_geom: Optional[int] = None,
+        max_geom: int = 1000,
     ):
         buffer_width = model.vis.global_.offwidth
         buffer_height = model.vis.global_.offheight
@@ -326,7 +326,7 @@ class WindowViewer(BaseRender):
         data: "mujoco.MjData",
         width: Optional[int] = None,
         height: Optional[int] = None,
-        max_geom: Optional[int] = None,
+        max_geom: int = 1000,
     ):
         glfw.init()
 
@@ -665,7 +665,7 @@ class MujocoRenderer:
         default_cam_config: Optional[dict] = None,
         width: Optional[int] = None,
         height: Optional[int] = None,
-        max_geom: Optional[int] = None,
+        max_geom: int = 1000,
     ):
         """A wrapper for clipping continuous actions within the valid bound.
 

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -63,7 +63,9 @@ def test_max_geom_attribute(
     """Test that the max_geom attribute is set correctly."""
 
     # initialize renderer
-    renderer = ExposedViewerRenderer(model, data, max_geom=max_geom)
+    renderer = ExposedViewerRenderer(
+        model, data, width=DEFAULT_SIZE, height=DEFAULT_SIZE, max_geom=max_geom
+    )
 
     # assert max_geom attribute
     assert renderer.max_geom == max_geom

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -1,0 +1,86 @@
+import os
+
+import mujoco
+import pytest
+
+from gymnasium.envs.mujoco.mujoco_rendering import MujocoRenderer, OffScreenViewer
+
+
+ASSET_PATH = os.path.join(
+    os.path.dirname(__file__), "assets", "walker2d_v5_uneven_feet.xml"
+)
+DEFAULT_FRAMEBUFFER_WIDTH = 640
+DEFAULT_FRAMEBUFFER_HEIGHT = 480
+DEFAULT_MAX_GEOMS = 1000
+
+
+class ExposedViewerRenderer(MujocoRenderer):
+    """Expose the viewer for testing to avoid warnings."""
+
+    def get_viewer(self, render_mode: str):
+        return self._get_viewer(render_mode)
+
+
+@pytest.fixture(scope="module")
+def model():
+    """Initialize a model."""
+    model = mujoco.MjModel.from_xml_path(ASSET_PATH)
+    model.vis.global_.offwidth = DEFAULT_FRAMEBUFFER_WIDTH
+    model.vis.global_.offheight = DEFAULT_FRAMEBUFFER_HEIGHT
+    return model
+
+
+@pytest.fixture(scope="module")
+def data(model):
+    """Initialize data."""
+    return mujoco.MjData(model)
+
+
+@pytest.mark.parametrize("width", [10, 100, 1000, None])
+@pytest.mark.parametrize("height", [10, 100, 1000, None])
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_offscreen_viewer_custom_dimensions(
+    model: mujoco.MjModel, data: mujoco.MjData, width: int, height: int
+):
+    """Test that the offscreen viewer has the correct dimensions."""
+
+    # set default buffer dimensions if no dims are given
+    check_width = width or DEFAULT_FRAMEBUFFER_WIDTH
+    check_height = height or DEFAULT_FRAMEBUFFER_HEIGHT
+
+    # check for "dimensions too big" error
+    if (
+        check_width > DEFAULT_FRAMEBUFFER_WIDTH
+        or check_height > DEFAULT_FRAMEBUFFER_HEIGHT
+    ):
+        # after ValueError, AttributeError is raised on call to __del__
+        with pytest.raises((ValueError, AttributeError)):
+            viewer = OffScreenViewer(model, data, width=width, height=height)
+        return
+
+    # initialize viewer
+    viewer = OffScreenViewer(model, data, width=width, height=height)
+
+    # assert viewer dimensions
+    assert viewer.viewport.width == check_width
+    assert viewer.viewport.height == check_height
+
+
+@pytest.mark.parametrize("render_mode", ["human", "rgb_array", "depth_array"])
+@pytest.mark.parametrize("max_geom", [10, 100, 1000, 10000, None])
+def test_max_geom_attribute(
+    model: mujoco.MjModel, data: mujoco.MjData, render_mode: str, max_geom: int
+):
+    """Test that the max_geom attribute is set correctly."""
+
+    # initialize renderer
+    renderer = ExposedViewerRenderer(model, data, max_geom=max_geom)
+
+    # assert max_geom attribute
+    assert renderer.max_geom == max_geom
+
+    # initialize viewer via render
+    viewer = renderer.get_viewer(render_mode)
+
+    # assert that max_geom is set correctly in the viewer scene
+    assert viewer.scn.maxgeom == (max_geom or DEFAULT_MAX_GEOMS)

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -9,7 +9,7 @@ from gymnasium.envs.mujoco.mujoco_rendering import MujocoRenderer, OffScreenView
 ASSET_PATH = os.path.join(
     os.path.dirname(__file__), "assets", "walker2d_v5_uneven_feet.xml"
 )
-DEFAULT_FRAMEBUFFER_WIDTH = 640
+DEFAULT_FRAMEBUFFER_WIDTH = 480
 DEFAULT_FRAMEBUFFER_HEIGHT = 480
 DEFAULT_MAX_GEOMS = 1000
 

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -36,8 +36,8 @@ def data(model):
     return mujoco.MjData(model)
 
 
-@pytest.mark.parametrize("width", [10, 100, 1000, None])
-@pytest.mark.parametrize("height", [10, 100, 1000, None])
+@pytest.mark.parametrize("width", [10, 100, 200, 480])
+@pytest.mark.parametrize("height", [10, 100, 200, 480])
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_offscreen_viewer_custom_dimensions(
     model: mujoco.MjModel, data: mujoco.MjData, width: int, height: int
@@ -47,16 +47,6 @@ def test_offscreen_viewer_custom_dimensions(
     # set default buffer dimensions if no dims are given
     check_width = width or DEFAULT_FRAMEBUFFER_WIDTH
     check_height = height or DEFAULT_FRAMEBUFFER_HEIGHT
-
-    # check for "dimensions too big" error
-    if (
-        check_width > DEFAULT_FRAMEBUFFER_WIDTH
-        or check_height > DEFAULT_FRAMEBUFFER_HEIGHT
-    ):
-        # after ValueError, AttributeError is raised on call to __del__
-        with pytest.raises((ValueError, AttributeError)):
-            viewer = OffScreenViewer(model, data, width=width, height=height)
-        return
 
     # initialize viewer
     viewer = OffScreenViewer(model, data, width=width, height=height)

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -54,6 +54,9 @@ def test_offscreen_viewer_custom_dimensions(
     img = viewer.render(render_mode="rgb_array")
     assert img.shape == (height, width, 3)
 
+    # close viewer after usage
+    viewer.close()
+
 
 @pytest.mark.parametrize("render_mode", ["human", "rgb_array", "depth_array"])
 @pytest.mark.parametrize("max_geom", [10, 100, 1000, 10000])
@@ -75,3 +78,6 @@ def test_max_geom_attribute(
 
     # assert that max_geom is set correctly in the viewer scene
     assert viewer.scn.maxgeom == max_geom
+
+    # close viewer after usage
+    viewer.close()

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -3,14 +3,13 @@ import os
 import mujoco
 import pytest
 
+from gymnasium.envs.mujoco.mujoco_env import DEFAULT_SIZE
 from gymnasium.envs.mujoco.mujoco_rendering import MujocoRenderer, OffScreenViewer
 
 
 ASSET_PATH = os.path.join(
     os.path.dirname(__file__), "assets", "walker2d_v5_uneven_feet.xml"
 )
-DEFAULT_FRAMEBUFFER_WIDTH = 480
-DEFAULT_FRAMEBUFFER_HEIGHT = 480
 DEFAULT_MAX_GEOMS = 1000
 
 
@@ -25,8 +24,8 @@ class ExposedViewerRenderer(MujocoRenderer):
 def model():
     """Initialize a model."""
     model = mujoco.MjModel.from_xml_path(ASSET_PATH)
-    model.vis.global_.offwidth = DEFAULT_FRAMEBUFFER_WIDTH
-    model.vis.global_.offheight = DEFAULT_FRAMEBUFFER_HEIGHT
+    model.vis.global_.offwidth = DEFAULT_SIZE
+    model.vis.global_.offheight = DEFAULT_SIZE
     return model
 
 
@@ -44,16 +43,12 @@ def test_offscreen_viewer_custom_dimensions(
 ):
     """Test that the offscreen viewer has the correct dimensions."""
 
-    # set default buffer dimensions if no dims are given
-    check_width = width or DEFAULT_FRAMEBUFFER_WIDTH
-    check_height = height or DEFAULT_FRAMEBUFFER_HEIGHT
-
     # initialize viewer
     viewer = OffScreenViewer(model, data, width=width, height=height)
 
     # assert viewer dimensions
-    assert viewer.viewport.width == check_width
-    assert viewer.viewport.height == check_height
+    assert viewer.viewport.width == width
+    assert viewer.viewport.height == height
 
 
 @pytest.mark.parametrize("render_mode", ["human", "rgb_array", "depth_array"])

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -50,6 +50,10 @@ def test_offscreen_viewer_custom_dimensions(
     assert viewer.viewport.width == width
     assert viewer.viewport.height == height
 
+    # check that the render method returns an image of the correct shape
+    img = viewer.render(render_mode="rgb_array")
+    assert img.shape == (height, width, 3)
+
 
 @pytest.mark.parametrize("render_mode", ["human", "rgb_array", "depth_array"])
 @pytest.mark.parametrize("max_geom", [10, 100, 1000, 10000])

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -67,7 +67,7 @@ def test_offscreen_viewer_custom_dimensions(
 
 
 @pytest.mark.parametrize("render_mode", ["human", "rgb_array", "depth_array"])
-@pytest.mark.parametrize("max_geom", [10, 100, 1000, 10000, None])
+@pytest.mark.parametrize("max_geom", [10, 100, 1000, 10000])
 def test_max_geom_attribute(
     model: mujoco.MjModel, data: mujoco.MjData, render_mode: str, max_geom: int
 ):
@@ -83,4 +83,4 @@ def test_max_geom_attribute(
     viewer = renderer.get_viewer(render_mode)
 
     # assert that max_geom is set correctly in the viewer scene
-    assert viewer.scn.maxgeom == (max_geom or DEFAULT_MAX_GEOMS)
+    assert viewer.scn.maxgeom == max_geom


### PR DESCRIPTION
# Description

Offscreen Renderers do not allow control of viewer dimensions or the maximum number of geometries in the scene. We fix this issue with minimal implementation to address #730. This is motivated by the need to have multiple renderers at different resolutions and to render cluttered scenes

Fixes #730 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (none required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes