### PR TITLE
Resetting CartPoleVectorEnv step counter in its reset method

### DIFF
--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -473,6 +473,7 @@ class CartPoleVectorEnv(VectorEnv):
             low=self.low, high=self.high, size=(4, self.num_envs)
         ).astype(np.float32)
         self.steps_beyond_terminated = None
+        self.steps = np.zeros(self.num_envs, dtype=np.int32)
 
         if self.render_mode == "human":
             self.render()


### PR DESCRIPTION
# Description

Currently, `CartPoleVectorEnv.reset()` does not reset the step counter (`CartPoleVectorEnv.steps`). I believe this to be a bug. This PR fixes this issue.

Fixes #885 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
