### PR TITLE
fix MujocoPyEnv human render not being freed upon `close()`

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -329,6 +329,7 @@ class MuJocoPyEnv(BaseMujocoEnv):
 
     def close(self):
         if self.viewer is not None:
+            self.viewer.free()
             self.viewer = None
             self._viewers = {}
 


### PR DESCRIPTION
# Description
<!--
I could not run CI on my PC, so I am making this temp PR to check if it passes 
-->
Fixes # https://github.com/Farama-Foundation/Gymnasium/issues/743

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation 

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
