### PR TITLE
add `default_camera_config` argument on `Swimmer`, `InvertedPendulum` & `InvertedDoublePendulum`

### DIFF
--- a/gymnasium/envs/mujoco/swimmer_v5.py
+++ b/gymnasium/envs/mujoco/swimmer_v5.py
@@ -1,5 +1,7 @@
 __credits__ = ["Kallinteris-Andreas", "Rushiv Arora"]
 
+from typing import Dict, Union
+
 import numpy as np
 
 from gymnasium import utils
@@ -169,6 +171,7 @@ class SwimmerEnv(MujocoEnv, utils.EzPickle):
         self,
         xml_file: str = "swimmer.xml",
         frame_skip: int = 4,
+        default_camera_config: Dict[str, Union[float, int]] = {},
         forward_reward_weight: float = 1.0,
         ctrl_cost_weight: float = 1e-4,
         reset_noise_scale: float = 0.1,
@@ -179,6 +182,7 @@ class SwimmerEnv(MujocoEnv, utils.EzPickle):
             self,
             xml_file,
             frame_skip,
+            default_camera_config,
             forward_reward_weight,
             ctrl_cost_weight,
             reset_noise_scale,
@@ -195,7 +199,14 @@ class SwimmerEnv(MujocoEnv, utils.EzPickle):
             exclude_current_positions_from_observation
         )
 
-        MujocoEnv.__init__(self, xml_file, frame_skip, observation_space=None, **kwargs)
+        MujocoEnv.__init__(
+            self,
+            xml_file,
+            frame_skip,
+            observation_space=None,
+            default_camera_config=default_camera_config,
+            **kwargs,
+        )
 
         self.metadata = {
             "render_modes": [


### PR DESCRIPTION
# Description
These were missing from the `v5` https://github.com/Farama-Foundation/Gymnasium/pull/572 PR

in the case of swimmer, the changelog was stating it was added for the pendulums, it was updated to include them
