### PR TITLE
Bipedal Walker - Fix initial body  position

### DIFF
--- a/gymnasium/envs/box2d/bipedal_walker.py
+++ b/gymnasium/envs/box2d/bipedal_walker.py
@@ -444,7 +444,7 @@ class BipedalWalker(gym.Env, EzPickle):
         self._generate_clouds()
 
         init_x = TERRAIN_STEP * TERRAIN_STARTPAD / 2
-        init_y = TERRAIN_HEIGHT + 2 * LEG_H
+        init_y = TERRAIN_HEIGHT + 2 * LEG_H - LEG_DOWN
         self.hull = self.world.CreateDynamicBody(
             position=(init_x, init_y), fixtures=HULL_FD
         )
@@ -458,7 +458,7 @@ class BipedalWalker(gym.Env, EzPickle):
         self.joints: List[Box2D.b2RevoluteJoint] = []
         for i in [-1, +1]:
             leg = self.world.CreateDynamicBody(
-                position=(init_x, init_y - LEG_H / 2 - LEG_DOWN),
+                position=(init_x, init_y - LEG_H / 2 + LEG_DOWN),
                 angle=(i * 0.05),
                 fixtures=LEG_FD,
             )
@@ -480,7 +480,7 @@ class BipedalWalker(gym.Env, EzPickle):
             self.joints.append(self.world.CreateJoint(rjd))
 
             lower = self.world.CreateDynamicBody(
-                position=(init_x, init_y - LEG_H * 3 / 2 - LEG_DOWN),
+                position=(init_x, init_y - LEG_H * 3 / 2 + LEG_DOWN),
                 angle=(i * 0.05),
                 fixtures=LOWER_FD,
             )


### PR DESCRIPTION
# Description

I found a small error in the bipedal_walker environment. When resetting the environment, it passes a wrong body position. The position mismatch causes the Box2D physics engine to resolve it, thereby affecting the initial state of the environment and the following few frames. This issue might impact the training process.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [] I have done this task
- [x] I have not done this task
-->
