### PR TITLE
remove `FuncEnv.__init__()` `options==None` options

### DIFF
--- a/gymnasium/functional.py
+++ b/gymnasium/functional.py
@@ -43,9 +43,9 @@ class FuncEnv(
     observation_space: Space
     action_space: Space
 
-    def __init__(self, options: dict[str, Any] | None = None):
+    def __init__(self, options: dict[str, Any] = {}):
         """Initialize the environment constants."""
-        self.__dict__.update(options or {})
+        self.__dict__.update(options)
 
     def initial(self, rng: Any) -> StateType:
         """Generates the initial state of the environment with a random number generator."""

--- a/tests/envs/functional/test_core.py
+++ b/tests/envs/functional/test_core.py
@@ -27,7 +27,7 @@ class BasicTestEnv(FuncEnv):
 
 def test_api():
     env = BasicTestEnv()
-    state = env.initial(None)
+    state = env.initial({})
     obs = env.observation(state)
     assert state.shape == (2,)
     assert state.dtype == np.float32


### PR DESCRIPTION
# Description

The previous implementation allowed passing `options=None` which would act like `options={}`

you may not want to merge this if you believe it will break something or if it was intentional design, from what I can tell it does not break anything


## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update



# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

