### PR TITLE
fix `third_party_environments.md` `discord` invite link

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -15,7 +15,7 @@ many-agent RL ([MAgent2](https://magent2.farama.org/)),
 
 *This page contains environments which are not maintained by Farama Foundation and, as such, cannot be guaranteed to function as intended.*
 
-*If you'd like to contribute an environment, please reach out on [Discord](https://discord.gg/nHg2JRN489).*
+*If you'd like to contribute an environment, please reach out on [Discord](https://discord.gg/bnJ6kubTg6).*
 
 ### [CARL: context adaptive RL](https://github.com/automl/CARL)
 


### PR DESCRIPTION
# Description

the only had expired, you may want to use a different link if you keep some form of statistics, I used the one from the readme