### PR TITLE
Fix async vectorization for custom registered envs

### DIFF
--- a/tests/envs/registration/test_make_vec.py
+++ b/tests/envs/registration/test_make_vec.py
@@ -153,9 +153,12 @@ def test_make_vec_with_spec(env_id: str, kwargs: dict):
     recreated_envs.close()
 
 
-def test_async_with_dynamically_registered_env():
+@pytest.mark.parametrize("ctx", [None, "spawn", "fork", "forkserver"])
+def test_async_with_dynamically_registered_env(ctx):
     gym.register("TestEnv-v0", CartPoleEnv)
 
-    gym.make_vec("TestEnv-v0", vectorization_mode="async")
+    gym.make_vec(
+        "TestEnv-v0", vectorization_mode="async", vector_kwargs=dict(context=ctx)
+    )
 
     del gym.registry["TestEnv-v0"]


### PR DESCRIPTION
# Description

This has been hanging around the backlog for a while, turns out the fix was simpler than I expected. Assuming everything's good with this fix, of course.

The problem was essentially that depending on the start method/context of multiprocessing, local variables will or will not be inherited by the subprocess. This means that locally registered environments may or may not be available in the subprocess.

The solution is simply fetching the right env spec in the main process, and giving it to the subprocess (as opposed to the prior approach, where we just give the subprocess the string id)


Fixes #222 (phew, fixed it before a year passed from the original issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
