### PR TITLE
`env_match.check_environments_match` expand error messages

### DIFF
--- a/gymnasium/utils/env_match.py
+++ b/gymnasium/utils/env_match.py
@@ -61,16 +61,22 @@ def check_environments_match(
         obs_a, obs_b
     ), f"resetting observation is not equivalent, observation_a = {obs_a}, observation_b = {obs_b}"
     if info_comparison == "equivalence":
-        assert data_equivalence(info_a, info_b), f"resetting info is not equivalent, info_a = {info_a}, info_b = {info_b}"
+        assert data_equivalence(
+            info_a, info_b
+        ), f"resetting info is not equivalent, info_a = {info_a}, info_b = {info_b}"
     elif info_comparison == "superset":
         for key in info_a:
             assert data_equivalence(
                 info_a[key], info_b[key]
             ), f"resetting info is not a superset, key {key} present in info_a with value = {info_a[key]}, in info_b with value = {info_b[key]}"
     elif info_comparison == "keys-equivalance":
-        assert info_a.keys() == info_b.keys(), f"resetting info keys are not equivalent, info_a's keys are {info_a.keys()}, info_b's keys are {info_b.keys()}"
+        assert (
+            info_a.keys() == info_b.keys()
+        ), f"resetting info keys are not equivalent, info_a's keys are {info_a.keys()}, info_b's keys are {info_b.keys()}"
     elif info_comparison == "keys-superset":
-        assert info_b.keys() >= info_a.keys(), f"resetting info keys are not a superset, keys not present in info_b are: {info_b.keys() - info_a.keys()}"
+        assert (
+            info_b.keys() >= info_a.keys()
+        ), f"resetting info keys are not a superset, keys not present in info_b are: {info_b.keys() - info_a.keys()}"
 
     if not skip_render:
         assert (
@@ -95,7 +101,9 @@ def check_environments_match(
             skip_truncated or truncated_a == truncated_b
         ), f"stepping truncated is not equivalent in step = {step}, truncated_a = {truncated_a}, truncated_b = {truncated_b}"
         if info_comparison == "equivalence":
-            assert data_equivalence(info_a, info_b), f"stepping info is not equivalent in step = {step}, info_a = {info_a}, info_b = {info_b}"
+            assert data_equivalence(
+                info_a, info_b
+            ), f"stepping info is not equivalent in step = {step}, info_a = {info_a}, info_b = {info_b}"
         elif info_comparison == "superset":
             for key in info_a:
                 assert data_equivalence(

--- a/gymnasium/utils/env_match.py
+++ b/gymnasium/utils/env_match.py
@@ -59,18 +59,18 @@ def check_environments_match(
 
     assert skip_obs or data_equivalence(
         obs_a, obs_b
-    ), "resetting observation is not equivalent"
+    ), f"resetting observation is not equivalent, observation_a = {obs_a}, observation_b = {obs_b}"
     if info_comparison == "equivalence":
-        assert data_equivalence(info_a, info_b), "resetting info is not equivalent"
+        assert data_equivalence(info_a, info_b), f"resetting info is not equivalent, info_a = {info_a}, info_b = {info_b}"
     elif info_comparison == "superset":
         for key in info_a:
             assert data_equivalence(
                 info_a[key], info_b[key]
-            ), "resetting info is not a superset"
+            ), f"resetting info is not a superset, key {key} present in info_a with value = {info_a[key]}, in info_b with value = {info_b[key]}"
     elif info_comparison == "keys-equivalance":
-        assert info_a.keys() == info_b.keys(), "resetting info keys are not equivalent"
+        assert info_a.keys() == info_b.keys(), f"resetting info keys are not equivalent, info_a's keys are {info_a.keys()}, info_b's keys are {info_b.keys()}"
     elif info_comparison == "keys-superset":
-        assert info_b.keys() >= info_a.keys(), "resetting info keys are not a superset"
+        assert info_b.keys() >= info_a.keys(), f"resetting info keys are not a superset, keys not present in info_b are: {info_b.keys() - info_a.keys()}"
 
     if not skip_render:
         assert (
@@ -83,60 +83,61 @@ def check_environments_match(
         obs_b, rew_b, terminal_b, truncated_b, info_b = env_b.step(action)
         assert skip_obs or data_equivalence(
             obs_a, obs_b
-        ), "stepping observation is not equivalent"
+        ), f"stepping observation is not equivalent in step = {step}, observation_a = {obs_a}, observation_b = {obs_b}"
+        breakpoint()
         assert skip_rew or data_equivalence(
             rew_a, rew_b
-        ), "stepping reward is not equivalent"
+        ), f"stepping reward is not equivalent in step = {step}, reward_a = {rew_a}, reward_b = {rew_b}"
         assert (
             skip_terminal or terminal_a == terminal_b
-        ), "stepping terminal is not equivalent"
+        ), f"stepping terminal is not equivalent in step = {step}, terminal_a = {terminal_a}, terminal_b = {terminal_b}"
         assert (
             skip_truncated or truncated_a == truncated_b
-        ), "stepping truncated is not equivalent"
+        ), f"stepping truncated is not equivalent in step = {step}, truncated_a = {truncated_a}, truncated_b = {truncated_b}"
         if info_comparison == "equivalence":
