### PR TITLE
Add `vector.HumanRendering` wrapper

### DIFF
--- a/docs/api/vector/wrappers.md
+++ b/docs/api/vector/wrappers.md
@@ -33,6 +33,7 @@ title: Vector Wrappers
 .. autoclass:: gymnasium.wrappers.vector.VectorizeTransformObservation
 .. autoclass:: gymnasium.wrappers.vector.VectorizeTransformAction
 .. autoclass:: gymnasium.wrappers.vector.VectorizeTransformReward
+.. autoclass:: gymnasium.wrappers.vector.HumanRendering
 ```
 
 ## Vectorized Common wrappers

--- a/docs/api/wrappers/table.md
+++ b/docs/api/wrappers/table.md
@@ -92,6 +92,8 @@ wrapper in the page on the wrapper type
       - Description
     * - :class:`DictInfoToList`
       - Converts infos of vectorized environments from ``dict`` to ``List[dict]``.
+    * - :class:`HumanRendering`
+      - Allows human like rendering for vector environments that support "rgb_array" rendering.
     * - :class:`VectorizeTransformAction`
       - Vectorizes a single-agent transform action wrapper for vector environments.
     * - :class:`VectorizeTransformObservation`

--- a/gymnasium/__init__.py
+++ b/gymnasium/__init__.py
@@ -1,6 +1,7 @@
 """Root `__init__` of the gymnasium module setting the `__all__` of gymnasium modules."""
 # isort: skip_file
 
+from gymnasium.spaces.space import Space
 from gymnasium.core import (
     Env,
     Wrapper,
@@ -8,7 +9,6 @@ from gymnasium.core import (
     ActionWrapper,
     RewardWrapper,
 )
-from gymnasium.spaces.space import Space
 from gymnasium.envs.registration import (
     make,
     spec,

--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -510,7 +510,7 @@ class CartPoleVectorEnv(VectorEnv):
                     for _ in range(self.num_envs)
                 ]
         if self.clocks is None:
-            self.clock = [pygame.time.Clock() for _ in range(self.num_envs)]
+            self.clocks = [pygame.time.Clock() for _ in range(self.num_envs)]
 
         world_width = self.x_threshold * 2
         scale = self.screen_width / world_width
@@ -522,9 +522,9 @@ class CartPoleVectorEnv(VectorEnv):
         if self.state is None:
             return None
 
-        for state, screen, clock in zip(self.state, self.screens, self.clocks):
-            x = self.state.T
-
+        for state, screen, clock, x in zip(
+            self.state, self.screens, self.clocks, self.state.T
+        ):
             self.surf = pygame.Surface((self.screen_width, self.screen_height))
             self.surf.fill((255, 255, 255))
 

--- a/gymnasium/wrappers/base_/__init__.py
+++ b/gymnasium/wrappers/base_/__init__.py
@@ -1,0 +1,7 @@
+"""Code common for both regular and vector wrappers. Should not be used directly."""
+
+__all__ = [
+    "HumanRenderingBase",
+]
+
+from gymnasium.wrappers.base_.rendering import HumanRenderingBase

--- a/gymnasium/wrappers/base_/rendering.py
+++ b/gymnasium/wrappers/base_/rendering.py
@@ -1,0 +1,200 @@
+"""Human rendering routines used in both regular and vector wrappers. Should not be used directly.
+
+* ``HumanRenderingBase`` - Provides actual rendering for wrapper.HumanRendering and wrapper.vector.HumanRendering
+"""
+
+__all__ = [
+    "HumanRenderingBase",
+    "T_env",
+    "T_wrapper",
+]
+
+import itertools
+from copy import deepcopy
+from math import ceil, sqrt
+from typing import Generic, TypeVar
+
+import numpy as np
+
+import gymnasium as gym
+from gymnasium import logger
+from gymnasium.core import RenderFrame
+from gymnasium.error import DependencyNotInstalled
+
+
+ALL_ACCEPTABLE_RENDER_MODES = ["rgb_array", "rgb_array_list"]
+
+T_env = TypeVar("T_env", gym.Env, gym.vector.VectorEnv, covariant=True)
+T_wrapper = TypeVar("T_wrapper", gym.Wrapper, gym.vector.VectorWrapper, covariant=True)
+
+
+class HumanRenderingBase(Generic[T_wrapper, T_env]):
+    """Abstract base class for rendering."""
+
+    def __init__(self: T_wrapper, env: T_env, num_envs: int = 1):
+        """Initialize a :class:`HumanRenderingBase` instance."""
+        self.screen_size = None
+        self._sub_frame_size = None
+        self._scale = ceil(sqrt(num_envs))
+        self.window = None
+        self.clock = None
+
+        metadata_ = deepcopy(env.metadata)
+        if "human" in metadata_["render_modes"]:
+            logger.warn(
+                "Environment %s natively supports 'human' rendering, do not use rendering wrapper.",
+                env,
+            )
+        else:
+            metadata_["render_modes"].append("human")
+        self.metadata = metadata_  # should not access env.metadata from now on
+
+        if "render_fps" not in self.metadata:
+            logger.warn(
+                "The metadata 'render_fps' is required to be used with the HumanRendering wrapper"
+            )
+
+        if env.render_mode not in ALL_ACCEPTABLE_RENDER_MODES:
+            logger.warn(
+                f"Expected {env} 'render_mode' to be one of 'rgb_array' or 'rgb_array_list' but got '{env.render_mode}'"
+            )
+
+    def _get_render_mode(self: T_wrapper, env: T_env):
+        """If HumanRendering can make use of the wrapped environments render mode, then return "human"."""
+        if env.render_mode not in ALL_ACCEPTABLE_RENDER_MODES:
+            return env.render_mode
+        return "human"
+
+    def _set_render_mode(self: T_wrapper, env: T_env, mode: str):
+        """Sets the render mode of the wrapped environment, translate if necessary."""
+        if mode == "human":
+            available_modes = self._available_acceptable_render_modes()
+            assert available_modes, f"{env} has no valid render modes available"
+            logger.warn(
+                "Setting render mode %s directly to unwrapped %s",
+                available_modes[0],
+                env.unwrapped,
+            )
+            env.unwrapped.render_mode = available_modes[0]
+            return
+        env.unwrapped.render_mode = mode
+
+    def _check_config(self: T_wrapper, env: T_env):
+        """Used to check the config in reset, before _render_frame."""
+        if env.render_mode is None:
+            available_modes = self._available_acceptable_render_modes()
+            if available_modes:
+                raise AssertionError(
+                    "Render mode was not set for {}, set to acceptable '{}'".format(
+                        env, available_modes[0]
+                    )
+                )
+            raise AssertionError(
+                "Render mode was not set for {}, there are no acceptable render modes".format(
+                    env
+                )
+            )
+        assert (
+            "render_fps" in self.metadata
+        ), "The metadata 'render_fps' is required to be used with the HumanRendering wrapper"
+        assert (
+            env.render_mode in ALL_ACCEPTABLE_RENDER_MODES
+        ), f"Expected {env} 'render_mode' to be one of 'rgb_array' or 'rgb_array_list' but got '{env.render_mode}'"
+
+    def _available_acceptable_render_modes(self):
+        available_modes = [
+            mode
+            for mode in ALL_ACCEPTABLE_RENDER_MODES
+            if mode in self.metadata.get("render_modes", [])
+        ]
+        return available_modes
+
+    def _render_frame(self: T_wrapper):
+        """Fetch the last frame from the base environment and render it to the screen."""
+        try:
+            import pygame
+        except ImportError:
+            raise DependencyNotInstalled(
+                "pygame is not installed, run `pip install gymnasium[box2d]`"
+            )
+
+        def _render_sub_frame(rgb_array: RenderFrame, subframe=(0, 0)):
+            """Render the subframe.
+
+            :param rgb_array: image
+            :param subframe: (row, col) tuple
+            """
+            assert isinstance(
+                rgb_array, np.ndarray
+            ), "must be a np.ndarray to be rendered"
+
+            rgb_array = np.transpose(rgb_array, axes=(1, 0, 2))
+            if self.screen_size is None:
+                self.screen_size = rgb_array.shape[:2]
+                self._sub_frame_size = (
+                    self.screen_size[0] // self._scale,
+                    self.screen_size[1] // self._scale,
+                )
+            assert (
+                self.screen_size == rgb_array.shape[:2]
+            ), f"The shape of the rgb array has changed from {self.screen_size} to {rgb_array.shape[:2]}"
+
+            if self.window is None:
+                pygame.init()
+                pygame.display.init()
+                self.window = pygame.display.set_mode(self.screen_size)
+            if self.clock is None:
+                self.clock = pygame.time.Clock()
+
+            surf = pygame.surfarray.make_surface(rgb_array)
+            if self._scale > 1:
+                surf = pygame.transform.scale(surf, self._sub_frame_size)
+            self.window.blit(
+                surf,
+                (
+                    self._sub_frame_size[0] * subframe[1],
+                    self._sub_frame_size[1] * subframe[0],
+                ),
+            )
+
+        if self.env.render_mode == "rgb_array_list":
+            last_rgb_array = self.env.render()
+            assert isinstance(
+                last_rgb_array, list
+            ), "Expected render to return a list of (list of environment) RGB arrays"
+            last_rgb_array = last_rgb_array[-1]
+        elif self.env.render_mode == "rgb_array":
+            last_rgb_array = self.env.render()
+        else:
+            raise Exception(
+                f"Wrapped environment must have mode 'rgb_array' or 'rgb_array_list'"
+                f", actual render mode: {self.env.render_mode}"
+            )
+        if isinstance(last_rgb_array, list):
+            # A list of frames, from environments, length match self.num_envs (should now exist for vectored)?
+            assert (
+                len(last_rgb_array) == self.num_envs
+            ), "First dimension (list) %d should equal number of environments %d" % (
+                len(last_rgb_array),
+                self.num_envs,
+            )
+
+            for index, sub_frame in zip(itertools.count(), last_rgb_array):
+                _render_sub_frame(
+                    sub_frame, subframe=(index // self._scale, index % self._scale)
+                )
+        else:
+            _render_sub_frame(last_rgb_array)
+
+        pygame.event.pump()
+        self.clock.tick(self.metadata["render_fps"])
+        pygame.display.flip()
+
+    def _close(self):
+        """Close the rendering window. Can be called even if the class is not fully instantiated."""
+        if getattr(self, "window", None) is not None:
+            import pygame
+
+            pygame.display.quit()
+            pygame.quit()
+            self.window = None

--- a/gymnasium/wrappers/vector/__init__.py
+++ b/gymnasium/wrappers/vector/__init__.py
@@ -1,9 +1,15 @@
-"""Wrappers for vector environments."""
+"""A collections of rendering-based wrappers.
+
+* ``RenderCollection`` - Collects rendered frames into a list
+* ``RecordVideo`` - Records a video of the environments
+* ``HumanRendering`` - Provides human rendering of environments with ``"rgb_array"``
+"""
 # pyright: reportUnsupportedDunderAll=false
 import importlib
 
 from gymnasium.wrappers.vector.common import RecordEpisodeStatistics
 from gymnasium.wrappers.vector.dict_info_to_list import DictInfoToList
+from gymnasium.wrappers.vector.rendering import HumanRendering
 from gymnasium.wrappers.vector.stateful_observation import NormalizeObservation
 from gymnasium.wrappers.vector.stateful_reward import NormalizeReward
 from gymnasium.wrappers.vector.vectorize_action import (
@@ -63,7 +69,7 @@ __all__ = [
     # --- Rendering ---
     # "RenderCollection",
     # "RecordVideo",
-    # "HumanRendering",
+    "HumanRendering",
     # --- Conversion ---
     "JaxToNumpy",
     "JaxToTorch",

--- a/gymnasium/wrappers/vector/rendering.py
+++ b/gymnasium/wrappers/vector/rendering.py
@@ -1,0 +1,111 @@
+"""A collections of rendering-based wrappers.
+
+* ``HumanRendering`` - Provides human rendering of vector environments with ``"rgb_array"``
+"""
+from __future__ import annotations
+
+from typing import Any, SupportsFloat
+
+import gymnasium as gym
+from gymnasium.core import ActType, ObsType
+
+
+__all__ = [
+    "HumanRendering",
+]
+
+from gymnasium.wrappers.base_.rendering import HumanRenderingBase
+
+
+class HumanRendering(
+    gym.vector.VectorWrapper,
+    HumanRenderingBase[
+        gym.vector.VectorWrapper,
+        gym.vector.VectorEnv[ObsType, ActType, gym.vector.vector_env.ArrayType],
+    ],
+    gym.utils.RecordConstructorArgs,
+):
+    # noinspection PyShadowingNames
+    """Allows human like rendering for vector environments that support "rgb_array" rendering.
+
+    This wrapper is particularly useful when you have implemented an environment that can produce
+    RGB images but haven't implemented any code to render the images to the screen.
+    If you want to use this wrapper with your environments, remember to specify ``"render_fps"``
+    in the metadata of your environment.
+
+    The ``render_mode`` of the wrapped environment must be either ``'rgb_array'`` or ``'rgb_array_list'``.
+
+    Example:
+        >>> from gymnasium import make_vec
+        >>> from gymnasium.wrappers.vector.rendering import HumanRendering
+        >>> env = make_vec("CartPole-v1", num_envs=3, vector_kwargs=dict(render_mode="rgb_array"))
+        >>> wrapped = HumanRendering(env)  # Will warn that ChartPole-v1 natively supports 'human' rendering
+        >>> obs, _ = wrapped.reset()     # This will start rendering to the screen
+        >>> wrapped.render_mode, env.render_mode, env.unwrapped.render_mode  # extra check
+        ('human', 'rgb_array', 'rgb_array')
+
+        Warning: If the base environment uses ``render_mode="rgb_array_list"``, its (i.e. the *base environment's*)
+         render method will always return an empty list:
+
+    Change logs:
+     * v1.0.0 - Initially added
+    """
+
+    def __init__(
+        self,
+        env: gym.vector.VectorEnv[ObsType, ActType, gym.vector.vector_env.ArrayType],
+    ):
+        """Initialize a :class:`HumanRendering` instance.
+
+        Note: RenderState can determine if only one process should be rendered or multiple
+
+        Args:
+            env: The environment that is being wrapped
+        """
+        gym.utils.RecordConstructorArgs.__init__(self)
+        gym.vector.VectorWrapper.__init__(self, env)  # Creates the 'unwrapped' property
+        HumanRenderingBase.__init__(self, env, num_envs=self.num_envs)
+
+    @property
+    def render_mode(self):
+        """Returns 'human' when env has a compatible mode."""
+        return self._get_render_mode(self.env)
+
+    @render_mode.setter
+    def render_mode(self, mode: str):
+        """Forwards render mode other than 'human' to env."""
+        self._set_render_mode(self.env, mode)
+
+    @property
+    def autoreset_envs(self):
+        """Make wrapped :attr:`autoreset_envs` readable."""
+        return self.unwrapped.autoreset_envs
+
+    @autoreset_envs.setter
+    def autoreset_envs(self, value) -> None:
+        """Make wrapped :attr:`autoreset_envs` writeable."""
+        self.unwrapped.autoreset_envs = value
+
+    def step(self, action: ActType) -> tuple[ObsType, SupportsFloat, bool, bool, dict]:
+        """Perform a step in the base environment and render a frame to the screen."""
+        result = super().step(action)
+        self._render_frame()
+        return result
+
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[ObsType, dict[str, Any]]:
+        """Reset the base environment and render a frame to the screen."""
+        result = super().reset(seed=seed, options=options)
+        self._check_config(self.env)
+        self._render_frame()
+        return result
+
+    def render(self) -> None:
+        """This method doesn't do much, actual rendering is performed in :meth:`step` and :meth:`reset`."""
+        return None
+
+    def close(self):
+        """Close the rendering window."""
+        self._close()
+        super().close()

--- a/tests/wrappers/test_human_rendering.py
+++ b/tests/wrappers/test_human_rendering.py
@@ -1,5 +1,5 @@
 """Test suite of HumanRendering wrapper."""
-import re
+from __future__ import annotations
 
 import pytest
 
@@ -7,27 +7,73 @@ import gymnasium as gym
 from gymnasium.wrappers import HumanRendering
 
 
-def test_human_rendering():
-    for mode in ["rgb_array", "rgb_array_list"]:
-        env = HumanRendering(
-            gym.make("CartPole-v1", render_mode=mode, disable_env_checker=True)
-        )
-        assert env.render_mode == "human"
+@pytest.mark.parametrize(
+    "mode, apply_wrapper, reset_exception, exception_message",
+    [
+        [
+            None,
+            True,
+            AssertionError,
+            r"Render mode was not set for [^>]+CartPole[^,]+, set to acceptable 'rgb_array'",
+        ],
+        ["rgb_array", True, None, None],
+        ["rgb_array_list", True, None, None],
+        ["human", False, None, None],  # Automatic applied
+        [
+            "human",
+            True,
+            AssertionError,  # The HumanRenderer has already been applied automatically
+            r"Expected [^>]+CartPole[^ ]+ 'render_mode' to be one of 'rgb_array' or 'rgb_array_list' but got 'human'",
+        ],
+        [
+            "whatever",
+            True,
+            AssertionError,
+            r"Expected [^>]+CartPole[^ ]+ 'render_mode' to be one of 'rgb_array'"
+            r" or 'rgb_array_list' but got 'whatever'",
+        ],
+        [
+            "whatever",
+            True,
+            AssertionError,
+            r"Expected [^>]+CartPole[^ ]+ 'render_mode' to be one of 'rgb_array'"
+            r" or 'rgb_array_list' but got 'whatever'",
+        ],
+    ],
+)
+def test_human_rendering(
+    mode: str,
+    apply_wrapper: bool,
+    reset_exception: type[Exception],
+    exception_message: str,
+):
+    env = gym.make("CartPole-v1", render_mode=mode, disable_env_checker=True)
+
+    if apply_wrapper:
+        env = HumanRendering(env)
+        assert (
+            env.render_mode == "human"
+            if mode in ["rgb_array", "rgb_array_list"]
+            else env.render_mode == mode
+        ), f"Unexpected render mode {env.render_mode}"
+
+    if reset_exception:
+        with pytest.raises(
+            reset_exception,
+            match=exception_message,
+        ):
+            env.reset()
+        return
+    else:
         env.reset()
 
-        for _ in range(75):
-            _, _, terminated, truncated, _ = env.step(env.action_space.sample())
-            if terminated or truncated:
-                env.reset()
+    assert (
+        env.render_mode == "human"
+    ), "Can't verify actual rendering, verifying render mode"
 
-        env.close()
+    for _ in range(75):
+        _, _, terminated, truncated, _ = env.step(env.action_space.sample())
+        if terminated or truncated:
+            env.reset()
 
-    env = gym.make("CartPole-v1", render_mode="human")
-    with pytest.raises(
-        AssertionError,
-        match=re.escape(
-            "Expected env.render_mode to be one of 'rgb_array' or 'rgb_array_list' but got 'human'"
-        ),
-    ):
-        HumanRendering(env)
     env.close()

--- a/tests/wrappers/vector/test_vector_human_rendering.py
+++ b/tests/wrappers/vector/test_vector_human_rendering.py
@@ -1,0 +1,121 @@
+"""Test suite of vector HumanRendering wrapper."""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+import gymnasium as gym
+from gymnasium.wrappers.vector import HumanRendering
+
+
+@pytest.mark.parametrize(
+    "mode, apply_wrapper, expected_exception, exception_message",
+    [
+        [
+            None,
+            True,
+            {"reset": AssertionError},
+            r"Render mode was not set for CartPoleVectorEnv[^\)]+\), set to acceptable 'rgb_array'",
+        ],
+        ["rgb_array", True, None, None],
+        [
+            "rgb_array_list",  # interpreted as rgb_array
+            True,
+            {"reset": AssertionError},  # There is no vectorized RenderCollection
+            r"Expected render to return a list of \(list of environment\) RGB arrays",
+        ],
+        ["human", False, None, None],
+        [
+            "human",
+            True,
+            {
+                "reset": AssertionError
+            },  # No automatic wrapping for vectorized environments (yet)
+            r"Expected CartPoleVectorEnv[^\)]+\) 'render_mode' to be one of 'rgb_array' or 'rgb_array_list' but got 'human'",
+        ],
+        [
+            "whatever",
+            True,
+            {"reset": AssertionError},
+            r"Expected CartPoleVectorEnv[^\)]+\) 'render_mode' to be one of 'rgb_array' or 'rgb_array_list' but got 'whatever'",
+        ],
+        [
+            {},
+            True,
+            {"reset": AssertionError},
+            r"Render mode was not set for CartPoleVectorEnv[^\)]+\), set to acceptable 'rgb_array'",
+        ],
+    ],
+)
+def test_human_vector_rendering(
+    mode: str,
+    apply_wrapper: bool,
+    expected_exception: dict[str, type[Exception]],
+    exception_message: str,
+):
+    exception_message = "" if exception_message is None else exception_message
+    num_envs = 3
+
+    def expect_exception_in(named):
+        return None if expected_exception is None else expected_exception.get(named)
+
+    make_exception = expect_exception_in("make")
+    wrap_exception = expect_exception_in("wrap")
+    reset_exception = expect_exception_in("reset")
+
+    options = mode if isinstance(mode, dict) else {"render_mode": mode}
+    mode = None if isinstance(mode, dict) else mode  # Mode to expect default if not set
+
+    if make_exception:
+        with pytest.raises(
+            make_exception,
+            match=re.escape(
+                exception_message,
+            ),
+        ):
+            gym.make_vec("CartPole-v1", num_envs=num_envs, vector_kwargs=options)
+        return
+    else:
+        env = gym.make_vec("CartPole-v1", num_envs=num_envs, vector_kwargs=options)
+
+    if apply_wrapper:
+        if wrap_exception:
+            with pytest.raises(
+                wrap_exception,
+                match=re.escape(
+                    exception_message,
+                ),
+            ):
+                env = HumanRendering(env)
+            env.close()
+            return
+        else:
+            env = HumanRendering(env)
+        assert (
+            env.render_mode == "human"
+            if mode in ["rgb_array", "rgb_array_list"]
+            else env.render_mode == mode
+        ), f"Unexpected render mode {env.render_mode}"
+
+    if reset_exception:
+        with pytest.raises(
+            reset_exception,
+            match=exception_message,
+        ):
+            env.reset()
+        env.close()
+        return
+    else:
+        env.reset()
+
+    assert (
+        env.render_mode == "human"
+    ), "Can't verify actual rendering, verifying render mode"
+
+    for _ in range(75):
+        _, _, terminated, truncated, _ = env.step(env.action_space.sample())
+        if terminated.all() or truncated.all():
+            env.reset()
+
+    env.close()


### PR DESCRIPTION
Corrected code to pass tests, and tests to test code! Also corrected some bugs in vectorized Cartpole
Doctest: fixed comments
Documentation was missing for vector.HumanRendering
Relax 'render_mode' further, does not need to be correct until actual rendering starts (i.e. env.reset() is called)

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #872 
Fixes #873 
Related to #233 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Screenshots

| Before | After |
| ------ | ----- |
| N/A |  <img width="450" alt="HumanVectorRender" src="https://github.com/Farama-Foundation/Gymnasium/assets/3210575/0496b0fa-e871-4de1-a090-eb1f07860318"> |

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
