### PR TITLE
Fix typos in docs FrozenLake_tuto.py

### DIFF
--- a/docs/tutorials/training_agents/FrozenLake_tuto.py
+++ b/docs/tutorials/training_agents/FrozenLake_tuto.py
@@ -86,7 +86,7 @@ params
 # Set the seed
 rng = np.random.default_rng(params.seed)
 
-# Create the figure folder if it doesn't exists
+# Create the figure folder if it doesn't exist
 params.savefig_folder.mkdir(parents=True, exist_ok=True)
 
 
@@ -529,7 +529,7 @@ plot_steps_and_rewards(res_all, st_all)
 # whereas on the :math:`7 \times 7` map, the agent needs :math:`\sim 300`
 # episodes, on the :math:`9 \times 9` map it needs :math:`\sim 800`
 # episodes, and the :math:`11 \times 11` map, it needs :math:`\sim 1800`
-# episodes to converge. Interestingely, the agent seems to be getting more
+# episodes to converge. Interestingly, the agent seems to be getting more
 # rewards on the :math:`9 \times 9` map than on the :math:`7 \times 7`
 # map, which could mean it didn't reach an optimal policy on the
 # :math:`7 \times 7` map.
@@ -554,12 +554,12 @@ plot_steps_and_rewards(res_all, st_all)
 # References
 # ----------
 #
-# -  Code inspired from `Deep Reinforcement Learning
+# -  Code inspired by `Deep Reinforcement Learning
 #    Course <https://simoninithomas.github.io/Deep_reinforcement_learning_Course/>`__
 #    by Thomas Simonini (http://simoninithomas.com/)
 # -  `Dissecting Reinforcement
 #    Learning-Part.2 <https://mpatacchiola.github.io/blog/2017/01/15/dissecting-reinforcement-learning-2.html>`__
-# -  `Dadid Silver’s course <https://www.davidsilver.uk/teaching/>`__ in
+# -  `David Silver’s course <https://www.davidsilver.uk/teaching/>`__ in
 #    particular lesson 4 and lesson 5
 # -  `Q-learning article on
 #    Wikipedia <https://en.wikipedia.org/wiki/Q-learning>`__


### PR DESCRIPTION
# Description

Corrections for some typos found in the documentation's Tutorials section in `FrozenLake_tuto.py`

## Type of change

- [x] This change requires a documentation update


<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
