### PR TITLE
typo fix in ant_v5 parameter `main_body` type

### DIFF
--- a/gymnasium/envs/mujoco/ant_v5.py
+++ b/gymnasium/envs/mujoco/ant_v5.py
@@ -202,7 +202,7 @@ class AntEnv(MujocoEnv, utils.EzPickle):
     |`ctrl_cost_weight`                          | **float**  | `0.5`        | Weight for _ctrl_cost_ term (see section on reward) |
     |`contact_cost_weight`                       | **float**  | `5e-4`       | Weight for _contact_cost_ term (see section on reward) |
     |`healthy_reward`                            | **float**  | `1`          | Weight for _healthy_reward_ term (see section on reward) |
-    |`main_body`                                 |**str|int** | `1`("torso") | Name or ID of the body, whose displacement is used to calculate the *dx*/_forward_reward_ (useful for custom MuJoCo models)|
+    |`main_body`                                 |**str\|int** | `1`("torso") | Name or ID of the body, whose displacement is used to calculate the *dx*/_forward_reward_ (useful for custom MuJoCo models)|
     |`terminate_when_unhealthy`                  | **bool**   | `True`       | If true, issue a done signal if the z-coordinate of the torso is no longer in the `healthy_z_range` |
     |`healthy_z_range`                           | **tuple**  | `(0.2, 1)`   | The ant is considered healthy if the z-coordinate of the torso is in this range |
     |`contact_force_range`                       | **tuple**  | `(-1, 1)`    | Contact forces are clipped to this range in the computation of *contact_cost* |


### PR DESCRIPTION
# Description

simple typo fix