### PR TITLE
[MuJoCo] add render arguments to the documention

### DIFF
--- a/docs/environments/mujoco.md
+++ b/docs/environments/mujoco.md
@@ -43,9 +43,12 @@ Among Gymnasium environments, this set of environments can be considered as more
 
 Environments can be configured by changing the XML files or by tweaking the parameters of their classes.
 
-## Arguments
+## Rendering Arguments
 The all MuJoCo Environments besides the general Gymnasium arguments and environment specific arguments they also take the following arguments for configuring the renderer:
 
+```python
+env = gymnasium.make("Ant-v5", render_mode="rgb_array", width=1280, height=720)
+```
 
 | Parameter                                  | Type       | Default      |Description                    |
 |--------------------------------------------|------------|--------------|-------------------------------|
@@ -55,4 +58,3 @@ The all MuJoCo Environments besides the general Gymnasium arguments and environm
 |`camera_name`                               |**str \| None**| `None`     | The name of the camera used (mutally exclusive option with `camera_id`). |
 |`default_camera_config`                     |**Dict[str, Union[float, int]] \| None**  | `None` |  The [mjvcamera](https://mujoco.readthedocs.io/en/stable/APIreference/APItypes.html?highlight=camera#mjvcamera) properties. |
 |`max_geom`                                  | **int**    | `1000`       | Max number of geometrical objects to render (useful for 3rd-party environments).|
-

--- a/docs/environments/mujoco.md
+++ b/docs/environments/mujoco.md
@@ -42,3 +42,17 @@ There are eleven Mujoco environments: Ant, HalfCheetah, Hopper, Humanoid, Humano
 Among Gymnasium environments, this set of environments can be considered as more difficult ones to solve by a policy.
 
 Environments can be configured by changing the XML files or by tweaking the parameters of their classes.
+
+## Arguments
+The all MuJoCo Environments besides the general Gymnasium arguments and environment specific arguments they also take the following arguments for confuguring renderer:
+
+
+| Parameter                                  | Type       | Default      |Description                    |
+|--------------------------------------------|------------|--------------|-------------------------------|
+|`width`                                     | **int**    | `480`        | The width of the render window. |
+|`height`                                    | **int**    | `480`        | The width of the render window. |
+|`camera_id`                                 |**int \| None**| `None`     | The camera ID used for the render window. |
+|`camera_name`                               |**str \| None**| `None`     | The name of the camera used (mutally exclusive option with `camera_id`). |
+|`default_camera_config`                     |**Dict[str, Union[float, int]] \| None**  | `None` |  The [mjvcamera](https://mujoco.readthedocs.io/en/stable/APIreference/APItypes.html?highlight=camera#mjvcamera) properties. |
+|`max_geom`                                  | **int**    | `1000`       | Max number of geometrical objects to render (useful for 3rd-party environments).|
+

--- a/docs/environments/mujoco.md
+++ b/docs/environments/mujoco.md
@@ -44,7 +44,7 @@ Among Gymnasium environments, this set of environments can be considered as more
 Environments can be configured by changing the XML files or by tweaking the parameters of their classes.
 
 ## Arguments
-The all MuJoCo Environments besides the general Gymnasium arguments and environment specific arguments they also take the following arguments for confuguring renderer:
+The all MuJoCo Environments besides the general Gymnasium arguments and environment specific arguments they also take the following arguments for configuring the renderer:
 
 
 | Parameter                                  | Type       | Default      |Description                    |


### PR DESCRIPTION
# Description

Adds a short description of the available arguments for changing the render properties of `MuJoCo` environments
I am not sure if the main page of MuJoCo is place to place the descriptions, if you have different suggestions of where to put them, i can move them

Fixes # (issue)

## Type of change

- [x] doc update


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

