### PR TITLE
Rename `RenderObservation` wrapper to `AddRenderObservation`

### DIFF
--- a/docs/api/wrappers/observation_wrappers.md
+++ b/docs/api/wrappers/observation_wrappers.md
@@ -18,7 +18,7 @@
 .. autoclass:: gymnasium.wrappers.GrayscaleObservation
 .. autoclass:: gymnasium.wrappers.MaxAndSkipObservation
 .. autoclass:: gymnasium.wrappers.NormalizeObservation
-.. autoclass:: gymnasium.wrappers.RenderObservation
+.. autoclass:: gymnasium.wrappers.AddRenderObservation
 .. autoclass:: gymnasium.wrappers.ResizeObservation
 .. autoclass:: gymnasium.wrappers.ReshapeObservation
 .. autoclass:: gymnasium.wrappers.RescaleObservation

--- a/docs/api/wrappers/table.md
+++ b/docs/api/wrappers/table.md
@@ -56,7 +56,7 @@ wrapper in the page on the wrapper type
       - Records videos of environment episodes using the environment's render function.
     * - :class:`RenderCollection`
       - Collect rendered frames of an environment such ``render`` returns a ``list[RenderedFrame]``.
-    * - :class:`RenderObservation`
+    * - :class:`AddRenderObservation`
       - Includes the rendered observations in the environment's observations.
     * - :class:`RescaleAction`
       - Affinely (linearly) rescales a ``Box`` action space of the environment to within the range of ``[min_action, max_action]``.

--- a/gymnasium/wrappers/__init__.py
+++ b/gymnasium/wrappers/__init__.py
@@ -73,11 +73,11 @@ from gymnasium.wrappers.transform_action import (
     TransformAction,
 )
 from gymnasium.wrappers.transform_observation import (
+    AddRenderObservation,
     DtypeObservation,
     FilterObservation,
     FlattenObservation,
     GrayscaleObservation,
-    RenderObservation,
     RescaleObservation,
     ReshapeObservation,
     ResizeObservation,
@@ -99,7 +99,7 @@ __all__ = [
     "TransformObservation",
     "MaxAndSkipObservation",
     "NormalizeObservation",
-    "RenderObservation",
+    "AddRenderObservation",
     "ResizeObservation",
     "ReshapeObservation",
     "RescaleObservation",

--- a/gymnasium/wrappers/__init__.py
+++ b/gymnasium/wrappers/__init__.py
@@ -142,7 +142,7 @@ _wrapper_to_class = {
 _renamed_wrapper = {
     "AutoResetWrapper": "Autoreset",
     "FrameStack": "FrameStackObservation",
-    "PixelObservationWrapper": "RenderObservation",
+    "PixelObservationWrapper": "AddRenderObservation",
     "VectorListInfo": "vector.DictInfoToList",
 }
 

--- a/gymnasium/wrappers/transform_observation.py
+++ b/gymnasium/wrappers/transform_observation.py
@@ -31,7 +31,7 @@ __all__ = [
     "ReshapeObservation",
     "RescaleObservation",
     "DtypeObservation",
-    "RenderObservation",
+    "AddRenderObservation",
 ]
 
 
@@ -607,7 +607,7 @@ class DtypeObservation(
         )
 
 
-class RenderObservation(
+class AddRenderObservation(
     TransformObservation[WrapperObsType, ActType, ObsType],
     gym.utils.RecordConstructorArgs,
 ):
@@ -620,7 +620,7 @@ class RenderObservation(
 
     Example - Replace the observation with the rendered image:
         >>> env = gym.make("CartPole-v1", render_mode="rgb_array")
-        >>> env = RenderObservation(env, render_only=True)
+        >>> env = AddRenderObservation(env, render_only=True)
         >>> env.observation_space
         Box(0, 255, (400, 600, 3), uint8)
         >>> obs, _ = env.reset(seed=123)
@@ -634,7 +634,7 @@ class RenderObservation(
 
     Example - Add the rendered image to the original observation as a dictionary item:
         >>> env = gym.make("CartPole-v1", render_mode="rgb_array")
-        >>> env = RenderObservation(env, render_only=False)
+        >>> env = AddRenderObservation(env, render_only=False)
         >>> env.observation_space
         Dict('pixels': Box(0, 255, (400, 600, 3), uint8), 'state': Box([-4.8000002e+00 -3.4028235e+38 -4.1887903e-01 -3.4028235e+38], [4.8000002e+00 3.4028235e+38 4.1887903e-01 3.4028235e+38], (4,), float32))
         >>> obs, info = env.reset(seed=123)
@@ -651,7 +651,7 @@ class RenderObservation(
 
     Change logs:
      * v0.15.0 - Initially added as ``PixelObservationWrapper``
-     * v1.0.0 - Renamed to ``RenderObservation``
+     * v1.0.0 - Renamed to ``AddRenderObservation``
     """
 
     def __init__(
@@ -661,7 +661,7 @@ class RenderObservation(
         render_key: str = "pixels",
         obs_key: str = "state",
     ):
-        """Constructor of the pixel observation wrapper.
+        """Constructor of the add render observation wrapper.
 
         Args:
             env: The environment to wrap.

--- a/tests/wrappers/test_add_render_observation.py
+++ b/tests/wrappers/test_add_render_observation.py
@@ -3,7 +3,7 @@ import numpy as np
 import pytest
 
 from gymnasium import spaces
-from gymnasium.wrappers import RenderObservation
+from gymnasium.wrappers import AddRenderObservation
 from tests.testing_env import GenericTestEnv
 
 
@@ -30,7 +30,7 @@ def test_dict_observation(pixels_only, pixel_key="rgb"):
     # width, height = (320, 240)
 
     # The wrapper should only add one observation.
-    wrapped_env = RenderObservation(
+    wrapped_env = AddRenderObservation(
         env,
         render_key=pixel_key,
         render_only=pixels_only,
@@ -69,7 +69,7 @@ def test_single_array_observation(pixels_only):
     assert isinstance(env.observation_space, spaces.Box)
 
     # The wrapper should only add one observation.
-    wrapped_env = RenderObservation(
+    wrapped_env = AddRenderObservation(
         env,
         render_key=pixel_key,
         render_only=pixels_only,


### PR DESCRIPTION
# Description

`RenderObservation` is an unclear wrapper name, does it mean that the observation is render. 
Therefore, this PR updates the wrapper name to `AddRenderObservation` to make it more clear that the wrapper adds the environment rendering to the environment observation