### PR TITLE
fix `load_quadruped_model` tutorial not being listed

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -86,6 +86,7 @@ environments/third_party_environments
 :caption: Tutorials
 
 tutorials/**/index
+tutorials/**/*.md
 tutorials/third-party-tutorials
 Comet Tutorial <https://www.comet.com/docs/v2/integrations/ml-frameworks/gymnasium/?utm_source=gymnasium&utm_medium=partner&utm_campaign=partner_gymnasium_2023&utm_content=docs_gymnasium>
 ```


### PR DESCRIPTION
fixes https://github.com/Farama-Foundation/Gymnasium/issues/901

credit: @mgoulao 