### PR TITLE
add render check to `check_environments_match` 

### DIFF
--- a/gymnasium/utils/env_match.py
+++ b/gymnasium/utils/env_match.py
@@ -38,8 +38,8 @@ def check_environments_match(
     """
     skip_render = (
         skip_render
-        or env_a.unwrapped.render_mode not in [None, "human"]
-        or env_b.unwrapped.render not in [None, "human"]
+        or env_a.unwrapped.render_mode in [None, "human"]
+        or env_b.unwrapped.render in [None, "human"]
     )
 
     assert info_comparison in [

--- a/gymnasium/utils/env_match.py
+++ b/gymnasium/utils/env_match.py
@@ -13,6 +13,7 @@ def check_environments_match(
     skip_rew: bool = False,
     skip_terminal: bool = False,
     skip_truncated: bool = False,
+    skip_render: bool = False,
     info_comparison: str = "equivalence",
 ):
     """Checks if the environments `env_a` & `env_b` are identical.
@@ -27,6 +28,7 @@ def check_environments_match(
         skip_terminal: If `True` it does not check for equivalence of the observation.
         skip_truncated: If `True` it does not check for equivalence of the observation.
         skip_info: If `True` it does not check for equivalence of the observation.
+        skip_render: If `True` it does not check for equivalent renders. note:the render checked are automatically skipped if `render_mode` is not set or is "human".
         info_comparison: The options are
             If "equivalence" then checks if the `info`s are identical,
             If "superset" checks if `info_b` is a (non-strict) superset of `info_a`
@@ -34,6 +36,12 @@ def check_environments_match(
             If "keys-superset" checks if the `info_b`s keys are a superset of `info_a`'s keys.
             If "skip" no checks are made at the `info`.
     """
+    skip_render = (
+        skip_render
+        or env_a.unwrapped.render_mode not in [None, "human"]
+        or env_b.unwrapped.render not in [None, "human"]
+    )
+
     assert info_comparison in [
         "equivalence",
         "superset",
@@ -64,7 +72,12 @@ def check_environments_match(
     elif info_comparison == "keys-superset":
         assert info_b.keys() >= info_a.keys(), "resetting info keys are not a superset"
 
-    for _ in range(num_steps):
+    if not skip_render:
+        assert (
+            env_a.render() == env_b.render()
+        ).all(), "resetting render is not equivalent"
+
+    for step in range(num_steps):
         action = env_a.action_space.sample()
         obs_a, rew_a, terminal_a, truncated_a, info_a = env_a.step(action)
         obs_b, rew_b, terminal_b, truncated_b, info_b = env_b.step(action)
@@ -95,6 +108,10 @@ def check_environments_match(
             assert (
                 info_b.keys() >= info_a.keys()
             ), "stepping info keys are not a superset"
+        if not skip_render:
+            assert (
+                env_a.render() == env_b.render()
+            ).all(), "stepping render is not equivalent"
 
         if terminal_a or truncated_a or terminal_b or truncated_b:
             obs_a, info_a = env_a.reset(seed=seed)
@@ -119,3 +136,7 @@ def check_environments_match(
                 assert (
                     info_b.keys() >= info_a.keys()
                 ), "resetting info keys are not a superset"
+            if not skip_render:
+                assert (
+                    env_a.render() == env_b.render()
+                ).all(), "resetting render is not equivalent"


### PR DESCRIPTION
# Description

updates `check_environments_match` to also check for that `env.render()` is identical

I have being using it to verify the model changes for the `mujoco==3.0.0`

Fixes # (issue)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
