### PR TITLE
just testing CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ accept-rom-license = ["autorom[accept-rom-license] ~=0.4.2"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
-mujoco-py = ["mujoco-py >=2.1,<2.2", "cython<3"]
-mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]       # kept for backward compatibility
+mujoco-py = ["mujoco-py >=2.1,<2.2", "cython==3.0.0"]
+mujoco_py = ["mujoco-py >=2.1,<2.2", "cython==3.0.0"]       # kept for backward compatibility
 mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]         # kept for backward compatibility
@@ -65,7 +65,7 @@ all = [
     "pygame >=2.1.3",
     # mujoco-py
     "mujoco-py >=2.1,<2.2",
-    "cython<3",
+    "cython==3.0.0",
     # mujoco
     "mujoco >=2.1.5",
     "imageio >=2.14.1",


### PR DESCRIPTION
Just testing CI do not mind me 

for some reason, this work on my computer, so I am making sure it does also work on the CI
```py
>>> import cython
>>> import gymnasium
>>> env = gymnasium.make('Ant-v2')
/home/master-andreas/Gymnasium/gymnasium/envs/registration.py:508: DeprecationWarning: WARN: The environment Ant-v2 is out of date. You should consider upgrading to version `v5`.
  logger.deprecation(
/home/master-andreas/Gymnasium/gymnasium/envs/mujoco/mujoco_env.py:215: DeprecationWarning: WARN: This version of the mujoco environments depends on the mujoco-py bindings, which are no longer maintained and may stop working. Please upgrade to the v5 or v4 versions of the environments (which depend on the mujoco python bindings instead), unless you are trying to precisely replicate previous works).
  logger.deprecation(
>>> cython.__version__
'3.0.0'
>>> _ = env.reset();
```