### PR TITLE
Fix MuJoCo human rendering on `mujoco<3`

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -619,9 +619,6 @@ class WindowViewer(BaseRender):
                 bottomleft, "Solver iterations", str(self.data.solver_iter + 1)
             )
         self.add_overlay(
-            bottomleft, "Solver iterations", str(self.data.solver_niter[0] + 1)
-        )
-        self.add_overlay(
             bottomleft, "Step", str(round(self.data.time / self.model.opt.timestep))
         )
         self.add_overlay(bottomleft, "timestep", "%.5f" % self.model.opt.timestep)


### PR DESCRIPTION
Fixes https://github.com/Farama-Foundation/Gymnasium/issues/878

typo fix, remove duplicated line

tested with `mujoco==2.3.7` & `mujoco==3.1.1`
