### PR TITLE
[Bug Fix] Small fixes for new mujoco release 3.0.0 

### DIFF
--- a/gymnasium/envs/mujoco/assets/swimmer.xml
+++ b/gymnasium/envs/mujoco/assets/swimmer.xml
@@ -1,8 +1,8 @@
 <mujoco model="swimmer">
   <compiler angle="degree" coordinate="local" inertiafromgeom="true"/>
-  <option collision="predefined" density="4000" integrator="RK4" timestep="0.01" viscosity="0.1"/>
+  <option density="4000" integrator="RK4" timestep="0.01" viscosity="0.1"/>
   <default>
-    <geom conaffinity="1" condim="1" contype="1" material="geom" rgba="0.8 0.6 .4 1"/>
+    <geom conaffinity="0" condim="1" contype="0" material="geom" rgba="0.8 0.6 .4 1"/>
     <joint armature='0.1'  />
   </default>
   <asset>
@@ -14,7 +14,7 @@
   </asset>
   <worldbody>
     <light cutoff="100" diffuse="1 1 1" dir="-0 0 -1.3" directional="true" exponent="1" pos="0 0 1.3" specular=".1 .1 .1"/>
-    <geom conaffinity="1" condim="3" material="MatPlane" name="floor" pos="0 0 -0.1" rgba="0.8 0.9 0.8 1" size="40 40 0.1" type="plane"/>
+    <geom condim="3" material="MatPlane" name="floor" pos="0 0 -0.1" rgba="0.8 0.9 0.8 1" size="40 40 0.1" type="plane"/>
     <!--  ================= SWIMMER ================= /-->
     <body name="torso" pos="0 0 0">
       <camera name="track" mode="trackcom" pos="0 -3 3" xyaxes="1 0 0 0 1 1"/>

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -614,9 +614,6 @@ class WindowViewer(BaseRender):
             bottomleft, "Solver iterations", str(self.data.solver_niter[0] + 1)
         )
         self.add_overlay(
-            bottomleft, "Number of Islands", str(self.data.solver_nisland)
-        )
-        self.add_overlay(
             bottomleft, "Step", str(round(self.data.time / self.model.opt.timestep))
         )
         self.add_overlay(bottomleft, "timestep", "%.5f" % self.model.opt.timestep)

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -611,7 +611,10 @@ class WindowViewer(BaseRender):
 
         self.add_overlay(bottomleft, "FPS", "%d%s" % (1 / self._time_per_render, ""))
         self.add_overlay(
-            bottomleft, "Solver iterations", str(self.data.solver_iter + 1)
+            bottomleft, "Solver iterations", str(self.data.solver_niter[0] + 1)
+        )
+        self.add_overlay(
+            bottomleft, "Number of Islands", str(self.data.solver_nisland)
         )
         self.add_overlay(
             bottomleft, "Step", str(round(self.data.time / self.model.opt.timestep))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
 mujoco-py = ["mujoco-py >=2.1,<2.2", "cython<3"]
 mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]       # kept for backward compatibility
-mujoco = ["mujoco >=2.3.3", "imageio >=2.14.1"]
+mujoco = ["mujoco >=3.0.0", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]         # kept for backward compatibility
 jax = ["jax >=0.4.0", "jaxlib >=0.4.0"]
@@ -67,7 +67,7 @@ all = [
     "mujoco-py >=2.1,<2.2",
     "cython<3",
     # mujoco
-    "mujoco >=2.3.3",
+    "mujoco >=3.0.0",
     "imageio >=2.14.1",
     # toy-text
     "pygame >=2.1.3",


### PR DESCRIPTION
# Description

- **Fix for mujoco rendering**: The `MjData` member `solver_iter` has been renamed to `solver_niter` as specified in the [changelog](https://mujoco.readthedocs.io/en/stable/changelog.html?highlight=solver_niter#general). We are also not using islands in our environments so we just output the first element of the list. Fixes https://github.com/google-deepmind/mujoco/issues/1107

- **Fix for swimmer xml**: As specified in the 11 point of the changelog the `collision` argument has been removed from `option`. 
This PR makes the changes specified in the migration guide. The changelog provides the migration guide for `"pair"` that in the previous mujoco release documentation appears to be named as `"predefined"` such as in the swimmer xml (seems like a release note errata). I haven't compared reproducibility with the current `Swimmer-v5` environment, but as specified in the docs mujoco only guaranties reproducibility for a fixed version https://mujoco.readthedocs.io/en/3.0.0/computation/index.html?highlight=reproducibility#reproducibility

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
