### PR TITLE
add `exact` argument to `utlis.env_checker.data_equivilance`

### DIFF
--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -54,7 +54,9 @@ def data_equivalence(data_1, data_2, exact: bool = False) -> bool:
     elif isinstance(data_1, np.ndarray):
         if data_1.shape == data_2.shape and data_1.dtype == data_2.dtype:
             if data_1.dtype == object:
-                return all(data_equivalence(a, b, exact) for a, b in zip(data_1, data_2))
+                return all(
+                    data_equivalence(a, b, exact) for a, b in zip(data_1, data_2)
+                )
             else:
                 if exact:
                     return np.all(data_1 == data_2)

--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -30,37 +30,40 @@ from gymnasium.utils.passive_env_checker import (
 )
 
 
-def data_equivalence(data_1, data_2) -> bool:
+def data_equivalence(data_1, data_2, exact: bool = False) -> bool:
     """Assert equality between data 1 and 2, i.e observations, actions, info.
 
     Args:
         data_1: data structure 1
         data_2: data structure 2
+        exact: whether to compare array exactly or not if false compares with absolute and realive torrelance of 1e-5 (for more information check [np.allclose](https://numpy.org/doc/stable/reference/generated/numpy.allclose.html)).
 
     Returns:
         If observation 1 and 2 are equivalent
     """
-    if type(data_1) is type(data_2):
-        if isinstance(data_1, dict):
-            return data_1.keys() == data_2.keys() and all(
-                data_equivalence(data_1[k], data_2[k]) for k in data_1.keys()
-            )
-        elif isinstance(data_1, (tuple, list)):
-            return len(data_1) == len(data_2) and all(
-                data_equivalence(o_1, o_2) for o_1, o_2 in zip(data_1, data_2)
-            )
-        elif isinstance(data_1, np.ndarray):
-            if data_1.shape == data_2.shape and data_1.dtype == data_2.dtype:
-                if data_1.dtype == object:
-                    return all(data_equivalence(a, b) for a, b in zip(data_1, data_2))
-                else:
-                    return np.allclose(data_1, data_2, atol=0.00001)
-            else:
-                return False
-        else:
-            return data_1 == data_2
-    else:
+    if type(data_1) is not type(data_2):
         return False
+    if isinstance(data_1, dict):
+        return data_1.keys() == data_2.keys() and all(
+            data_equivalence(data_1[k], data_2[k], exact) for k in data_1.keys()
+        )
+    elif isinstance(data_1, (tuple, list)):
+        return len(data_1) == len(data_2) and all(
+            data_equivalence(o_1, o_2, exact) for o_1, o_2 in zip(data_1, data_2)
+        )
+    elif isinstance(data_1, np.ndarray):
+        if data_1.shape == data_2.shape and data_1.dtype == data_2.dtype:
+            if data_1.dtype == object:
+                return all(data_equivalence(a, b, exact) for a, b in zip(data_1, data_2))
+            else:
+                if exact:
+                    return np.all(data_1 == data_2)
+                else:
+                    return np.allclose(data_1, data_2, rtol=1e-5, atol=1e-5)
+        else:
+            return False
+    else:
+        return data_1 == data_2
 
 
 def check_reset_seed(env: gym.Env):


### PR DESCRIPTION
# Description
Adds an `exact` argument to `utlis.env_checker.data_equivilance` function, which when set to `True` it uses equality comparison of arrays instead of [np.allclose](https://numpy.org/doc/stable/reference/generated/numpy.allclose.html),

testing: this change was manually tested

Note: 
- default behavior does not change,
- We already have a function that has the `exact=True` behavior in `Gymnasium-Robotics`, which can be removed later
https://github.com/Farama-Foundation/Gymnasium-Robotics/blob/main/tests/utils.py#L12-L34


## Type of change
- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
