### PR TITLE
Change space and force calculation

### DIFF
--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -131,7 +131,11 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
             dtype=np.float32,
         )
 
-        self.action_space = spaces.Discrete(2)
+        self.action_space = spaces.Box(
+           np.array([0.0], dtype=np.float32),
+           np.array([1.0], dtype=np.float32),
+           dtype=np.float32)
+
         self.observation_space = spaces.Box(-high, high, dtype=np.float32)
 
         self.render_mode = render_mode
@@ -151,7 +155,7 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         ), f"{action!r} ({type(action)}) invalid"
         assert self.state is not None, "Call reset before using step method."
         x, x_dot, theta, theta_dot = self.state
-        force = self.force_mag if action == 1 else -self.force_mag
+        force = (action[0] - 0.5) * 2.0 * self.force_mag
         costheta = math.cos(theta)
         sintheta = math.sin(theta)
 
@@ -380,7 +384,11 @@ class CartPoleVectorEnv(VectorEnv):
         self.low = -0.05
         self.high = 0.05
 
-        self.single_action_space = spaces.Discrete(2)
+        self.single_action_space = spaces.Box(
+            np.array([0.0], dtype=np.float32),
+            np.array([1.0], dtype=np.float32),
+            dtype=np.float32)
+
         self.action_space = batch_space(self.single_action_space, num_envs)
         self.single_observation_space = spaces.Box(-high, high, dtype=np.float32)
         self.observation_space = batch_space(self.single_observation_space, num_envs)
@@ -403,7 +411,7 @@ class CartPoleVectorEnv(VectorEnv):
         assert self.state is not None, "Call reset before using step method."
 
         x, x_dot, theta, theta_dot = self.state
-        force = np.sign(action - 0.5) * self.force_mag
+        force = (action - 0.5) * 2.0 * self.force_mag
         costheta = np.cos(theta)
         sintheta = np.sin(theta)
 


### PR DESCRIPTION
# Description

The goal is to endow CartPole with a continuous-valued action. It seems odd that it was ever constrained to give full gas all the time. A control system should try to minimise its use of fuel but this policy renders that impossible. Also, this digitisation presents neural networks with a problem that's irrelevant and obfuscating to most research goals. 

I notice that two environments already have continuous and digitised action variants, but in two different styles, and it's hard to see what the digitsed variants offer that isn't a strict subset of what the continuous ones do, begging the question why the project would want the digitised variants hanging around.
 
The current patch simply switches the input space to a 1D box ranging from 0 to 1 and interprets the value such that 0 and 1 are interpreted the same as before: full gas to the left or right respectively. To apply no force, one must now send 0.5. Existing client code would have suffered an exception if it had sent any value besides 0 or 1, so this change is guaranteed not to break existing experiments. The fact that actions can't stray outside of the range 0-1 means that no new extreme observations could have been introduced. 

So while backward compatibility has been preserved, if an experiment wants to use the new continuous action, then it must use a version of Gymnasium subsequent to the present patch.

In this light, you might think the patch can be accepted as is (but for documentation updates and maybe new tests.) On the other hand, you might think it should be called CartPole-v2, or CartPoleContinuous (and in either case perhaps that 0 should mean no force while negative/positive values mean push left/right), or you might reject the whole concept in which case I'd have to direct anybody interested in my stuff to use my cloned repo, or make a new third party environment, both of which would seem like a lot of baggage for such a tiny and non-breaking change.

Please let me know your thoughts.


- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

