### PR TITLE
Change autoreset order such that reset will happen on the next step

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -639,6 +639,7 @@ def _async_worker(
     env = env_fn()
     observation_space = env.observation_space
     action_space = env.action_space
+    autoreset = False
 
     parent_pipe.close()
 
@@ -653,20 +654,21 @@ def _async_worker(
                         observation_space, index, observation, shared_memory
                     )
                     observation = None
+                    autoreset = False
                 pipe.send(((observation, info), True))
             elif command == "step":
-                (
-                    observation,
-                    reward,
-                    terminated,
-                    truncated,
-                    info,
-                ) = env.step(data)
-                if terminated or truncated:
-                    old_observation, old_info = observation, info
+                if autoreset:
                     observation, info = env.reset()
-                    info["final_observation"] = old_observation
-                    info["final_info"] = old_info
+                    reward, terminated, truncated = 0, False, False
+                else:
+                    (
+                        observation,
+                        reward,
+                        terminated,
+                        truncated,
+                        info,
+                    ) = env.step(data)
+                    autoreset = terminated or truncated
 
                 if shared_memory:
                     write_to_shared_memory(

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -231,7 +231,7 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
         return self
 
     def _add_info(
-        self, infos: dict[str, Any], info: dict[str, Any], env_num: int
+        self, vector_infos: dict[str, Any], env_info: dict[str, Any], env_num: int
     ) -> dict[str, Any]:
         """Add env info to the info dictionary of the vectorized environment.
 
@@ -241,48 +241,51 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
         whether or not the i-indexed environment has this `info`.
 
         Args:
-            infos (dict): the infos of the vectorized environment
-            info (dict): the info coming from the single environment
+            vector_infos (dict): the infos of the vectorized environment
+            env_info (dict): the info coming from the single environment
             env_num (int): the index of the single environment
 
         Returns:
             infos (dict): the (updated) infos of the vectorized environment
-
         """
-        for k in info.keys():
-            if k not in infos:
-                info_array, array_mask = self._init_info_arrays(type(info[k]))
+        for key, value in env_info.items():
+            # If value is a dictionary, then we apply the `_add_info` recursively.
+            if isinstance(value, dict):
+                array = self._add_info(vector_infos.get(key, {}), value, env_num)
+            # Otherwise, we are a base case to group the data
             else:
-                info_array, array_mask = infos[k], infos[f"_{k}"]
+                # If the key doesn't exist in the vector infos, then we can create an array of that batch type
+                if key not in vector_infos:
+                    if type(value) in [int, float, bool] or issubclass(
+                        type(value), np.number
+                    ):
+                        array = np.zeros(self.num_envs, dtype=type(value))
+                    elif isinstance(value, np.ndarray):
+                        # We assume that all instances of the np.array info are of the same shape
+                        array = np.zeros(
+                            (self.num_envs, *value.shape), dtype=value.dtype
+                        )
+                    else:
+                        # For unknown objects, we use a Numpy object array
+                        array = np.full(self.num_envs, fill_value=None, dtype=object)
+                # Otherwise, just use the array that already exists
+                else:
+                    array = vector_infos[key]
 
-            info_array[env_num], array_mask[env_num] = info[k], True
-            infos[k], infos[f"_{k}"] = info_array, array_mask
-        return infos
+                # Assign the data in the `env_num` position
+                #   We only want to run this for the base-case data (not recursive data forcing the ugly function structure)
+                array[env_num] = value
 
-    def _init_info_arrays(self, dtype: type) -> tuple[np.ndarray, np.ndarray]:
-        """Initialize the info array.
+            # Get the array mask and if it doesn't already exist then create a zero bool array
+            array_mask = vector_infos.get(
+                f"_{key}", np.zeros(self.num_envs, dtype=np.bool_)
+            )
+            array_mask[env_num] = True
 
-        Initialize the info array. If the dtype is numeric
-        the info array will have the same dtype, otherwise
-        will be an array of `None`. Also, a boolean array
-        of the same length is returned. It will be used for
-        assessing which environment has info data.
+            # Update the vector info with the updated data and mask information
+            vector_infos[key], vector_infos[f"_{key}"] = array, array_mask
 
-        Args:
-            dtype (type): data type of the info coming from the env.
-
-        Returns:
-            array (np.ndarray): the initialized info array.
-            array_mask (np.ndarray): the initialized boolean array.
-
-        """
-        if dtype in [int, float, bool] or issubclass(dtype, np.number):
-            array = np.zeros(self.num_envs, dtype=dtype)
-        else:
-            array = np.zeros(self.num_envs, dtype=object)
-            array[:] = None
-        array_mask = np.zeros(self.num_envs, dtype=bool)
-        return array, array_mask
+        return vector_infos
 
     def __del__(self):
         """Closes the vector environment."""

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -444,23 +444,23 @@ class VectorObservationWrapper(VectorWrapper):
         options: dict[str, Any] | None = None,
     ) -> tuple[ObsType, dict[str, Any]]:
         """Modifies the observation returned from the environment ``reset`` using the :meth:`observation`."""
-        obs, info = self.env.reset(seed=seed, options=options)
-        return self.vector_observation(obs), info
+        observations, infos = self.env.reset(seed=seed, options=options)
+        return self.observation(observations), infos
 
     def step(
         self, actions: ActType
     ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, dict[str, Any]]:
         """Modifies the observation returned from the environment ``step`` using the :meth:`observation`."""
-        observation, reward, termination, truncation, info = self.env.step(actions)
+        observations, rewards, terminations, truncations, infos = self.env.step(actions)
         return (
-            self.vector_observation(observation),
-            reward,
-            termination,
-            truncation,
-            self.update_final_obs(info),
+            self.observation(observations),
+            rewards,
+            terminations,
+            truncations,
+            infos,
         )
 
-    def vector_observation(self, observation: ObsType) -> ObsType:
+    def observation(self, observation: ObsType) -> ObsType:
         """Defines the vector observation transformation.
 
         Args:
@@ -470,25 +470,6 @@ class VectorObservationWrapper(VectorWrapper):
             the transformed observation
         """
         raise NotImplementedError
-
-    def single_observation(self, observation: ObsType) -> ObsType:
-        """Defines the single observation transformation.
-
-        Args:
-            observation: A single observation from the environment
-
-        Returns:
-            The transformed observation
-        """
-        raise NotImplementedError
-
-    def update_final_obs(self, info: dict[str, Any]) -> dict[str, Any]:
-        """Updates the `final_obs` in the info using `single_observation`."""
-        if "final_observation" in info:
-            for i, obs in enumerate(info["final_observation"]):
-                if obs is not None:
-                    info["final_observation"][i] = self.single_observation(obs)
-        return info
 
 
 class VectorActionWrapper(VectorWrapper):
@@ -525,14 +506,14 @@ class VectorRewardWrapper(VectorWrapper):
         self, actions: ActType
     ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, dict[str, Any]]:
         """Steps through the environment returning a reward modified by :meth:`reward`."""
