### PR TITLE
Add `skip_close_check` to `check_env`

### DIFF
--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -256,7 +256,12 @@ def check_space_limit(space, space_type: str):
             check_space_limit(subspace, space_type)
 
 
-def check_env(env: gym.Env, warn: bool = None, skip_render_check: bool = False):
+def check_env(
+    env: gym.Env,
+    warn: bool = None,
+    skip_render_check: bool = False,
+    skip_close_check: bool = False,
+):
     """Check that an environment follows Gymnasium's API.
 
     .. py:currentmodule:: gymnasium.Env
@@ -269,7 +274,8 @@ def check_env(env: gym.Env, warn: bool = None, skip_render_check: bool = False):
     Args:
         env: The Gym environment that will be checked
         warn: Ignored, previously silenced particular warnings
-        skip_render_check: Whether to skip the checks for the render method. True by default (useful for the CI)
+        skip_render_check: Whether to skip the checks for the render method. False by default (useful for the CI)
+        skip_close_check: Whether to skip the checks for the close method. False by default
     """
     if warn is not None:
         logger.warn("`check_env(warn=...)` parameter is now ignored.")
@@ -323,7 +329,7 @@ def check_env(env: gym.Env, warn: bool = None, skip_render_check: bool = False):
                 "Not able to test alternative render modes due to the environment not having a spec. Try instantialising the environment through gymnasium.make"
             )
 
-    if env.spec is not None:
+    if not skip_close_check and env.spec is not None:
         new_env = env.spec.make()
         new_env.close()
         try:


### PR DESCRIPTION
# Description

For some environments, they cannot have multiple instances of an environment, e.g. real-world environments.
Therefore, this PR adds an argument that allows disabling testing of the close function within `check_env` 

Fixes https://github.com/Farama-Foundation/Gymnasium/issues/875