### PR TITLE
Add support for `JaxToNumpy` to handle NamedTuples (fixes #780)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -79,6 +79,11 @@ authors:
     email: omar.younis98@gmail.com
     affiliation: University of Bologna
     orcid: 'https://orcid.org/0009-0004-2783-7932'
+  - given-names: Roger
+    family-names: Larsson
+    email: roger.larsson@slentelit.se
+    affiliation: Slentelit AB
+    orcid: 'https://orcid.org/0009-0004-7872-3142'
 identifiers:
   - type: doi
     value: 10.5281/zenodo.8127025

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -79,11 +79,6 @@ authors:
     email: omar.younis98@gmail.com
     affiliation: University of Bologna
     orcid: 'https://orcid.org/0009-0004-2783-7932'
-  - given-names: Roger
-    family-names: Larsson
-    email: roger.larsson@slentelit.se
-    affiliation: Slentelit AB
-    orcid: 'https://orcid.org/0009-0004-7872-3142'
 identifiers:
   - type: doi
     value: 10.5281/zenodo.8127025

--- a/gymnasium/wrappers/jax_to_numpy.py
+++ b/gymnasium/wrappers/jax_to_numpy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import functools
 import numbers
 from collections import abc
-from typing import Any, Iterable, Mapping, NamedTuple, SupportsFloat, Type
+from typing import Any, Iterable, Mapping, NamedTuple, SupportsFloat
 
 import numpy as np
 
@@ -71,6 +71,7 @@ def _namedtuple_numpy_to_jax(
 ) -> NamedTuple:
     """Converts an NamedTuple from Numpy to Jax."""
     # "To prevent conflicts with field names, the method and attribute names start with an underscore."
+    # noinspection PyProtectedMember
     return type(value)._make(numpy_to_jax(v) for v in value)
 
 
@@ -113,16 +114,17 @@ def _namedtuple_jax_to_numpy(
 ) -> NamedTuple:
     """Converts an NamedTuple from JAX NamedTuple to a NamedTuple of Numpy Array."""
     # "To prevent conflicts with field names, the method and attribute names start with an underscore."
+    # noinspection PyProtectedMember
     return type(value)._make(jax_to_numpy(v) for v in value)
 
 
-def register_namedtuple(cls: Type[NamedTuple]):
+def register_namedtuple(cls: type[NamedTuple]):
     """Register conversion methods for namedtuple.
 
-    Note: can be registered by specific type, not NamedTuple, like this
+    Note: can be registered by specific type, not generic NamedTuple, like this
 
-    1. declaration of NamedTuple, using Name = namedtuple() or class Name(NamedTuple)
-    2. register_namedtuple(NewName)
+    1. declaration of NewNamedTuple, using NewNamedTuple = namedtuple() or class NewNamedTuple(NamedTuple)
+    2. register_namedtuple(NewNamedTuple)
     """
     numpy_to_jax.register(cls, _namedtuple_numpy_to_jax)
     jax_to_numpy.register(cls, _namedtuple_jax_to_numpy)

--- a/gymnasium/wrappers/jax_to_numpy.py
+++ b/gymnasium/wrappers/jax_to_numpy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import functools
 import numbers
 from collections import abc
-from typing import Any, Iterable, Mapping, SupportsFloat
+from typing import Any, Iterable, Mapping, NamedTuple, SupportsFloat, Type
 
 import numpy as np
 
@@ -21,7 +21,7 @@ except ImportError:
         "Jax is not installed therefore cannot call `numpy_to_jax`, run `pip install gymnasium[jax]`"
     )
 
-__all__ = ["JaxToNumpy", "jax_to_numpy", "numpy_to_jax"]
+__all__ = ["JaxToNumpy", "jax_to_numpy", "numpy_to_jax", "register_namedtuple"]
 
 
 @functools.singledispatch
@@ -58,8 +58,20 @@ def _mapping_numpy_to_jax(value: Mapping[str, Any]) -> Mapping[str, Any]:
 def _iterable_numpy_to_jax(
     value: Iterable[np.ndarray | Any],
 ) -> Iterable[jax.Array | Any]:
-    """Converts an Iterable from Numpy Arrays to an iterable of Jax Array."""
+    """Converts an Iterable from Numpy Arrays to an iterable of Jax Array.
+
+    Note: NamedTuples will not work "missing N required positional argument: 'name', ..."
+    see `register_namedtuple`, for work around
+    """
     return type(value)(numpy_to_jax(v) for v in value)
