### PR TITLE
Fix "tendon_lenght" to "tenon_length" for Humanoid-v5 info key

### DIFF
--- a/gymnasium/envs/mujoco/humanoid_v5.py
+++ b/gymnasium/envs/mujoco/humanoid_v5.py
@@ -404,7 +404,7 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
             "qfrc_actuator": (self.data.qvel.size - 6)
             * include_qfrc_actuator_in_observation,
             "cfrc_ext": self.data.cfrc_ext[1:].size * include_cfrc_ext_in_observation,
-            "ten_lenght": 0,
+            "ten_length": 0,
             "ten_velocity": 0,
         }
 
@@ -481,7 +481,7 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
         info = {
             "x_position": self.data.qpos[0],
             "y_position": self.data.qpos[1],
-            "tendon_lenght": self.data.ten_length,
+            "tendon_length": self.data.ten_length,
             "tendon_velocity": self.data.ten_velocity,
             "distance_from_origin": np.linalg.norm(self.data.qpos[0:2], ord=2),
             "x_velocity": x_velocity,
@@ -533,7 +533,7 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
         return {
             "x_position": self.data.qpos[0],
             "y_position": self.data.qpos[1],
-            "tendon_lenght": self.data.ten_length,
+            "tendon_length": self.data.ten_length,
             "tendon_velocity": self.data.ten_velocity,
             "distance_from_origin": np.linalg.norm(self.data.qpos[0:2], ord=2),
         }

--- a/gymnasium/envs/mujoco/humanoidstandup_v5.py
+++ b/gymnasium/envs/mujoco/humanoidstandup_v5.py
@@ -382,7 +382,7 @@ class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
             "qfrc_actuator": (self.data.qvel.size - 6)
             * include_qfrc_actuator_in_observation,
             "cfrc_ext": self.data.cfrc_ext[1:].size * include_cfrc_ext_in_observation,
-            "ten_lenght": 0,
+            "ten_length": 0,
             "ten_velocity": 0,
         }
 
@@ -431,7 +431,7 @@ class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
             "x_position": self.data.qpos[0],
             "y_position": self.data.qpos[1],
             "z_distance_from_origin": self.data.qpos[2] - self.init_qpos[2],
-            "tendon_lenght": self.data.ten_length,
+            "tendon_length": self.data.ten_length,
             "tendon_velocity": self.data.ten_velocity,
             **reward_info,
         }
@@ -482,6 +482,6 @@ class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
             "x_position": self.data.qpos[0],
             "y_position": self.data.qpos[1],
             "z_distance_from_origin": self.data.qpos[2] - self.init_qpos[2],
-            "tendon_lenght": self.data.ten_length,
+            "tendon_length": self.data.ten_length,
             "tendon_velocity": self.data.ten_velocity,
         }


### PR DESCRIPTION
# Description

Fix spelling for Humanoid-v5 and HumanoidStandup-v5 info key