### PR TITLE
Fixed typo on homepage, "it's" to "its"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ If you are financially able to do so and would like to support the development o
 
 You can cite Gymnasium as:
 
-
-
 ```
 @misc{towers_gymnasium_2023,
         title = {Gymnasium},

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <img src="https://raw.githubusercontent.com/Farama-Foundation/Gymnasium/main/gymnasium-text.png" width="500px"/>
 </p>
 
-Gymnasium is an open source Python library for developing and comparing reinforcement learning algorithms by providing a standard API to communicate between learning algorithms and environments, as well as a standard set of environments compliant with that API. This is a fork of OpenAI's [Gym](https://github.com/openai/gym) library by it's maintainers (OpenAI handed over maintenance a few years ago to an outside team), and is where future maintenance will occur going forward.
+Gymnasium is an open source Python library for developing and comparing reinforcement learning algorithms by providing a standard API to communicate between learning algorithms and environments, as well as a standard set of environments compliant with that API. This is a fork of OpenAI's [Gym](https://github.com/openai/gym) library by its maintainers (OpenAI handed over maintenance a few years ago to an outside team), and is where future maintenance will occur going forward.
 
 The documentation website is at [gymnasium.farama.org](https://gymnasium.farama.org), and we have a public discord server (which we also use to coordinate development work) that you can join here: https://discord.gg/bnJ6kubTg6
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ If you are financially able to do so and would like to support the development o
 
 You can cite Gymnasium as:
 
+
+
 ```
 @misc{towers_gymnasium_2023,
         title = {Gymnasium},


### PR DESCRIPTION
# Description

Change the "it's" to "its", it should be a typo.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [Yes ] This change requires a documentation update
