### PR TITLE
Factorize `self.terminated` function out in `Ant`. `Hopper`, `Humanoid`, `Walker2d`

### DIFF
--- a/gymnasium/envs/mujoco/ant_v5.py
+++ b/gymnasium/envs/mujoco/ant_v5.py
@@ -363,11 +363,6 @@ class AntEnv(MujocoEnv, utils.EzPickle):
         is_healthy = np.isfinite(state).all() and min_z <= state[2] <= max_z
         return is_healthy
 
-    @property
-    def terminated(self):
-        terminated = (not self.is_healthy) and self._terminate_when_unhealthy
-        return terminated
-
     def step(self, action):
         xy_position_before = self.data.body(self._main_body).xpos[:2].copy()
         self.do_simulation(action, self.frame_skip)
@@ -378,7 +373,7 @@ class AntEnv(MujocoEnv, utils.EzPickle):
 
         observation = self._get_obs()
         reward, reward_info = self._get_rew(x_velocity, action)
-        terminated = self.terminated
+        terminated = (not self.is_healthy) and self._terminate_when_unhealthy
         info = {
             "x_position": self.data.qpos[0],
             "y_position": self.data.qpos[1],

--- a/gymnasium/envs/mujoco/hopper_v5.py
+++ b/gymnasium/envs/mujoco/hopper_v5.py
@@ -290,11 +290,6 @@ class HopperEnv(MujocoEnv, utils.EzPickle):
 
         return is_healthy
 
-    @property
-    def terminated(self):
-        terminated = (not self.is_healthy) and self._terminate_when_unhealthy
-        return terminated
-
     def _get_obs(self):
         position = self.data.qpos.flatten()
         velocity = np.clip(self.data.qvel.flatten(), -10, 10)
@@ -313,7 +308,7 @@ class HopperEnv(MujocoEnv, utils.EzPickle):
 
         observation = self._get_obs()
         reward, reward_info = self._get_rew(x_velocity, action)
-        terminated = self.terminated
+        terminated = (not self.is_healthy) and self._terminate_when_unhealthy
         info = {
             "x_position": x_position_after,
             "z_distance_from_origin": self.data.qpos[1] - self.init_qpos[1],

--- a/gymnasium/envs/mujoco/humanoid_v5.py
+++ b/gymnasium/envs/mujoco/humanoid_v5.py
@@ -448,11 +448,6 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
 
         return is_healthy
 
-    @property
-    def terminated(self):
-        terminated = (not self.is_healthy) and self._terminate_when_unhealthy
-        return terminated
-
     def _get_obs(self):
         position = self.data.qpos.flatten()
         velocity = self.data.qvel.flatten()
@@ -499,7 +494,7 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
 
         observation = self._get_obs()
         reward, reward_info = self._get_rew(x_velocity, action)
-        terminated = self.terminated
+        terminated = (not self.is_healthy) and self._terminate_when_unhealthy
         info = {
             "x_position": self.data.qpos[0],
             "y_position": self.data.qpos[1],

--- a/gymnasium/envs/mujoco/walker2d_v5.py
+++ b/gymnasium/envs/mujoco/walker2d_v5.py
@@ -289,11 +289,6 @@ class Walker2dEnv(MujocoEnv, utils.EzPickle):
 
         return is_healthy
 
-    @property
-    def terminated(self):
-        terminated = (not self.is_healthy) and self._terminate_when_unhealthy
-        return terminated
-
     def _get_obs(self):
         position = self.data.qpos.flatten()
         velocity = np.clip(self.data.qvel.flatten(), -10, 10)
@@ -312,7 +307,7 @@ class Walker2dEnv(MujocoEnv, utils.EzPickle):
 
         observation = self._get_obs()
         reward, reward_info = self._get_rew(x_velocity, action)
-        terminated = self.terminated
+        terminated = (not self.is_healthy) and self._terminate_when_unhealthy
         info = {
             "x_position": x_position_after,
             "z_distance_from_origin": self.data.qpos[1] - self.init_qpos[1],


### PR DESCRIPTION
# Description
simply removes the single line `terminate` function

## validation
https://github.com/Kallinteris-Andreas/gymnasium-changes-validation/tree/main/simplify_termination_code
The environment were validated for 1 mil steps per environment and had identical behavior
performance if less than $\pm 1$ %