### PR TITLE
Add `check_mujoco_reset_state`

### DIFF
--- a/gymnasium/envs/mujoco/utils.py
+++ b/gymnasium/envs/mujoco/utils.py
@@ -7,11 +7,10 @@ import mujoco
 import numpy as np
 
 import gymnasium
-from gymnasium.envs.mujoco import MujocoEnv
 
 
 def get_state(
-    env: MujocoEnv,
+    env: gymnasium.envs.mujoco.MujocoEnv,
     state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_PHYSICS,
 ):
     """Gets the state of `env`.
@@ -23,12 +22,12 @@ def get_state(
     assert mujoco.__version__ >= "2.3.6", "Feature requires `mujuco>=2.3.6`"
 
     state = np.empty(mujoco.mj_stateSize(env.unwrapped.model, state_type))
-    mujoco.mj_getState(env.unwrapped.model, env.unwrapped.data, state_type)
+    mujoco.mj_getState(env.unwrapped.model, env.unwrapped.data, state, state_type)
     return state
 
 
 def set_state(
-    env: MujocoEnv,
+    env: gymnasium.envs.mujoco.MujocoEnv,
     state: np.ndarray,
     state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_PHYSICS,
 ):
@@ -50,7 +49,7 @@ def set_state(
     return state
 
 
-def check_mujoco_reset_state(env: MujocoEnv, seed=1234):
+def check_mujoco_reset_state(env: gymnasium.envs.mujoco.MujocoEnv, seed=1234):
     """Asserts that `env.reset` properly resets the state (not affected by previous steps), assuming `check_reset_seed` has passed."""
     env.action_space.seed(seed)
     action = env.action_space.sample()

--- a/gymnasium/envs/mujoco/utils.py
+++ b/gymnasium/envs/mujoco/utils.py
@@ -10,7 +10,7 @@ import gymnasium
 
 
 def get_state(
-    env: gymnasium.MujocoEnv,
+    env: gymnasium.envs.mujoco.MujocoEnv,
     state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_PHYSICS,
 ):
     """Gets the state of `env`.
