### PR TITLE
Pin pyright version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,6 @@ repos:
         language: node
         pass_filenames: false
         types: [python]
-        additional_dependencies: ["pyright"]
+        additional_dependencies: ["pyright==1.1.347"]
         args:
           - --project=pyproject.toml


### PR DESCRIPTION
The 1.1.348 version of pyright introduced some breaking changes. We might want to update our code to handle that, in the meantime, I'm (hopefully) pinning the version so that it doesn't change like that