-        observation, reward, termination, truncation, info = self.env.step(actions)
-        return observation, self.rewards(reward), termination, truncation, info
+        observations, rewards, terminations, truncations, infos = self.env.step(actions)
+        return observations, self.rewards(rewards), terminations, truncations, infos
 
-    def rewards(self, reward: ArrayType) -> ArrayType:
+    def rewards(self, rewards: ArrayType) -> ArrayType:
         """Transform the reward before returning it.
 
         Args:
-            reward (array): the reward to transform
+            rewards (array): the reward to transform
 
         Returns:
             array: the transformed reward

--- a/gymnasium/wrappers/common.py
+++ b/gymnasium/wrappers/common.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, SupportsFloat
 
 import gymnasium as gym
 from gymnasium import logger
-from gymnasium.core import ActType, ObsType, RenderFrame
+from gymnasium.core import ActType, ObsType, RenderFrame, WrapperObsType
 from gymnasium.error import ResetNeeded
 from gymnasium.utils.passive_env_checker import (
     check_action_space,
@@ -196,6 +196,15 @@ class Autoreset(
         gym.utils.RecordConstructorArgs.__init__(self)
         gym.Wrapper.__init__(self, env)
 
+        self.autoreset = False
+
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[WrapperObsType, dict[str, Any]]:
+        """Resets the environment and sets autoreset to False preventing."""
+        self.autoreset = False
+        return super().reset(seed=seed, options=options)
+
     def step(
         self, action: ActType
     ) -> tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]:
@@ -207,24 +216,13 @@ class Autoreset(
         Returns:
             The autoreset environment :meth:`step`
         """
-        obs, reward, terminated, truncated, info = self.env.step(action)
+        if self.autoreset:
+            obs, info = self.env.reset()
+            reward, terminated, truncated = 0.0, False, False
+        else:
+            obs, reward, terminated, truncated, info = self.env.step(action)
 
