### PR TITLE
Made readout of seed possible in env

### DIFF
--- a/docs/api/env.md
+++ b/docs/api/env.md
@@ -54,6 +54,7 @@ title: Env
 
 .. autoproperty:: gymnasium.Env.unwrapped
 .. autoproperty:: gymnasium.Env.np_random
+.. autoproperty:: gymnasium.Env.np_random_seed
 ```
 
 ## Implementing environments

--- a/docs/api/vector.md
+++ b/docs/api/vector.md
@@ -67,6 +67,7 @@ vector/utils
 ```{eval-rst}
 .. autoproperty:: gymnasium.vector.VectorEnv.unwrapped
 .. autoproperty:: gymnasium.vector.VectorEnv.np_random
+.. autoproperty:: gymnasium.vector.VectorEnv.np_random_seed
 ```
 
 ## Making Vector Environments

--- a/docs/api/vector/async_vector_env.md
+++ b/docs/api/vector/async_vector_env.md
@@ -11,3 +11,10 @@
     .. automethod:: gymnasium.vector.AsyncVectorEnv.get_attr
     .. automethod:: gymnasium.vector.AsyncVectorEnv.set_attr
 ```
+
+### Additional Methods
+
+```{eval-rst}
+.. autoproperty:: gymnasium.vector.VectorEnv.np_random
+.. autoproperty:: gymnasium.vector.VectorEnv.np_random_seed
+```

--- a/docs/api/vector/sync_vector_env.md
+++ b/docs/api/vector/sync_vector_env.md
@@ -11,3 +11,10 @@
     .. automethod:: gymnasium.vector.SyncVectorEnv.get_attr
     .. automethod:: gymnasium.vector.SyncVectorEnv.set_attr
 ```
+
+### Additional Methods
+
+```{eval-rst}
+.. autoproperty:: gymnasium.vector.VectorEnv.np_random
+.. autoproperty:: gymnasium.vector.VectorEnv.np_random_seed
+```

--- a/docs/api/wrappers.md
+++ b/docs/api/wrappers.md
@@ -48,5 +48,6 @@ wrappers/vector_wrappers
 .. autoproperty:: gymnasium.Wrapper.spec
 .. autoproperty:: gymnasium.Wrapper.metadata
 .. autoproperty:: gymnasium.Wrapper.np_random
+.. autoproperty:: gymnasium.Wrapper.np_random_seed
 .. autoproperty:: gymnasium.Wrapper.unwrapped
 ```

--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -66,6 +66,7 @@ class Env(Generic[ObsType, ActType]):
 
     # Created
     _np_random: np.random.Generator | None = None