@@ -27,7 +27,7 @@ def get_state(
 
 
 def set_state(
-    env: gymnasium.MujocoEnv,
+    env: gymnasium.envs.mujoco.MujocoEnv,
     state: np.ndarray,
     state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_PHYSICS,
 ):
@@ -49,7 +49,7 @@ def set_state(
     return state
 
 
-def check_mujoco_reset_state(env: gymnasium.mujocoEnv, seed=1234):
+def check_mujoco_reset_state(env: gymnasium.envs.mujoco.mujocoEnv, seed=1234):
     """Asserts that `env.reset` properly resets the state (not affected by previous steps), assuming `check_reset_seed` has passed."""
     env.action_space.seed(seed)
     action = env.action_space.sample()

--- a/gymnasium/envs/mujoco/utils.py
+++ b/gymnasium/envs/mujoco/utils.py
@@ -10,7 +10,7 @@ import gymnasium
 
 
 def get_state(
-    env: gymnasium.envs.mujoco.MujocoEnv,
+    env: gymnasium.envs.mujoco.mujoco_env.MujocoEnv,
     state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_PHYSICS,
 ):
     """Gets the state of `env`.
@@ -27,7 +27,7 @@ def get_state(
 
 
 def set_state(
-    env: gymnasium.envs.mujoco.MujocoEnv,
+    env: gymnasium.envs.mujoco.mujoco_env.MujocoEnv,
     state: np.ndarray,
     state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_PHYSICS,
 ):
@@ -49,7 +49,7 @@ def set_state(
     return state
 
 
-def check_mujoco_reset_state(env: gymnasium.envs.mujoco.mujocoEnv, seed=1234):
+def check_mujoco_reset_state(env: gymnasium.envs.mujoco.mujoco_env.mujocoEnv, seed=1234):
     """Asserts that `env.reset` properly resets the state (not affected by previous steps), assuming `check_reset_seed` has passed."""
     env.action_space.seed(seed)
     action = env.action_space.sample()

--- a/gymnasium/envs/mujoco/utils.py
+++ b/gymnasium/envs/mujoco/utils.py
@@ -55,10 +55,10 @@ def check_mujoco_reset_state(env: gymnasium.envs.mujoco.MujocoEnv, seed=1234):
     action = env.action_space.sample()
 
     env.reset(seed=seed)
-    first_reset_state = get_state(env, mujoco.mjtState.mjSTATE_PHYSICS)
+    first_reset_state = get_state(env, mujoco.mjtState.mjSTATE_INTEGRATION)
     env.step(action)
 
     env.reset(seed=seed)
-    second_reset_state = get_state(env, mujoco.mjtState.mjSTATE_PHYSICS)
+    second_reset_state = get_state(env, mujoco.mjtState.mjSTATE_INTEGRATION)
 
     assert np.all(first_reset_state == second_reset_state), "reset is not deterministic"

--- a/gymnasium/envs/mujoco/utils.py
+++ b/gymnasium/envs/mujoco/utils.py
@@ -1,11 +1,13 @@
-"""A set of MujocoEnv related utilies, mainly for testing purposes.
+"""A set of MujocoEnv related utilities, mainly for testing purposes.
 
 Author: @Kallinteris-Andreas
 """
 
 import mujoco
 import numpy as np
+
 import gymnasium
+
 
 def get_state(
     env: gymnasium.MujocoEnv,
@@ -60,4 +62,3 @@ def check_mujoco_reset_state(env: gymnasium.mujocoEnv, seed=1234):
     second_reset_state = get_state(env, mujoco.mjtState.mjSTATE_PHYSICS)
 
     assert np.all(first_reset_state == second_reset_state), "reset is not deterministic"
-  

--- a/gymnasium/envs/mujoco/utils.py
+++ b/gymnasium/envs/mujoco/utils.py
@@ -1,0 +1,63 @@
+"""A set of MujocoEnv related utilies, mainly for testing purposes.
+
+Author: @Kallinteris-Andreas
+"""
+
+import mujoco
+import numpy as np
+import gymnasium
+
+def get_state(
+    env: gymnasium.MujocoEnv,
+    state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_PHYSICS,
+):
+    """Gets the state of `env`.
+
+    Arguments:
+        env: Environment whose state to copy, `env.model` & `env.data` must be accessible.
+        state_type: see the [documentation of mjtState](https://mujoco.readthedocs.io/en/stable/APIreference/APItypes.html#mjtstate) most users can use the default for training purposes or `mujoco.mjtState.mjSTATE_INTEGRATION` for validation purposes.
+    """
+    assert mujoco.__version__ >= "2.3.6", "Feature requires `mujuco>=2.3.6`"
+
+    state = np.empty(mujoco.mj_stateSize(env.unwrapped.model, state_type))
+    mujoco.mj_getState(env.unwrapped.model, env.unwrapped.data, state_type)
+    return state
+
+
+def set_state(
+    env: gymnasium.MujocoEnv,
+    state: np.ndarray,
+    state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_PHYSICS,
+):
+    """Set the state of `env`.
+
+    Arguments:
+        env: Environment whose state to set, `env.model` & `env.data` must be accessible.
+        state: State to set (generated from get_state).
+        state_type: see the [documentation of mjtState](https://mujoco.readthedocs.io/en/stable/APIreference/APItypes.html#mjtstate) most users can use the default for training purposes or `mujoco.mjtState.mjSTATE_INTEGRATION` for validation purposes.
+    """
+    assert mujoco.__version__ >= "2.3.6", "Feature requires `mujuco>=2.3.6`"
+
+    mujoco.mj_setState(
+        env.unwrapped.model,
+        env.unwrapped.data,
+        state,
+        spec=mujoco.mjtState.mjSTATE_PHYSICS,
+    )
+    return state
+
+
+def check_mujoco_reset_state(env: gymnasium.mujocoEnv, seed=1234):
+    """Asserts that `env.reset` properly resets the state (not affected by previous steps), assuming `check_reset_seed` has passed."""
+    env.action_space.seed(seed)
+    action = env.action_space.sample()
+
+    env.reset(seed=seed)
+    first_reset_state = get_state(env, mujoco.mjtState.mjSTATE_PHYSICS)
+    env.step(action)
+
+    env.reset(seed=seed)
+    second_reset_state = get_state(env, mujoco.mjtState.mjSTATE_PHYSICS)
+
+    assert np.all(first_reset_state == second_reset_state), "reset is not deterministic"
+  

--- a/gymnasium/envs/mujoco/utils.py
+++ b/gymnasium/envs/mujoco/utils.py
@@ -7,10 +7,11 @@ import mujoco
 import numpy as np
 
 import gymnasium
+from gymnasium.envs.mujoco import MujocoEnv
 
 
 def get_state(
-    env: gymnasium.envs.mujoco.mujoco_env.MujocoEnv,
+    env: MujocoEnv,
     state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_PHYSICS,
 ):
     """Gets the state of `env`.
@@ -27,7 +28,7 @@ def get_state(
 
 
 def set_state(
-    env: gymnasium.envs.mujoco.mujoco_env.MujocoEnv,
+    env: MujocoEnv,
     state: np.ndarray,
     state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_PHYSICS,
 ):
@@ -49,7 +50,7 @@ def set_state(
     return state
 
 
-def check_mujoco_reset_state(env: gymnasium.envs.mujoco.mujoco_env.mujocoEnv, seed=1234):
+def check_mujoco_reset_state(env: MujocoEnv, seed=1234):
     """Asserts that `env.reset` properly resets the state (not affected by previous steps), assuming `check_reset_seed` has passed."""
     env.action_space.seed(seed)
     action = env.action_space.sample()

--- a/tests/envs/mujoco/test_mujoco_v5.py
+++ b/tests/envs/mujoco/test_mujoco_v5.py
@@ -7,11 +7,10 @@ import pytest
 
 import gymnasium as gym
 from gymnasium.envs.mujoco.mujoco_env import BaseMujocoEnv, MujocoEnv
+from gymnasium.envs.mujoco.utils import check_mujoco_reset_state
 from gymnasium.error import Error
 from gymnasium.utils.env_checker import check_env
 from gymnasium.utils.env_match import check_environments_match
-
-from gymnasium.envs.mujoco.utils import check_mujoco_reset_state
 
 
 ALL_MUJOCO_ENVS = [
@@ -706,5 +705,5 @@ def test_reset_noise_scale(env_id):
 @pytest.mark.parametrize("version", ["v5", "v4"])
 def test_reset_state(env_name, version):
     """Asserst that `reset()` properly resets the internal state."""
-    env = gymnasium.make(f"{env_name}-{version}")
+    env = gym.make(f"{env_name}-{version}")
     check_mujoco_reset_state(env)

--- a/tests/envs/mujoco/test_mujoco_v5.py
+++ b/tests/envs/mujoco/test_mujoco_v5.py
@@ -11,6 +11,8 @@ from gymnasium.error import Error
 from gymnasium.utils.env_checker import check_env
 from gymnasium.utils.env_match import check_environments_match
 
+from gymnasium.envs.mujoco.utils import check_mujoco_reset_state
+
 
 ALL_MUJOCO_ENVS = [
     "Ant",
@@ -698,3 +700,11 @@ def test_reset_noise_scale(env_id):
 
     assert np.all(env.data.qpos == env.init_qpos)
     assert np.all(env.data.qvel == env.init_qvel)
+
+
+@pytest.mark.parametrize("env_name", ALL_MUJOCO_ENVS)
+@pytest.mark.parametrize("version", ["v5", "v4"])
+def test_reset_state(env_name, version):
+    """Asserst that `reset()` properly resets the internal state."""
+    env = gymnasium.make(f"{env_name}-{version}")
+    check_mujoco_reset_state(env)

--- a/tests/envs/mujoco/test_mujoco_v5.py
+++ b/tests/envs/mujoco/test_mujoco_v5.py
@@ -703,7 +703,7 @@ def test_reset_noise_scale(env_id):
 
 @pytest.mark.parametrize("env_name", ALL_MUJOCO_ENVS)
 @pytest.mark.parametrize("version", ["v5", "v4"])
-def test_reset_state(env_name, version):
+def test_reset_state(env_name: str, version: str):
     """Asserst that `reset()` properly resets the internal state."""
     env = gym.make(f"{env_name}-{version}")
     check_mujoco_reset_state(env)

--- a/tests/envs/mujoco/test_mujoco_v5.py
+++ b/tests/envs/mujoco/test_mujoco_v5.py
@@ -704,6 +704,6 @@ def test_reset_noise_scale(env_id):
 @pytest.mark.parametrize("env_name", ALL_MUJOCO_ENVS)
 @pytest.mark.parametrize("version", ["v5", "v4"])
 def test_reset_state(env_name: str, version: str):
-    """Asserst that `reset()` properly resets the internal state."""
+    """Asserts that `reset()` properly resets the internal state."""
     env = gym.make(f"{env_name}-{version}")
     check_mujoco_reset_state(env)


### PR DESCRIPTION
# Description
This was added mainly to address `Gymnasium-Robotics`'s https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/207 https://github.com/Farama-Foundation/Gymnasium-Robotics/pull/208, but it can also be used here and in `metaworld`?

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


