### PR TITLE
fix(docs): typo in `core.py`

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -1,5 +1,4 @@
 """Core API for Environment, Wrapper, ActionWrapper, RewardWrapper and ObservationWrapper."""
-
 from __future__ import annotations
 
 from copy import deepcopy

--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -90,7 +90,7 @@ class Env(Generic[ObsType, ActType]):
             reward (SupportsFloat): The reward as a result of taking the action.
             terminated (bool): Whether the agent reaches the terminal state (as defined under the MDP of the task)
                 which can be positive or negative. An example is reaching the goal state or moving into the lava from
-                the Sutton and Barton, Gridworld. If true, the user needs to call :meth:`reset`.
+                the Sutton and Barto, Gridworld. If true, the user needs to call :meth:`reset`.
             truncated (bool): Whether the truncation condition outside the scope of the MDP is satisfied.
                 Typically, this is a timelimit, but could also be used to indicate an agent physically going out of bounds.
                 Can be used to end the episode prematurely before a terminal state is reached.

--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -1,4 +1,5 @@
 """Core API for Environment, Wrapper, ActionWrapper, RewardWrapper and ObservationWrapper."""
+
 from __future__ import annotations
 
 from copy import deepcopy
@@ -90,7 +91,7 @@ class Env(Generic[ObsType, ActType]):
             reward (SupportsFloat): The reward as a result of taking the action.
             terminated (bool): Whether the agent reaches the terminal state (as defined under the MDP of the task)
                 which can be positive or negative. An example is reaching the goal state or moving into the lava from
-                the Sutton and Barto, Gridworld. If true, the user needs to call :meth:`reset`.
+                the Sutton and Barto Gridworld. If true, the user needs to call :meth:`reset`.
             truncated (bool): Whether the truncation condition outside the scope of the MDP is satisfied.
                 Typically, this is a timelimit, but could also be used to indicate an agent physically going out of bounds.
                 Can be used to end the episode prematurely before a terminal state is reached.


### PR DESCRIPTION
# Description

Fixes a very small typo ("Barton," -> "Barto").

## Type of change

- [x] Documentation only change (no code changed)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