-            assert data_equivalence(info_a, info_b), "stepping info is not equivalent"
+            assert data_equivalence(info_a, info_b), f"stepping info is not equivalent in step = {step}, info_a = {info_a}, info_b = {info_b}"
         elif info_comparison == "superset":
             for key in info_a:
                 assert data_equivalence(
                     info_a[key], info_b[key]
-                ), "stepping info is not a superset"
+                ), f"stepping info is not a superset in step = {step}, key {key} present in info_a with value = {info_a[key]}, in info_b with value = {info_b[key]}"
         elif info_comparison == "keys-equivalance":
             assert (
                 info_a.keys() == info_b.keys()
-            ), "stepping info keys are not equivalent"
+            ), f"stepping info keys are not equivalent in step = {step}, info_a's keys are {info_a.keys()}, info_b's keys are {info_b.keys()}"
         elif info_comparison == "keys-superset":
             assert (
                 info_b.keys() >= info_a.keys()
-            ), "stepping info keys are not a superset"
+            ), f"stepping info keys are not a superset in step = {step}, keys not present in info_b are: {info_b.keys() - info_a.keys()}"
         if not skip_render:
             assert (
                 env_a.render() == env_b.render()
-            ).all(), "stepping render is not equivalent"
+            ).all(), "stepping render is not equivalent in step = {step}"
 
         if terminal_a or truncated_a or terminal_b or truncated_b:
             obs_a, info_a = env_a.reset(seed=seed)
             obs_b, info_b = env_b.reset(seed=seed)
             assert skip_obs or data_equivalence(
                 obs_a, obs_b
-            ), "resetting observation is not equivalent"
+            ), f"resetting observation is not equivalent in step = {step}, observation_a = {obs_a}, observation_b = {obs_b}"
             if info_comparison == "equivalence":
                 assert data_equivalence(
                     info_a, info_b
-                ), "resetting info is not equivalent"
+                ), f"resetting info is not equivalent in step = {step}, info_a = {info_a}, info_b = {info_b}"
             elif info_comparison == "superset":
                 for key in info_a:
                     assert data_equivalence(
                         info_a[key], info_b[key]
-                    ), "resetting info is not a superset"
+                    ), f"resetting info is not a superset in step = {step}, key {key} present in info_a with value = {info_a[key]}, in info_b with value = {info_b[key]}"
             elif info_comparison == "keys-equivalance":
                 assert (
                     info_a.keys() == info_b.keys()
-                ), "resetting info keys are not equivalent"
+                ), f"resetting info keys are not equivalent in step = {step}, info_a's keys are {info_a.keys()}, info_b's keys are {info_b.keys()}"
             elif info_comparison == "keys-superset":
                 assert (
                     info_b.keys() >= info_a.keys()
-                ), "resetting info keys are not a superset"
+                ), f"resetting info keys are not a superset in step = {step}, keys not present in info_b are: {info_b.keys() - info_a.keys()}"
             if not skip_render:
                 assert (
                     env_a.render() == env_b.render()
-                ).all(), "resetting render is not equivalent"
+                ).all(), "resetting render is not equivalent in step = {step}"

--- a/gymnasium/utils/env_match.py
+++ b/gymnasium/utils/env_match.py
@@ -90,7 +90,6 @@ def check_environments_match(
         assert skip_obs or data_equivalence(
             obs_a, obs_b
         ), f"stepping observation is not equivalent in step = {step}, observation_a = {obs_a}, observation_b = {obs_b}"
-        breakpoint()
         assert skip_rew or data_equivalence(
             rew_a, rew_b
         ), f"stepping reward is not equivalent in step = {step}, reward_a = {rew_a}, reward_b = {rew_b}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
 mujoco-py = ["mujoco-py >=2.1,<2.2", "cython<3"]
 mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]       # kept for backward compatibility
-mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1"]
+mujoco = ["mujoco >=2.1.5, <= 3.1.1", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]         # kept for backward compatibility
 jax = ["jax >=0.4.0", "jaxlib >=0.4.0", "flax >= 0.5.0"]
@@ -67,7 +67,7 @@ all = [
     "mujoco-py >=2.1,<2.2",
     "cython<3",
     # mujoco
-    "mujoco >=2.1.5",
+    "mujoco >=2.1.5, <=3.1.1",
     "imageio >=2.14.1",
     # toy-text
     "pygame >=2.1.3",


### PR DESCRIPTION
# Description

makes `check_environments_match` assert fail messages more verbose

## Type of change
- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