+
+
+def _namedtuple_numpy_to_jax(
+    value: NamedTuple,
+) -> NamedTuple:
+    """Converts an NamedTuple from Numpy to Jax."""
+    # "To prevent conflicts with field names, the method and attribute names start with an underscore."
+    return type(value)._make(numpy_to_jax(v) for v in value)
 
 
 @functools.singledispatch
@@ -88,8 +100,32 @@ def _mapping_jax_to_numpy(
 def _iterable_jax_to_numpy(
     value: Iterable[np.ndarray | Any],
 ) -> Iterable[jax.Array | Any]:
-    """Converts an Iterable from Numpy arrays to an iterable of Jax Array."""
+    """Converts an Iterable from Numpy arrays to an iterable of Jax Array.
+
+    Note: NamedTuples will not work "missing N required positional argument: 'name', ..."
+    see `register_namedtuple`, for work around
+    """
     return type(value)(jax_to_numpy(v) for v in value)
+
+
+def _namedtuple_jax_to_numpy(
+    value: NamedTuple,
+) -> NamedTuple:
+    """Converts an NamedTuple from JAX NamedTuple to a NamedTuple of Numpy Array."""
+    # "To prevent conflicts with field names, the method and attribute names start with an underscore."
+    return type(value)._make(jax_to_numpy(v) for v in value)
+
+
+def register_namedtuple(cls: Type[NamedTuple]):
+    """Register conversion methods for namedtuple.
+
+    Note: can be registered by specific type, not NamedTuple, like this
+
+    1. declaration of NamedTuple, using Name = namedtuple() or class Name(NamedTuple)
+    2. register_namedtuple(NewName)
+    """
+    numpy_to_jax.register(cls, _namedtuple_numpy_to_jax)
+    jax_to_numpy.register(cls, _namedtuple_jax_to_numpy)
 
 
 class JaxToNumpy(

--- a/tests/wrappers/test_jax_to_numpy.py
+++ b/tests/wrappers/test_jax_to_numpy.py
@@ -20,6 +20,7 @@ from tests.testing_env import GenericTestEnv  # noqa: E402
 
 class UnregNamedTuple(NamedTuple):
     """Do not register this named tuple"""
+
     a: jax.Array
     b: jax.Array
 

--- a/tests/wrappers/test_jax_to_numpy.py
+++ b/tests/wrappers/test_jax_to_numpy.py
@@ -13,33 +13,13 @@ from gymnasium.wrappers.jax_to_numpy import (  # noqa: E402
     JaxToNumpy,
     jax_to_numpy,
     numpy_to_jax,
-    register_namedtuple,
 )
 from tests.testing_env import GenericTestEnv  # noqa: E402
 
 
-class UnregNamedTuple(NamedTuple):
-    """Do not register this named tuple"""
-
+class TestingNamedTuple(NamedTuple):
     a: jax.Array
     b: jax.Array
-
-
-@pytest.mark.xfail
-def test_fail_on_namedtuple():
-    """Expect Bug (#780) to still exist"""
-    test_roundtripping(
-        UnregNamedTuple(a=3, b=2),
-        UnregNamedTuple(a=np.array(3, dtype=np.int32), b=np.array(2, dtype=np.int32)),
-    )
-
-
-class RegisteredNamedTuple(NamedTuple):
-    a: jax.Array
-    b: jax.Array
-
-
-register_namedtuple(RegisteredNamedTuple)  # Bug (#780) work around
 
 
 @pytest.mark.parametrize(
@@ -82,9 +62,13 @@ register_namedtuple(RegisteredNamedTuple)  # Bug (#780) work around
             },
         ),
         (
-            RegisteredNamedTuple(a=3, b=2),
-            RegisteredNamedTuple(
-                a=np.array(3, dtype=np.int32), b=np.array(2, dtype=np.int32)
+            TestingNamedTuple(
+                a=np.array([1, 2], dtype=np.int32),
+                b=np.array([1.0, 2.0], dtype=np.float32),
+            ),
+            TestingNamedTuple(
+                a=np.array([1, 2], dtype=np.int32),
+                b=np.array([1.0, 2.0], dtype=np.float32),
             ),
         ),
     ],


### PR DESCRIPTION
They caused "missing N required positional argument: 'name', ..." in _iterable_numpy_to_jax or _iterable_jax_to_numpy as the for loop resulted in a generator that NamedTuples could not handle.

NamedTuple is not a useful base class, every used named type needs to be registered individually. jax_to_numpy.register_namedtuple(NewNamedTuple)

[Bug Report] TypeError: <NamedTuple>.__new__() missing 1 required positional argument: '<argument>'

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (780)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up) - did changes that looks Wrong
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