+    _seed: int | None = None
 
     def step(
         self, action: ActType
@@ -148,7 +149,7 @@ class Env(Generic[ObsType, ActType]):
         """
         # Initialize the RNG if the seed is manually passed
         if seed is not None:
-            self._np_random, seed = seeding.np_random(seed)
+            self._np_random, self._seed = seeding.np_random(seed)
 
     def render(self) -> RenderFrame | list[RenderFrame] | None:
         """Compute the render frames as specified by :attr:`render_mode` during the initialization of the environment.
@@ -202,6 +203,11 @@ class Env(Generic[ObsType, ActType]):
         return self
 
     @property
+    def seed(self) -> int | None:
+        """Returns the environment's internal :attr:`_seed` that if not set will initialise with a random seed."""
+        return self._seed
+
+    @property
     def np_random(self) -> np.random.Generator:
         """Returns the environment's internal :attr:`_np_random` that if not set will initialise with a random seed.
 
@@ -209,7 +215,7 @@ class Env(Generic[ObsType, ActType]):
             Instances of `np.random.Generator`
         """
         if self._np_random is None:
-            self._np_random, _ = seeding.np_random()
+            self._np_random, self._seed = seeding.np_random()
         return self._np_random
 
     @np_random.setter

--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Generic, Literal, SupportsFloat, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, SupportsFloat, TypeVar
 
 import numpy as np
 
@@ -66,7 +66,8 @@ class Env(Generic[ObsType, ActType]):
 
     # Created
     _np_random: np.random.Generator | None = None
-    _np_random_seed: int | None | Literal["unknown"] = None
+    # will be set to the "invalid" value -1 if the seed of the currently set rng is unknown
+    _np_random_seed: int | None = None
 
     def step(
         self, action: ActType
@@ -205,11 +206,11 @@ class Env(Generic[ObsType, ActType]):
         return self
 
     @property
-    def np_random_seed(self) -> int | Literal["unknown"]:
+    def np_random_seed(self) -> int:
         """Returns the environment's internal :attr:`_np_random_seed` that if not set will first initialise with a random int as seed.
 
         If :attr:`np_random_seed` was set directly instead of through :meth:`reset` or :meth:`set_np_random_through_seed`,
-        the seed will take the value "unknown".
+        the seed will take the value -1.
         """
         if self._np_random_seed is None:
             self._np_random, self._np_random_seed = seeding.np_random()
@@ -231,10 +232,12 @@ class Env(Generic[ObsType, ActType]):
         """Sets the environment's internal :attr:`_np_random` with the user-provided Generator.
 
         Since it is generally not possible to extract a seed from an instance of a random number generator,
-        this will also set the :attr:`_np_random_seed` to "unknown".
+        this will also set the :attr:`_np_random_seed` to `-1`, which is not valid as input for the creation
+        of a numpy rng.
         """
         self._np_random = value
-        self._np_random_seed = "unknown"
+        # Setting a numpy rng with -1 will cause a ValueError
+        self._np_random_seed = -1
 
     def __str__(self):
         """Returns a string of the environment with :attr:`spec` id's if :attr:`spec.
@@ -252,7 +255,7 @@ class Env(Generic[ObsType, ActType]):
 
         This is the same mechanism for setting these properties as :meth:`reset`. However,
         it is different from setting the np_random property directly, in which case the seed will be set
-        to "unknown", since it is generally not possible to extract a seed from an instance of a
+        to `-1`, since it is generally not possible to extract a seed from an instance of a
         random number generator.
         """
         self._np_random, self._np_random_seed = seeding.np_random(seed)

--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -152,7 +152,7 @@ class Env(Generic[ObsType, ActType]):
         """
         # Initialize the RNG if the seed is manually passed
         if seed is not None:
-            self.set_np_random_through_seed(seed)
+            self._np_random, self._np_random_seed = seeding.np_random(seed)
 
     def render(self) -> RenderFrame | list[RenderFrame] | None:
         """Compute the render frames as specified by :attr:`render_mode` during the initialization of the environment.
@@ -211,6 +211,9 @@ class Env(Generic[ObsType, ActType]):
 
         If :attr:`np_random_seed` was set directly instead of through :meth:`reset` or :meth:`set_np_random_through_seed`,
         the seed will take the value -1.
+
+        Returns:
+            int: the seed of the current `np_random` or -1, if the seed of the rng is unknown
         """
         if self._np_random_seed is None:
             self._np_random, self._np_random_seed = seeding.np_random()
@@ -250,15 +253,6 @@ class Env(Generic[ObsType, ActType]):
         else:
             return f"<{type(self).__name__}<{self.spec.id}>>"
 
-    def set_np_random_through_seed(self, seed: int):
-        """Sets the environment's properties :attr:`np_random` and :attr:`np_random_seed` through a seed.
-
-        This is the same mechanism for setting these properties as :meth:`reset`. However,
-        it is different from setting the np_random property directly, in which case the seed will be set
-        to `-1`, since it is generally not possible to extract a seed from an instance of a
-        random number generator.
-        """
-        self._np_random, self._np_random_seed = seeding.np_random(seed)
 
     def __enter__(self):
         """Support with-statement for the environment."""
@@ -338,7 +332,7 @@ class Wrapper(
 
     @property
     def np_random_seed(self) -> int | None:
-        """Returns the base enviroment's :attr:`seed`."""
+        """Returns the base enviroment's :attr:`np_random_seed`."""
         return self.env.np_random_seed
 
     @property

--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -66,7 +66,7 @@ class Env(Generic[ObsType, ActType]):
 
     # Created
     _np_random: np.random.Generator | None = None
-    _seed: int | None = None
+    _np_random_seed: int | None = None
 
     def step(
         self, action: ActType
@@ -131,10 +131,12 @@ class Env(Generic[ObsType, ActType]):
             The ``return_info`` parameter was removed and now info is expected to be returned.
 
         Args:
-            seed (optional int): The seed that is used to initialize the environment's PRNG (`np_random`).
+            seed (optional int): The seed that is used to initialize the environment's PRNG (`np_random`) and
+                the read-only attribute `np_random_seed`.
                 If the environment does not already have a PRNG and ``seed=None`` (the default option) is passed,
                 a seed will be chosen from some source of entropy (e.g. timestamp or /dev/urandom).
-                However, if the environment already has a PRNG and ``seed=None`` is passed, the PRNG will *not* be reset.
+                However, if the environment already has a PRNG and ``seed=None`` is passed, the PRNG will *not* be reset
+                and the env's :attr:`np_random_seed` will *not* be altered.
                 If you pass an integer, the PRNG will be reset even if it already exists.
                 Usually, you want to pass an integer *right after the environment has been initialized and then never again*.
                 Please refer to the minimal example above to see this paradigm in action.
@@ -149,7 +151,7 @@ class Env(Generic[ObsType, ActType]):
         """
         # Initialize the RNG if the seed is manually passed
         if seed is not None:
-            self._np_random, self._seed = seeding.np_random(seed)
+            self._np_random, self._np_random_seed = seeding.np_random(seed)
 
     def render(self) -> RenderFrame | list[RenderFrame] | None:
         """Compute the render frames as specified by :attr:`render_mode` during the initialization of the environment.
@@ -203,9 +205,9 @@ class Env(Generic[ObsType, ActType]):
         return self
 
     @property
-    def seed(self) -> int | None:
-        """Returns the environment's internal :attr:`_seed` that if not set will initialise with a random seed."""
-        return self._seed
+    def np_random_seed(self) -> int | None:
+        """Returns the environment's internal :attr:`_np_random_seed` that if not set will initialise with a random seed."""
+        return self._np_random_seed
 
     @property
     def np_random(self) -> np.random.Generator:
@@ -215,7 +217,7 @@ class Env(Generic[ObsType, ActType]):
             Instances of `np.random.Generator`
         """
         if self._np_random is None:
-            self._np_random, self._seed = seeding.np_random()
+            self._np_random, self._np_random_seed = seeding.np_random()
         return self._np_random
 
     @np_random.setter
@@ -310,9 +312,9 @@ class Wrapper(
         return self.env.close()
 
     @property
-    def seed(self) -> int | None:
+    def np_random_seed(self) -> int | None:
         """Returns the base enviroment's :attr:`seed`."""
-        return self.env.seed
+        return self.env.np_random_seed
 
     @property
     def unwrapped(self) -> Env[ObsType, ActType]:

--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -310,6 +310,11 @@ class Wrapper(
         return self.env.close()
 
     @property
+    def seed(self) -> int | None:
+        """Returns the base enviroment's :attr:`seed`."""
+        return self.env.seed
+
+    @property
     def unwrapped(self) -> Env[ObsType, ActType]:
         """Returns the base environment of the wrapper.
 

--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -253,7 +253,6 @@ class Env(Generic[ObsType, ActType]):
         else:
             return f"<{type(self).__name__}<{self.spec.id}>>"
 
-
     def __enter__(self):
         """Support with-statement for the environment."""
         return self

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -197,6 +197,17 @@ class AsyncVectorEnv(VectorEnv):
         self._state = AsyncState.DEFAULT
         self._check_spaces()
 
+    @property
+    def np_random_seed(self) -> tuple[int, ...]:
+        """Returns the seeds of the wrapped envs."""
+        return self.get_attr("np_random_seed")
+
+    @property
+    def np_random(self) -> tuple[np.random.Generator, ...]:
+        """Returns the numpy random number generators of the wrapped envs."""
+        return self.get_attr("np_random")
+
+
     def reset(
         self,
         *,
@@ -241,7 +252,7 @@ class AsyncVectorEnv(VectorEnv):
         elif isinstance(seed, int):
             seed = [seed + i for i in range(self.num_envs)]
         assert len(seed) == self.num_envs, \
-            f"If seeds are passed as a list, then the length must match num_envs={self.num_envs} but got length={len(seed)}."
+            f"If seeds are passed as a list the length must match num_envs={self.num_envs} but got length={len(seed)}."
 
         if self._state != AsyncState.DEFAULT:
             raise AlreadyPendingCallError(
@@ -473,7 +484,7 @@ class AsyncVectorEnv(VectorEnv):
 
         return results
 
-    def get_attr(self, name: str):
+    def get_attr(self, name: str) -> tuple[Any, ...]:
         """Get a property from each parallel environment.
 
         Args:

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -240,7 +240,8 @@ class AsyncVectorEnv(VectorEnv):
             seed = [None for _ in range(self.num_envs)]
         elif isinstance(seed, int):
             seed = [seed + i for i in range(self.num_envs)]
-        assert len(seed) == self.num_envs
+        assert len(seed) == self.num_envs, \
+            f"If seeds are passed as a list, then the length must match num_envs={self.num_envs} but got length={len(seed)}."
 
         if self._state != AsyncState.DEFAULT:
             raise AlreadyPendingCallError(

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -207,7 +207,6 @@ class AsyncVectorEnv(VectorEnv):
         """Returns the numpy random number generators of the wrapped envs."""
         return self.get_attr("np_random")
 
-
     def reset(
         self,
         *,
@@ -251,8 +250,9 @@ class AsyncVectorEnv(VectorEnv):
             seed = [None for _ in range(self.num_envs)]
         elif isinstance(seed, int):
             seed = [seed + i for i in range(self.num_envs)]
-        assert len(seed) == self.num_envs, \
-            f"If seeds are passed as a list the length must match num_envs={self.num_envs} but got length={len(seed)}."
+        assert (
+            len(seed) == self.num_envs
+        ), f"If seeds are passed as a list the length must match num_envs={self.num_envs} but got length={len(seed)}."
 
         if self._state != AsyncState.DEFAULT:
             raise AlreadyPendingCallError(

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -100,6 +100,16 @@ class SyncVectorEnv(VectorEnv):
 
         self._autoreset_envs = np.zeros((self.num_envs,), dtype=np.bool_)
 
+    @property
+    def np_random_seed(self) -> tuple[int, ...]:
+        """Returns the seeds of the wrapped envs."""
+        return self.get_attr("np_random_seed")
+
+    @property
+    def np_random(self) -> tuple[np.random.Generator, ...]:
+        """Returns the numpy random number generators of the wrapped envs."""
+        return self.get_attr("np_random")
+
     def reset(
         self,
         *,
@@ -122,7 +132,8 @@ class SyncVectorEnv(VectorEnv):
             seed = [None for _ in range(self.num_envs)]
         elif isinstance(seed, int):
             seed = [seed + i for i in range(self.num_envs)]
-        assert len(seed) == self.num_envs
+        assert len(seed) == self.num_envs, \
+            f"If seeds are passed as a list the length must match num_envs={self.num_envs} but got length={len(seed)}."
 
         self._terminations = np.zeros((self.num_envs,), dtype=np.bool_)
         self._truncations = np.zeros((self.num_envs,), dtype=np.bool_)
@@ -211,7 +222,7 @@ class SyncVectorEnv(VectorEnv):
 
         return tuple(results)
 
-    def get_attr(self, name: str) -> Any:
+    def get_attr(self, name: str) -> tuple[Any, ...]:
         """Get a property from each parallel environment.
 
         Args:

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -132,8 +132,9 @@ class SyncVectorEnv(VectorEnv):
             seed = [None for _ in range(self.num_envs)]
         elif isinstance(seed, int):
             seed = [seed + i for i in range(self.num_envs)]
-        assert len(seed) == self.num_envs, \
-            f"If seeds are passed as a list the length must match num_envs={self.num_envs} but got length={len(seed)}."
+        assert (
+            len(seed) == self.num_envs
+        ), f"If seeds are passed as a list the length must match num_envs={self.num_envs} but got length={len(seed)}."
 
         self._terminations = np.zeros((self.num_envs,), dtype=np.bool_)
         self._truncations = np.zeros((self.num_envs,), dtype=np.bool_)

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -446,6 +446,10 @@ class VectorWrapper(VectorEnv):
         """Returns the `render_mode` from the base environment."""
         return self.env.render_mode
 
+    @np_random.setter
+    def np_random(self, value: np.random.Generator):
+        self.env.np_random = value
+
 
 class VectorObservationWrapper(VectorWrapper):
     """Wraps the vectorized environment to allow a modular transformation of the observation.

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -104,6 +104,7 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
     num_envs: int
 
     _np_random: np.random.Generator | None = None
+    _np_random_seed: int | None = None
 
     def reset(
         self,
@@ -133,7 +134,7 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
             {}
         """
         if seed is not None:
-            self._np_random, seed = seeding.np_random(seed)
+            self._np_random, self._np_random_seed = seeding.np_random(seed)
 
     def step(
         self, actions: ActType
@@ -211,6 +212,20 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
         pass
 
     @property
+    def np_random_seed(self) -> int | None:
+        """Returns the environment's internal :attr:`_np_random_seed` that if not set will first initialise with a random int as seed.
+
+        If :attr:`np_random_seed` was set directly instead of through :meth:`reset` or :meth:`set_np_random_through_seed`,
+        the seed will take the value -1.
+
+        Returns:
+            int: the seed of the current `np_random` or -1, if the seed of the rng is unknown
+        """
+        if self._np_random_seed is None:
+            self._np_random, self._np_random_seed = seeding.np_random()
+        return self._np_random_seed
+
+    @property
     def np_random(self) -> np.random.Generator:
         """Returns the environment's internal :attr:`_np_random` that if not set will initialise with a random seed.
 
@@ -218,7 +233,7 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
             Instances of `np.random.Generator`
         """
         if self._np_random is None:
-            self._np_random, seed = seeding.np_random()
+            self._np_random, self._np_random_seed = seeding.np_random()
         return self._np_random
 
     @np_random.setter

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -239,6 +239,7 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
     @np_random.setter
     def np_random(self, value: np.random.Generator):
         self._np_random = value
+        self._np_random_seed = -1
 
     @property
     def unwrapped(self):

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -109,13 +109,13 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
     def reset(
         self,
         *,
-        seed: int | list[int] | None = None,
+        seed: int | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[ObsType, dict[str, Any]]:  # type: ignore
         """Reset all parallel environments and return a batch of initial observations and info.
 
         Args:
-            seed: The environment reset seeds
+            seed: The environment reset seed
             options: If to return the options
 
         Returns:

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -446,6 +446,15 @@ class VectorWrapper(VectorEnv):
         """Returns the `render_mode` from the base environment."""
         return self.env.render_mode
 
+    @property
+    def np_random(self) -> np.random.Generator:
+        """Returns the environment's internal :attr:`_np_random` that if not set will initialise with a random seed.
+
+        Returns:
+            Instances of `np.random.Generator`
+        """
+        return self.env.np_random
+
     @np_random.setter
     def np_random(self, value: np.random.Generator):
         self.env.np_random = value

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,10 +1,11 @@
 """Checks that the core Gymnasium API is implemented as expected."""
 from __future__ import annotations
 
-import numpy as np
-import pytest
 import re
 from typing import Any, SupportsFloat
+
+import numpy as np
+import pytest
 
 import gymnasium as gym
 from gymnasium import ActionWrapper, Env, ObservationWrapper, RewardWrapper, Wrapper
@@ -249,5 +250,3 @@ class TestRandomSeeding:
         rng, _ = np_random()
         wrapper_env.np_random = rng
         assert wrapper_env.np_random_seed == -1
-
-

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,17 +1,17 @@
 """Checks that the core Gymnasium API is implemented as expected."""
 from __future__ import annotations
 
-import re
-from typing import Any, SupportsFloat
-
 import numpy as np
 import pytest
+import re
+from typing import Any, SupportsFloat
 
 import gymnasium as gym
 from gymnasium import ActionWrapper, Env, ObservationWrapper, RewardWrapper, Wrapper
 from gymnasium.core import ActType, ObsType, WrapperActType, WrapperObsType
 from gymnasium.spaces import Box
 from gymnasium.utils import seeding
+from gymnasium.utils.seeding import np_random
 from gymnasium.wrappers import OrderEnforcing
 from tests.testing_env import GenericTestEnv
 
@@ -37,17 +37,22 @@ class ExampleEnv(Env):
         options: dict | None = None,
     ) -> tuple[ObsType, dict]:
         """Resets the environment."""
+        super().reset(seed=seed, options=options)
         return 0, {}
 
 
-def test_example_env():
-    """Tests a gymnasium environment."""
-    env = ExampleEnv()
+@pytest.fixture
+def example_env():
+    return ExampleEnv()
 
-    assert env.metadata == {"render_modes": []}
-    assert env.render_mode is None
-    assert env.spec is None
-    assert env._np_random is None  # pyright: ignore [reportPrivateUsage]
+
+def test_example_env(example_env):
+    """Tests a gymnasium environment."""
+
+    assert example_env.metadata == {"render_modes": []}
+    assert example_env.render_mode is None
+    assert example_env.spec is None
+    assert example_env._np_random is None  # pyright: ignore [reportPrivateUsage]
 
 
 class ExampleWrapper(Wrapper):
@@ -77,9 +82,9 @@ class ExampleWrapper(Wrapper):
         return self._np_random
 
 
-def test_example_wrapper():
+def test_example_wrapper(example_env):
     """Tests the gymnasium wrapper works as expected."""
-    env = ExampleEnv()
+    env = example_env
     wrapper_env = ExampleWrapper(env)
 
     assert env.metadata == wrapper_env.metadata
@@ -202,3 +207,47 @@ def test_get_set_wrapper_attr():
     with pytest.raises(AttributeError):
         env.unwrapped._disable_render_order_enforcing
     assert env.get_wrapper_attr("_disable_render_order_enforcing") is True
+
+
+class TestRandomSeeding:
+    @staticmethod
+    def test_nonempty_seed_retrieved_when_not_set(example_env):
+        assert example_env.np_random_seed is not None
+        assert isinstance(example_env.np_random_seed, int)
+
+    @staticmethod
+    def test_seed_set_at_reset_and_retrieved(example_env):
+        seed = 42
+        example_env.reset(seed=seed)
+        assert example_env.np_random_seed == seed
+        # resetting with seed=None means seed remains the same
+        example_env.reset(seed=None)
+        assert example_env.np_random_seed == seed
+
+    @staticmethod
+    def test_seed_cannot_be_set_directly(example_env):
+        with pytest.raises(AttributeError):
+            example_env.np_random_seed = 42
+
+    @staticmethod
+    def test_negative_seed_retrieved_when_seed_unknown(example_env):
+        rng, _ = np_random()
+        example_env.np_random = rng
+        # seed is unknown
+        assert example_env.np_random_seed == -1
+
+    @staticmethod
+    def test_seeding_works_in_wrapped_envs(example_env):
+        seed = 42
+        wrapper_env = ExampleWrapper(example_env)
+        wrapper_env.reset(seed=seed)
+        assert wrapper_env.np_random_seed == seed
+        # resetting with seed=None means seed remains the same
+        wrapper_env.reset(seed=None)
+        assert wrapper_env.np_random_seed == seed
+        # setting np_random directly makes seed unknown
+        rng, _ = np_random()
+        wrapper_env.np_random = rng
+        assert wrapper_env.np_random_seed == -1
+
+

--- a/tests/vector/test_vector_env.py
+++ b/tests/vector/test_vector_env.py
@@ -7,6 +7,7 @@ import pytest
 
 from gymnasium.spaces import Discrete
 from gymnasium.utils.env_checker import data_equivalence
+from gymnasium.utils.seeding import np_random
 from gymnasium.vector import AsyncVectorEnv, SyncVectorEnv
 from tests.testing_env import GenericTestEnv
 from tests.vector.testing_utils import make_env
@@ -122,3 +123,35 @@ def test_final_obs_info(vectoriser):
     )
 
     env.close()
+
+
+@pytest.fixture
+def example_env_list():
+    """Example vector environment."""
+    return [make_env("CartPole-v1", i) for i in range(4)]
+
+
+
+@pytest.mark.parametrize(
+    "venv_constructor",
+    [SyncVectorEnv, partial(AsyncVectorEnv, shared_memory=True), partial(AsyncVectorEnv, shared_memory=False)]
+)
+def test_random_seeding_basics(venv_constructor, example_env_list):
+    seed = 42
+    vector_env = venv_constructor(example_env_list)
+    vector_env.reset(seed=seed)
+    assert vector_env.np_random_seed == tuple(seed + i for i in range(vector_env.num_envs))
+    # resetting with seed=None means seed remains the same
+    vector_env.reset(seed=None)
+    assert vector_env.np_random_seed == tuple(seed + i for i in range(vector_env.num_envs))
+
+
+@pytest.mark.parametrize(
+    "venv_constructor",
+    [SyncVectorEnv, partial(AsyncVectorEnv, shared_memory=True), partial(AsyncVectorEnv, shared_memory=False)]
+)
+def test_random_seeds_set_at_retrieval(venv_constructor, example_env_list):
+    vector_env = venv_constructor(example_env_list)
+    assert len(set(vector_env.np_random_seed)) == vector_env.num_envs
+    # default seed starts at zero. Adjust or remove this test if the default seed changes
+    assert vector_env.np_random_seed == tuple(range(vector_env.num_envs))

--- a/tests/vector/test_vector_env.py
+++ b/tests/vector/test_vector_env.py
@@ -131,24 +131,35 @@ def example_env_list():
     return [make_env("CartPole-v1", i) for i in range(4)]
 
 
-
 @pytest.mark.parametrize(
     "venv_constructor",
-    [SyncVectorEnv, partial(AsyncVectorEnv, shared_memory=True), partial(AsyncVectorEnv, shared_memory=False)]
+    [
+        SyncVectorEnv,
+        partial(AsyncVectorEnv, shared_memory=True),
+        partial(AsyncVectorEnv, shared_memory=False),
+    ],
 )
 def test_random_seeding_basics(venv_constructor, example_env_list):
     seed = 42
     vector_env = venv_constructor(example_env_list)
     vector_env.reset(seed=seed)
-    assert vector_env.np_random_seed == tuple(seed + i for i in range(vector_env.num_envs))
+    assert vector_env.np_random_seed == tuple(
+        seed + i for i in range(vector_env.num_envs)
+    )
     # resetting with seed=None means seed remains the same
     vector_env.reset(seed=None)
-    assert vector_env.np_random_seed == tuple(seed + i for i in range(vector_env.num_envs))
+    assert vector_env.np_random_seed == tuple(
+        seed + i for i in range(vector_env.num_envs)
+    )
 
 
 @pytest.mark.parametrize(
     "venv_constructor",
-    [SyncVectorEnv, partial(AsyncVectorEnv, shared_memory=True), partial(AsyncVectorEnv, shared_memory=False)]
+    [
+        SyncVectorEnv,
+        partial(AsyncVectorEnv, shared_memory=True),
+        partial(AsyncVectorEnv, shared_memory=False),
+    ],
 )
 def test_random_seeds_set_at_retrieval(venv_constructor, example_env_list):
     vector_env = venv_constructor(example_env_list)

--- a/tests/vector/test_vector_env.py
+++ b/tests/vector/test_vector_env.py
@@ -7,7 +7,6 @@ import pytest
 
 from gymnasium.spaces import Discrete
 from gymnasium.utils.env_checker import data_equivalence
-from gymnasium.utils.seeding import np_random
 from gymnasium.vector import AsyncVectorEnv, SyncVectorEnv
 from tests.testing_env import GenericTestEnv
 from tests.vector.testing_utils import make_env


### PR DESCRIPTION
# Description

The random seed is fundamentally important for various evaluation protocols. Given the flakyness of RL, one
often wants to evaluate or even train per-seed and then aggregate and present the results with custom logic.

The current design of the environment makes it almost impossible to extract the seed. Numpy's `Generator` object created
by Gymnasium's `np_random` does not expose it, and the seed is not saved anywhere in the env, despite being passed from the user.

This forces users to save seeds somewhere else, which is especially cumbersome when env rollouts are parallelized (which happens all the time).

With this small change we add a hidden attribute `_seed` and a read-only property. It's entirely backwards compatible

Fixes # (issue)

Seed of env can't be read out

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
