### PR TITLE
refactor `BaseMujocoEnv`'s  `expand_model_path` functionality into its own function

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -27,6 +27,20 @@ else:
 DEFAULT_SIZE = 480
 
 
+def expand_model_path(model_path: str) -> str:
+    """Expands the `model_path` to a full path if it starts with '~' or '.' or '/'."""
+    if model_path.startswith(".") or model_path.startswith("/"):
+        fullpath = model_path
+    elif model_path.startswith("~"):
+        fullpath = path.expanduser(model_path)
+    else:
+        fullpath = path.join(path.dirname(__file__), "assets", model_path)
+    if not path.exists(fullpath):
+        raise OSError(f"File {fullpath} does not exist")
+
+    return fullpath
+
+
 class BaseMujocoEnv(gym.Env[NDArray[np.float64], NDArray[np.float32]]):
     """Superclass for all MuJoCo environments."""
 
@@ -57,14 +71,7 @@ class BaseMujocoEnv(gym.Env[NDArray[np.float64], NDArray[np.float32]]):
             OSError: when the `model_path` does not exist.
             error.DependencyNotInstalled: When `mujoco` is not installed.
         """
-        if model_path.startswith(".") or model_path.startswith("/"):
-            self.fullpath = model_path
-        elif model_path.startswith("~"):
-            self.fullpath = path.expanduser(model_path)
-        else:
-            self.fullpath = path.join(path.dirname(__file__), "assets", model_path)
-        if not path.exists(self.fullpath):
-            raise OSError(f"File {self.fullpath} does not exist")
+        self.fullpath = expand_model_path(model_path)
 
         self.width = width
         self.height = height


### PR DESCRIPTION
# Description
Takes a part of the `baseMujocoEnv.__init__()` and factorizes it into its own function

## Motivation
I want to use it in `MJX` and `gymnasium-robotics`