### PR TITLE
mark `mujoco-py` environments as explicity deprecated

### DIFF
--- a/docs/environments/mujoco.md
+++ b/docs/environments/mujoco.md
@@ -79,8 +79,8 @@ Gymnasium includes the following versions of the environments:
 | ------- | --------------- | ------------------------------------------------ |
 | `v5`    | `mujoco=>2.3.3` | Recommended (most features, the least bugs)      |
 | `v4`    | `mujoco=>2.1.3` | Maintained for reproducibility                   |
-| `v3`    | `mujoco-py`     | Maintained for reproducibility (limited support) |
-| `v2`    | `mujoco-py`     | Maintained for reproducibility (limited support) |
+| `v3`    | `mujoco-py`     | Deprecated, Kept for reproducibility (limited support) |
+| `v2`    | `mujoco-py`     | Deprecated, Kept for reproducibility (limited support) |
 
 For more information, see the section "Version History" for each environment.
 

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -220,10 +220,10 @@ class MuJocoPyEnv(BaseMujocoEnv):
             )
 
         logger.deprecation(
-            "This version of the mujoco environments depends "
-            "on the mujoco-py bindings, which are no longer maintained "
+            "This version of the mujoco environments is deprecated and depends "
+            "on the old mujoco-py bindings, which are no longer maintained "
             "and may stop working. Please upgrade to the v5 or v4 versions of "
-            "the environments (which depend on the mujoco python bindings instead), unless "
+            "the environments (which depend on the new mujoco python bindings instead), unless "
             "you are trying to precisely replicate previous works)."
         )
 


### PR DESCRIPTION
# Description
This PR simply changes the documentation to explicitly state that `mujoco-py` are deprecated

since this [issue](https://github.com/Farama-Foundation/Gymnasium/issues/921), it is clear that the inclusion of the old MuJoCo environments causes issues to user who do not interact with it

I am not sure about when, the removal of `mujoco-py` environments will happen, probably after 1.0, maybe with the release of `py313`?

Fixes # (issue)

## Type of change
- [X] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update