-        if terminated or truncated:
-            new_obs, new_info = self.env.reset()
-
-            assert (
-                "final_observation" not in new_info
-            ), f'new info dict already contains "final_observation", info keys: {new_info.keys()}'
-            assert (
-                "final_info" not in new_info
-            ), f'new info dict already contains "final_observation", info keys: {new_info.keys()}'
-
-            new_info["final_observation"] = obs
-            new_info["final_info"] = info
-
-            obs = new_obs
-            info = new_info
-
+        self.autoreset = terminated or truncated
         return obs, reward, terminated, truncated, info
 
 

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -444,7 +444,7 @@ class NormalizeObservation(
 
     Change logs:
      * v0.21.0 - Initially add
-     * v1.0.0 - Add `update_running_mean` attribute to allow disabling of updating the running mean / standard
+     * v1.0.0 - Add `update_running_mean` attribute to allow disabling of updating the running mean / standard, particularly useful for evaluation time.
     """
 
     def __init__(self, env: gym.Env[ObsType, ActType], epsilon: float = 1e-8):

--- a/gymnasium/wrappers/vector/common.py
+++ b/gymnasium/wrappers/vector/common.py
@@ -110,7 +110,7 @@ class RecordEpisodeStatistics(VectorWrapper):
 
         assert isinstance(
             infos, dict
-        ), f"`info` dtype is {type(infos)} while supported dtype is `dict`. This may be due to usage of other wrappers in the wrong order."
+        ), f"`vector.RecordEpisodeStatistics` requires `info` type to be `dict`, its actual type is {type(infos)}. This may be due to usage of other wrappers in the wrong order."
 
         self.episode_returns += rewards
         self.episode_lengths += 1

--- a/gymnasium/wrappers/vector/dict_info_to_list.py
+++ b/gymnasium/wrappers/vector/dict_info_to_list.py
@@ -80,6 +80,7 @@ class DictInfoToList(VectorWrapper):
     ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, list[dict[str, Any]]]:
         """Steps through the environment, convert dict info to list."""
         observation, reward, terminated, truncated, infos = self.env.step(actions)
+        assert isinstance(infos, dict)
         list_info = self._convert_info_to_list(infos)
 
         return observation, reward, terminated, truncated, list_info
@@ -92,6 +93,7 @@ class DictInfoToList(VectorWrapper):
     ) -> tuple[ObsType, list[dict[str, Any]]]:
         """Resets the environment using kwargs."""
         obs, infos = self.env.reset(seed=seed, options=options)
+        assert isinstance(infos, dict)
         list_info = self._convert_info_to_list(infos)
 
         return obs, list_info

--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -81,29 +81,15 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         """Sets the property to freeze/continue the running mean calculation of the observation statistics."""
         self._update_running_mean = setting
 
-    def vector_observation(self, observation: ObsType) -> ObsType:
+    def observation(self, observations: ObsType) -> ObsType:
         """Defines the vector observation normalization function.
 
         Args:
-            observation: A vector observation from the environment
+            observations: A vector observation from the environment
 
         Returns:
             the normalized observation
         """
-        return self._normalize_observations(observation)
-
-    def single_observation(self, observation: ObsType) -> ObsType:
-        """Defines the single observation normalization function.
-
-        Args:
-            observation: A single observation from the environment
-
-        Returns:
-            The normalized observation
-        """
-        return self._normalize_observations(observation[None])
-
-    def _normalize_observations(self, observations: ObsType) -> ObsType:
         if self._update_running_mean:
             self.obs_rms.update(observations)
         return (observations - self.obs_rms.mean) / np.sqrt(

--- a/gymnasium/wrappers/vector/vectorize_observation.py
+++ b/gymnasium/wrappers/vector/vectorize_observation.py
@@ -37,13 +37,10 @@ class TransformObservation(VectorObservationWrapper):
         >>> def scale_and_shift(obs):
         ...     return (obs - 1.0) * 2.0
         ...
-        >>> def vector_scale_and_shift(obs):
-        ...     return (obs - 1.0) * 2.0
-        ...
         >>> import gymnasium as gym
         >>> envs = gym.make_vec("CartPole-v1", num_envs=3, vectorization_mode="sync")
         >>> new_obs_space = Box(low=envs.observation_space.low, high=envs.observation_space.high)
-        >>> envs = TransformObservation(envs, single_func=scale_and_shift, vector_func=vector_scale_and_shift)
+        >>> envs = TransformObservation(envs, func=scale_and_shift, observation_space=new_obs_space)
         >>> obs, info = envs.reset(seed=123)
         >>> obs
         array([[-1.9635296, -2.0892358, -2.055928 , -2.0631256],
@@ -55,16 +52,14 @@ class TransformObservation(VectorObservationWrapper):
     def __init__(
         self,
         env: VectorEnv,
-        vector_func: Callable[[ObsType], Any],
-        single_func: Callable[[ObsType], Any],
+        func: Callable[[ObsType], Any],
         observation_space: Space | None = None,
     ):
         """Constructor for the transform observation wrapper.
 
         Args:
             env: The vector environment to wrap
-            vector_func: A function that will transform the vector observation. If this transformed observation is outside the observation space of ``env.observation_space`` then provide an ``observation_space``.
-            single_func: A function that will transform an individual observation, this function will be used for the final observation from the environment and is returned under ``info`` and not the normal observation.
+            func: A function that will transform the vector observation. If this transformed observation is outside the observation space of ``env.observation_space`` then provide an ``observation_space``.
             observation_space: The observation spaces of the wrapper, if None, then it is assumed the same as ``env.observation_space``.
         """
         super().__init__(env)
@@ -72,16 +67,11 @@ class TransformObservation(VectorObservationWrapper):
         if observation_space is not None:
             self.observation_space = observation_space
 
-        self.vector_func = vector_func
-        self.single_func = single_func
+        self.func = func
 
-    def vector_observation(self, observation: ObsType) -> ObsType:
+    def observation(self, observations: ObsType) -> ObsType:
         """Apply function to the vector observation."""
-        return self.vector_func(observation)
-
-    def single_observation(self, observation: ObsType) -> ObsType:
-        """Apply function to the single observation."""
-        return self.single_func(observation)
+        return self.func(observations)
 
 
 class VectorizeTransformObservation(VectorObservationWrapper):
@@ -158,16 +148,16 @@ class VectorizeTransformObservation(VectorObservationWrapper):
         self.same_out = self.observation_space == self.env.observation_space
         self.out = create_empty_array(self.single_observation_space, self.num_envs)
 
-    def vector_observation(self, observation: ObsType) -> ObsType:
+    def observation(self, observations: ObsType) -> ObsType:
         """Iterates over the vector observations applying the single-agent wrapper ``observation`` then concatenates the observations together again."""
         if self.same_out:
             return concatenate(
                 self.single_observation_space,
                 tuple(
                     self.wrapper.func(obs)
-                    for obs in iterate(self.observation_space, observation)
+                    for obs in iterate(self.observation_space, observations)
                 ),
-                observation,
+                observations,
             )
         else:
             return deepcopy(
@@ -175,15 +165,11 @@ class VectorizeTransformObservation(VectorObservationWrapper):
                     self.single_observation_space,
                     tuple(
                         self.wrapper.func(obs)
-                        for obs in iterate(self.env.observation_space, observation)
+                        for obs in iterate(self.env.observation_space, observations)
                     ),
                     self.out,
                 )
             )
-
-    def single_observation(self, observation: ObsType) -> ObsType:
-        """Transforms a single observation using the wrapper transformation function."""
-        return self.wrapper.func(observation)
 
 
 class FilterObservation(VectorizeTransformObservation):

--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -33,7 +33,7 @@ def test_create_async_vector_env(shared_memory):
 
 @pytest.mark.parametrize("shared_memory", [True, False])
 def test_reset_async_vector_env(shared_memory):
-    """Test the reset of an sync vector environment with or without shared memory."""
+    """Test the reset of async vector environment with or without shared memory."""
     env_fns = [make_env("CartPole-v1", i) for i in range(8)]
 
     env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)

--- a/tests/vector/test_vector_env.py
+++ b/tests/vector/test_vector_env.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from gymnasium.spaces import Discrete
+from gymnasium.utils.env_checker import data_equivalence
 from gymnasium.vector import AsyncVectorEnv, SyncVectorEnv
 from tests.testing_env import GenericTestEnv
 from tests.vector.testing_utils import make_env
@@ -29,6 +30,7 @@ def test_vector_env_equal(shared_memory):
     async_observations, async_infos = async_env.reset(seed=0)
     sync_observations, sync_infos = sync_env.reset(seed=0)
     assert np.all(async_observations == sync_observations)
+    assert data_equivalence(async_infos, sync_infos)
 
     for _ in range(num_steps):
         actions = async_env.action_space.sample()
@@ -49,16 +51,11 @@ def test_vector_env_equal(shared_memory):
             sync_infos,
         ) = sync_env.step(actions)
 
-        if any(sync_terminations) or any(sync_truncations):
-            assert "final_observation" in async_infos
-            assert "_final_observation" in async_infos
-            assert "final_observation" in sync_infos
-            assert "_final_observation" in sync_infos
-
         assert np.all(async_observations == sync_observations)
         assert np.all(async_rewards == sync_rewards)
         assert np.all(async_terminations == sync_terminations)
         assert np.all(async_truncations == sync_truncations)
+        assert data_equivalence(async_infos, sync_infos)
 
     async_env.close()
     sync_env.close()
@@ -115,14 +112,13 @@ def test_final_obs_info(vectoriser):
     )
 
     obs, _, termination, _, info = env.step([3])
+    assert obs == np.array([0]) and info == {"action": 3, "_action": np.array([True])}
+
+    obs, _, terminated, _, info = env.step([4])
     assert (
         obs == np.array([0])
         and termination == np.array([True])
         and info["reset"] == np.array([True])
     )
-    assert "final_observation" in info and "final_info" in info
-    assert info["final_observation"] == np.array([0]) and info["final_info"] == {
-        "action": 3
-    }
 
     env.close()

--- a/tests/vector/test_vector_env_info.py
+++ b/tests/vector/test_vector_env_info.py
@@ -3,58 +3,169 @@ import numpy as np
 import pytest
 
 import gymnasium as gym
+from gymnasium.spaces import Discrete
+from gymnasium.utils.env_checker import data_equivalence
+from gymnasium.vector import VectorEnv
 from gymnasium.vector.sync_vector_env import SyncVectorEnv
 from tests.vector.testing_utils import make_env
 
 
-ENV_ID = "CartPole-v1"
-NUM_ENVS = 3
-ENV_STEPS = 50
-SEED = 42
+def test_examples():
+    env = VectorEnv()
+
+    # Test num-envs==1 then expand_dims(sub-env-info) == vector-infos
+    env.num_envs = 1
+    sub_env_info = {"a": 0, "b": 0.0, "c": None, "d": np.zeros((2,)), "e": Discrete(1)}
+    vector_infos = env._add_info({}, sub_env_info, 0)
+    expected_vector_infos = {
+        "a": np.array([0]),
+        "b": np.array([0.0]),
+        "c": np.array([None], dtype=object),
+        "d": np.zeros(
+            (
+                1,
+                2,
+            )
+        ),
+        "e": np.array([Discrete(1)], dtype=object),
+        "_a": np.array([True]),
+        "_b": np.array([True]),
+        "_c": np.array([True]),
+        "_d": np.array([True]),
+        "_e": np.array([True]),
+    }
+    assert data_equivalence(vector_infos, expected_vector_infos)
+
+    # Thought: num-envs>1 then vector-infos should have the same structure as sub-env-info
+    env.num_envs = 3
+    sub_env_infos = [
+        {"a": 0, "b": 0.0, "c": None, "d": np.zeros((2,)), "e": Discrete(1)},
+        {"a": 1, "b": 1.0, "c": None, "d": np.zeros((2,)), "e": Discrete(2)},
+        {"a": 2, "b": 2.0, "c": None, "d": np.zeros((2,)), "e": Discrete(3)},
+    ]
+
+    vector_infos = {}
+    for i, info in enumerate(sub_env_infos):
+        vector_infos = env._add_info(vector_infos, info, i)
+
+    expected_vector_infos = {
+        "a": np.array([0, 1, 2]),
+        "b": np.array([0.0, 1.0, 2.0]),
+        "c": np.array([None, None, None], dtype=object),
+        "d": np.zeros((3, 2)),
+        "e": np.array([Discrete(1), Discrete(2), Discrete(3)], dtype=object),
+        "_a": np.array([True, True, True]),
+        "_b": np.array([True, True, True]),
+        "_c": np.array([True, True, True]),
+        "_d": np.array([True, True, True]),
+        "_e": np.array([True, True, True]),
+    }
+    assert data_equivalence(vector_infos, expected_vector_infos)
+
+    # Test different structures of sub-infos
+    env.num_envs = 3
+    sub_env_infos = [
+        {"a": 1, "b": 1.0},
+        {"c": None, "d": np.zeros((2,))},
+        {"e": Discrete(3)},
+    ]
+
+    vector_infos = {}
+    for i, info in enumerate(sub_env_infos):
+        vector_infos = env._add_info(vector_infos, info, i)
+
+    expected_vector_infos = {
+        "a": np.array([1, 0, 0]),
+        "b": np.array([1.0, 0.0, 0.0]),
+        "c": np.array([None, None, None], dtype=object),
+        "d": np.zeros((3, 2)),
+        "e": np.array([None, None, Discrete(3)], dtype=object),
+        "_a": np.array([True, False, False]),
+        "_b": np.array([True, False, False]),
+        "_c": np.array([False, True, False]),
+        "_d": np.array([False, True, False]),
+        "_e": np.array([False, False, True]),
+    }
+    assert data_equivalence(vector_infos, expected_vector_infos)
+
+    # Test recursive structure
+    env.num_envs = 3
+    sub_env_infos = [
+        {"episode": {"a": 1, "b": 1.0}},
+        {"episode": {"a": 2, "b": 2.0}, "a": 1},
+        {"a": 2},
+    ]
+
+    vector_infos = {}
+    for i, info in enumerate(sub_env_infos):
+        vector_infos = env._add_info(vector_infos, info, i)
+
+    expected_vector_infos = {
+        "episode": {
+            "a": np.array([1, 2, 0]),
+            "b": np.array([1.0, 2.0, 0.0]),
+            "_a": np.array([True, True, False]),
+            "_b": np.array([True, True, False]),
+        },
+        "_episode": np.array([True, True, False]),
+        "a": np.array([0, 1, 2]),
+        "_a": np.array([False, True, True]),
+    }
+    assert data_equivalence(vector_infos, expected_vector_infos)
 
 
 @pytest.mark.parametrize("vectorization_mode", ["async", "sync"])
-def test_vector_env_info(vectorization_mode: str):
+def test_vector_env_info(
+    vectorization_mode: str,
+    env_id: str = "CartPole-v1",
+    num_envs: int = 3,
+    env_steps: int = 50,
+    seed: int = 123,
+):
     """Test vector environment info for different vectorization modes."""
     env = gym.make_vec(
-        ENV_ID,
-        num_envs=NUM_ENVS,
+        env_id,
+        num_envs=num_envs,
         vectorization_mode=vectorization_mode,
     )
-    env.reset(seed=SEED)
-    for _ in range(ENV_STEPS):
-        env.action_space.seed(SEED)
+    env.reset(seed=seed)
+    for _ in range(env_steps):
+        env.action_space.seed(seed)
         action = env.action_space.sample()
-        _, _, terminateds, truncateds, infos = env.step(action)
-        if any(terminateds) or any(truncateds):
-            assert len(infos["final_observation"]) == NUM_ENVS
-            assert len(infos["_final_observation"]) == NUM_ENVS
+        _, _, terminations, truncations, infos = env.step(action)
+        if any(terminations) or any(truncations):
+            assert len(infos["final_observation"]) == num_envs
+            assert len(infos["_final_observation"]) == num_envs
 
             assert isinstance(infos["final_observation"], np.ndarray)
             assert isinstance(infos["_final_observation"], np.ndarray)
 
-            for i, (terminated, truncated) in enumerate(zip(terminateds, truncateds)):
+            for i, (terminated, truncated) in enumerate(zip(terminations, truncations)):
                 if terminated or truncated:
                     assert infos["_final_observation"][i]
                 else:
                     assert not infos["_final_observation"][i]
                     assert infos["final_observation"][i] is None
 
-    env.close()
-
 
 @pytest.mark.parametrize("concurrent_ends", [1, 2, 3])
-def test_vector_env_info_concurrent_termination(concurrent_ends):
+def test_vector_env_info_concurrent_termination(
+    concurrent_ends: int,
+    env_id: str = "CartPole-v1",
+    num_envs: int = 3,
+    env_steps: int = 50,
+    seed: int = 123,
+):
     """Test the vector environment information works with concurrent termination."""
     # envs that need to terminate together will have the same action
-    actions = [0] * concurrent_ends + [1] * (NUM_ENVS - concurrent_ends)
-    envs = [make_env(ENV_ID, SEED) for _ in range(NUM_ENVS)]
+    actions = [0] * concurrent_ends + [1] * (num_envs - concurrent_ends)
+    envs = [make_env(env_id, seed) for _ in range(num_envs)]
     envs = SyncVectorEnv(envs)
 
-    for _ in range(ENV_STEPS):
-        _, _, terminateds, truncateds, infos = envs.step(actions)
-        if any(terminateds) or any(truncateds):
-            for i, (terminated, truncated) in enumerate(zip(terminateds, truncateds)):
+    for _ in range(env_steps):
+        _, _, terminations, truncations, infos = envs.step(actions)
+        if any(terminations) or any(truncations):
+            for i, (terminated, truncated) in enumerate(zip(terminations, truncations)):
                 if i < concurrent_ends:
                     assert terminated or truncated
                     assert infos["_final_observation"][i]
@@ -62,5 +173,3 @@ def test_vector_env_info_concurrent_termination(concurrent_ends):
                     assert not infos["_final_observation"][i]
                     assert infos["final_observation"][i] is None
             return
-
-    envs.close()

--- a/tests/wrappers/test_autoreset.py
+++ b/tests/wrappers/test_autoreset.py
@@ -45,19 +45,15 @@ def test_autoreset_wrapper_autoreset():
     assert info == {"count": 2}
 
     obs, reward, terminated, truncated, info = env.step(action)
-    assert obs == np.array([0])
+    assert obs == np.array([3])
     assert (terminated or truncated) is True
     assert reward == 1
-    assert info == {
-        "count": 0,
-        "final_observation": np.array([3]),
-        "final_info": {"count": 3},
-    }
+    assert info == {"count": 3}
 
     obs, reward, terminated, truncated, info = env.step(action)
-    assert obs == np.array([1])
+    assert obs == np.array([0])
     assert reward == 0
     assert (terminated or truncated) is False
-    assert info == {"count": 1}
+    assert info == {"count": 0}
 
     env.close()

--- a/tests/wrappers/vector/test_dict_info_to_list.py
+++ b/tests/wrappers/vector/test_dict_info_to_list.py
@@ -1,21 +1,22 @@
 """Test suite for DictInfoTolist wrapper."""
+from __future__ import annotations
+
+from typing import Any
 
 import numpy as np
 import pytest
 
 import gymnasium as gym
+from gymnasium.core import ObsType
+from gymnasium.spaces import Discrete
+from gymnasium.utils.env_checker import data_equivalence
+from gymnasium.vector import VectorEnv
 from gymnasium.wrappers.vector import DictInfoToList, RecordEpisodeStatistics
 
 
-ENV_ID = "CartPole-v1"
-NUM_ENVS = 3
-ENV_STEPS = 50
-SEED = 42
-
-
-def test_usage_in_vector_env():
-    env = gym.make(ENV_ID, disable_env_checker=True)
-    vector_env = gym.make_vec(ENV_ID, num_envs=NUM_ENVS, vectorization_mode="sync")
+def test_usage_in_vector_env(env_id: str = "CartPole-v1", num_envs: int = 3):
+    env = gym.make(env_id, disable_env_checker=True)
+    vector_env = gym.make_vec(env_id, num_envs=num_envs)
 
     DictInfoToList(vector_env)
 
@@ -23,36 +24,40 @@ def test_usage_in_vector_env():
         DictInfoToList(env)
 
 
-def test_info_to_list():
-    env_to_wrap = gym.make_vec(ENV_ID, num_envs=NUM_ENVS, vectorization_mode="sync")
+def test_info_to_list(
+    env_id: str = "CartPole-v1", num_envs: int = 3, seed: int = 123, env_steps: int = 50
+):
+    env_to_wrap = gym.make_vec(env_id, num_envs=num_envs)
     wrapped_env = DictInfoToList(env_to_wrap)
-    wrapped_env.action_space.seed(SEED)
-    _, info = wrapped_env.reset(seed=SEED)
+    wrapped_env.action_space.seed(seed)
+    _, info = wrapped_env.reset(seed=seed)
     assert isinstance(info, list)
-    assert len(info) == NUM_ENVS
+    assert len(info) == num_envs
 
-    for _ in range(ENV_STEPS):
+    for _ in range(env_steps):
         action = wrapped_env.action_space.sample()
-        _, _, terminateds, truncateds, list_info = wrapped_env.step(action)
-        for i, (terminated, truncated) in enumerate(zip(terminateds, truncateds)):
+        _, _, terminations, truncations, list_info = wrapped_env.step(action)
+        for i, (terminated, truncated) in enumerate(zip(terminations, truncations)):
             if terminated or truncated:
                 assert "final_observation" in list_info[i]
             else:
                 assert "final_observation" not in list_info[i]
 
 
-def test_info_to_list_statistics():
-    env_to_wrap = gym.make_vec(ENV_ID, num_envs=NUM_ENVS, vectorization_mode="sync")
+def test_info_to_list_statistics(
+    env_id: str = "CartPole-v1", num_envs: int = 3, seed: int = 123, env_steps: int = 50
+):
+    env_to_wrap = gym.make_vec(env_id, num_envs=num_envs)
     wrapped_env = DictInfoToList(RecordEpisodeStatistics(env_to_wrap))
-    _, info = wrapped_env.reset(seed=SEED)
-    wrapped_env.action_space.seed(SEED)
+    _, info = wrapped_env.reset(seed=seed)
+    wrapped_env.action_space.seed(seed)
     assert isinstance(info, list)
-    assert len(info) == NUM_ENVS
+    assert len(info) == num_envs
 
-    for _ in range(ENV_STEPS):
+    for _ in range(env_steps):
         action = wrapped_env.action_space.sample()
-        _, _, terminateds, truncateds, list_info = wrapped_env.step(action)
-        for i, (terminated, truncated) in enumerate(zip(terminateds, truncateds)):
+        _, _, terminations, truncations, list_info = wrapped_env.step(action)
+        for i, (terminated, truncated) in enumerate(zip(terminations, truncations)):
             if terminated or truncated:
                 assert "episode" in list_info[i]
                 for stats in ["r", "l", "t"]:
@@ -60,3 +65,140 @@ def test_info_to_list_statistics():
                     assert np.isscalar(list_info[i]["episode"][stats])
             else:
                 assert "episode" not in list_info[i]
+
+
+class ResetOptionAsInfo(VectorEnv):
+    def reset(
+        self,
+        *,
+        seed: int | list[int] | None = None,
+        options: dict[str, Any] | None = None,  # options are passed as the output info
+    ) -> tuple[ObsType, dict[str, Any]]:
+        return None, options
+
+
+def test_update_info():
+    env = DictInfoToList(ResetOptionAsInfo())
+
+    # Test num-envs==1 then expand_dims(sub-env-info) == vector-infos
+    env.unwrapped.num_envs = 1
+
+    vector_infos = {
+        "a": np.array([0]),
+        "b": np.array([0.0]),
+        "c": np.array([None], dtype=object),
+        "d": np.zeros(
+            (
+                1,
+                2,
+            )
+        ),
+        "e": np.array([Discrete(1)], dtype=object),
+        "_a": np.array([True]),
+        "_b": np.array([True]),
+        "_c": np.array([True]),
+        "_d": np.array([True]),
+        "_e": np.array([True]),
+    }
+    _, list_info = env.reset(options=vector_infos)
+    expected_list_info = [
+        {
+            "a": np.int64(0),
+            "b": np.float64(0.0),
+            "c": None,
+            "d": np.zeros((2,)),
+            "e": Discrete(1),
+        }
+    ]
+
+    assert data_equivalence(list_info, expected_list_info)
+
+    # Thought: num-envs>1 then vector-infos should have the same structure as sub-env-info
+    env.unwrapped.num_envs = 3
+
+    vector_infos = {
+        "a": np.array([0, 1, 2]),
+        "b": np.array([0.0, 1.0, 2.0]),
+        "c": np.array([None, None, None], dtype=object),
+        "d": np.zeros((3, 2)),
+        "e": np.array([Discrete(1), Discrete(2), Discrete(3)], dtype=object),
+        "_a": np.array([True, True, True]),
+        "_b": np.array([True, True, True]),
+        "_c": np.array([True, True, True]),
+        "_d": np.array([True, True, True]),
+        "_e": np.array([True, True, True]),
+    }
+    _, list_info = env.reset(options=vector_infos)
+    expected_list_info = [
+        {
+            "a": np.int64(0),
+            "b": np.float64(0.0),
+            "c": None,
+            "d": np.zeros((2,)),
+            "e": Discrete(1),
+        },
+        {
+            "a": np.int64(1),
+            "b": np.float64(1.0),
+            "c": None,
+            "d": np.zeros((2,)),
+            "e": Discrete(2),
+        },
+        {
+            "a": np.int64(2),
+            "b": np.float64(2.0),
+            "c": None,
+            "d": np.zeros((2,)),
+            "e": Discrete(3),
+        },
+    ]
+
+    assert list_info[0].keys() == expected_list_info[0].keys()
+    for key in list_info[0].keys():
+        assert data_equivalence(list_info[0][key], expected_list_info[0][key])
+    assert data_equivalence(list_info, expected_list_info)
+
+    # Test different structures of sub-infos
+    env.unwrapped.num_envs = 3
+
+    vector_infos = {
+        "a": np.array([1, 0, 0]),
+        "b": np.array([1.0, 0.0, 0.0]),
+        "c": np.array([None, None, None], dtype=object),
+        "d": np.zeros((3, 2)),
+        "e": np.array([None, None, Discrete(3)], dtype=object),
+        "_a": np.array([True, False, False]),
+        "_b": np.array([True, False, False]),
+        "_c": np.array([False, True, False]),
+        "_d": np.array([False, True, False]),
+        "_e": np.array([False, False, True]),
+    }
+    _, list_info = env.reset(options=vector_infos)
+    expected_list_info = [
+        {"a": np.int64(1), "b": np.float64(1.0)},
+        {"c": None, "d": np.zeros((2,))},
+        {"e": Discrete(3)},
+    ]
+    assert data_equivalence(list_info, expected_list_info)
+
+    # Test recursive structure
+    env.unwrapped.num_envs = 3
+
+    vector_infos = {
+        "episode": {
+            "a": np.array([1, 2, 0]),
+            "b": np.array([1.0, 2.0, 0.0]),
+            "_a": np.array([True, True, False]),
+            "_b": np.array([True, True, False]),
+        },
+        "_episode": np.array([True, True, False]),
+        "a": np.array([0, 1, 2]),
+        "_a": np.array([False, True, True]),
+    }
+    _, list_info = env.reset(options=vector_infos)
+    expected_list_info = [
+        {"episode": {"a": np.int64(1), "b": np.float64(1.0)}},
+        {"episode": {"a": np.int64(2), "b": np.float64(2.0)}, "a": np.int64(1)},
+        {"a": np.int64(2)},
+    ]
+    assert data_equivalence(list_info, expected_list_info)

--- a/tests/wrappers/vector/test_record_episode_statistics.py
+++ b/tests/wrappers/vector/test_record_episode_statistics.py
@@ -1,0 +1,71 @@
+import pytest
+
+import gymnasium as gym
+from gymnasium.utils.env_checker import data_equivalence
+from gymnasium.vector import VectorEnv
+
+
+@pytest.mark.parametrize("num_envs", (1, 3))
+def test_record_episode_statistics(num_envs, env_id="CartPole-v1", num_steps=100):
+    wrapper_vector_env: VectorEnv = gym.wrappers.vector.RecordEpisodeStatistics(
+        gym.make_vec(id=env_id, num_envs=num_envs, vectorization_mode="sync"),
+    )
+    vector_wrapper_env = gym.make_vec(
+        id=env_id,
+        num_envs=num_envs,
+        vectorization_mode="sync",
+        wrappers=(gym.wrappers.RecordEpisodeStatistics,),
+    )
+
+    assert wrapper_vector_env.action_space == vector_wrapper_env.action_space
+    assert wrapper_vector_env.observation_space == vector_wrapper_env.observation_space
+    assert (
+        wrapper_vector_env.single_action_space == vector_wrapper_env.single_action_space
+    )
+    assert (
+        wrapper_vector_env.single_observation_space
+        == vector_wrapper_env.single_observation_space
+    )
+
+    assert wrapper_vector_env.num_envs == vector_wrapper_env.num_envs
+
+    wrapper_vector_obs, wrapper_vector_info = wrapper_vector_env.reset(seed=123)
+    vector_wrapper_obs, vector_wrapper_info = vector_wrapper_env.reset(seed=123)
+
+    assert data_equivalence(wrapper_vector_obs, vector_wrapper_obs)
+    assert data_equivalence(wrapper_vector_info, vector_wrapper_info)
+
+    for _ in range(num_steps):
+        action = wrapper_vector_env.action_space.sample()
+        (
+            wrapper_vector_obs,
+            wrapper_vector_reward,
+            wrapper_vector_terminated,
+            wrapper_vector_truncated,
+            wrapper_vector_info,
+        ) = wrapper_vector_env.step(action)
+        (
+            vector_wrapper_obs,
+            vector_wrapper_reward,
+            vector_wrapper_terminated,
+            vector_wrapper_truncated,
+            vector_wrapper_info,
+        ) = vector_wrapper_env.step(action)
+
+        data_equivalence(wrapper_vector_obs, vector_wrapper_obs)
+        data_equivalence(wrapper_vector_reward, vector_wrapper_reward)
+        data_equivalence(wrapper_vector_terminated, vector_wrapper_terminated)
+        data_equivalence(wrapper_vector_truncated, vector_wrapper_truncated)
+
+        if "episode" in wrapper_vector_info:
+            assert "episode" in vector_wrapper_info
+
+            wrapper_vector_time = wrapper_vector_info["episode"].pop("t")
+            vector_wrapper_time = vector_wrapper_info["episode"].pop("t")
+            assert wrapper_vector_time.shape == vector_wrapper_time.shape
+            assert wrapper_vector_time.dtype == vector_wrapper_time.dtype
+
+        data_equivalence(wrapper_vector_info, vector_wrapper_info)
+
+    wrapper_vector_env.close()
+    vector_wrapper_env.close()

--- a/tests/wrappers/vector/test_vector_wrappers.py
+++ b/tests/wrappers/vector/test_vector_wrappers.py
@@ -42,14 +42,14 @@ def custom_environments():
         ("CustomDictEnv-v0", "FilterObservation", {"filter_keys": ["a"]}),
         ("CartPole-v1", "FlattenObservation", {}),
         ("CarRacing-v2", "GrayscaleObservation", {}),
-        # ("CarRacing-v2", "ResizeObservation", {"shape": (35, 45)}),
+        ("CarRacing-v2", "ResizeObservation", {"shape": (35, 45)}),
         ("CarRacing-v2", "ReshapeObservation", {"shape": (96, 48, 6)}),
         ("CartPole-v1", "RescaleObservation", {"min_obs": 0, "max_obs": 1}),
         ("CartPole-v1", "DtypeObservation", {"dtype": np.int32}),
-        # ("CartPole-v1", "RenderObservation", {}),
-        # ("CartPole-v1", "TimeAwareObservation", {}),
-        # ("CartPole-v1", "FrameStackObservation", {}),
-        # ("CartPole-v1", "DelayObservation", {}),
+        # ("CartPole-v1", "RenderObservation", {}),  # not implemented
+        # ("CartPole-v1", "TimeAwareObservation", {}),  # not implemented
+        # ("CartPole-v1", "FrameStackObservation", {}),  # not implemented
+        # ("CartPole-v1", "DelayObservation", {}),  # not implemented
         ("MountainCarContinuous-v0", "ClipAction", {}),
         (
             "MountainCarContinuous-v0",


### PR DESCRIPTION
# Description

Vector environments have two choices for implementing an autoreset functionality
1. During the same step as a sub-environment has terminated / truncated, we can reset the sub-environment however this forces the terminated / truncated, referred to as final, observation and info to be stored in the info as `"final_observation"` and `"final_info"`. 
2. During the next step after a sub-environment has terminated / truncated, we can reset the sub-environment however in cases where `terminated=True` there is technically a dead action that does nothing.

An important note is that it is not possible to convert between reset orderings, i.e., if you have a vector environment using implementation 1, you can't run some code that makes it looks like 2, similarly for 2 you can't convert to 1 (to my knowledge).  

Previously, gym and gymnasium have used the first option however after a long time thinking about this, I believe that v1.0.0 is the best time for us to change to type 2. 

# Why?
I have three main reasons
 
## vector-only projects

My primary motivating factor is thinking about pure vector-only projects like EnvPool and SampleFactory, for optimisation reasons, it is (highly) inefficient to store data in a dictionary compared to a NumPy array. For this reason, from my knowledge, all vector-only projects use functionality 2 to autoreset environments. 

Why does this matter for Gymnasium? In v1.0.0, we have separated `Env` from `VectorEnv` such that neither inherits from the other. As a result, vector-only wrappers have been created to be used with vector environments (normal wrappers can be used inside vector environments for async and sync vector environments however for EnvPool and SampleFactory, this is not possible).  Therefore, given the note above about interoperability, if we continue with functionality 1, our vector wrappers cannot be used with these important vector-only projects. 

## more elegant training code 

As originally noted in https://github.com/Farama-Foundation/Gymnasium/issues/32#issuecomment-1365493442, functionality 1 requires relatively ugly code compared to functionality 2 
This is particularly true for vector environments; see https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/dqn.py#L200 

## Simplifies `VectorObservationWrapper`

`VectorObservationWrapper` requires two observation functions in order to transform an observation, a vector observation and a single observation as the final observation must be transformed on its own. 
But with functionality two, then there is no separate final observation that must be transformed 

# Why not? 

Unlike the step API in v0.25, there is no obvious way of telling if a vector environment has implemented functionality 1 or 2 or if the training code is adapted to 1 or 2. This is an issue that cannot be avoided but with v1.0.0, this is why we can only make it now

Second, users who use Gymnasium's async or sync vector env will have to update their usage. However, this will be obvious as `"final_observation"` and `"final_info"` will no longer exist

# Updating info concatenation and decomposition

By removing `"final_observation"` or `"final_info"` from info, we can implement a recursive vector info support, in particular, for vectoring `RecordEpisodeStatistics`.

Using `envs = gym.make_vec("CartPole-v1", num_envs=3, vectorization_mode="sync", wrappers=(gym.wrappers.RecordEpisodeStatistics,))`, when an sub-environment terminates / truncates, the info is `{"episode": np.array([{"r": 1, "t": 2, "l": 3}, None, None], dtype=object)}`. However this means to access the episode information, you need to do `info["final_info"][i]["episode"]["r"]` for each of the sub-environment. 

Rather, with functionality 2, you can do, `info["episode"]["r"]` for all of the sub-environment cumulative rewards (if they have terminated / truncated). 

Furthermore, it is necessary to update `DictToListInfo` to support the reverse operation of this.


