### PR TITLE
Add third-party tutorial page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,7 @@ environments/third_party_environments
 :caption: Tutorials
 
 tutorials/**/index
+tutorials/third-party-tutorials
 Comet Tutorial <https://www.comet.com/docs/v2/integrations/ml-frameworks/gymnasium/?utm_source=gymnasium&utm_medium=partner&utm_campaign=partner_gymnasium_2023&utm_content=docs_gymnasium>
 ```
 

--- a/docs/tutorials/third-party-tutorials.md
+++ b/docs/tutorials/third-party-tutorials.md
@@ -4,4 +4,4 @@
 
 ## [AgileRL](https://docs.agilerl.com/en/latest/tutorials/gymnasium/index.html)
 
-AgileRL focuses on reducing the time taken for training models and hyperparameter optimisation (HPO) providing tutorials for using it with PPO, TD3 and Rainbow. 
+AgileRL focuses on reducing the time taken for training models and hyperparameter optimisation (HPO) providing tutorials for using it with PPO, TD3 and Rainbow.

--- a/docs/tutorials/third-party-tutorials.md
+++ b/docs/tutorials/third-party-tutorials.md
@@ -1,0 +1,7 @@
+
+
+# Third-Party Tutorials
+
+## [AgileRL](https://docs.agilerl.com/en/latest/tutorials/gymnasium/index.html)
+
+AgileRL focuses on reducing the time taken for training models and hyperparameter optimisation (HPO) providing tutorials for using it with PPO, TD3 and Rainbow. 


### PR DESCRIPTION
# Description

Follow up to #839 and #866, as an alternative this PR adds a third-party tutorial page for external projects to have a link to their tutorials that incorporate Gymnasium with their project