### PR TITLE
Fix `Multidiscrete.from_jsonable` for windows

### DIFF
--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -172,7 +172,7 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
         self, sample_n: list[Sequence[int]]
     ) -> list[NDArray[np.integer[Any]]]:
         """Convert a JSONable data type to a batch of samples from this space."""
-        return [np.array(sample) for sample in sample_n]
+        return [np.array(sample, dtype=np.int64) for sample in sample_n]
 
     def __repr__(self):
         """Gives a string representation of this space."""


### PR DESCRIPTION
# Description

An upstreamed fix for `Multidiscrete.from_jsonable` for the windows os found through the conda gymnasium v0.29.1 (https://github.com/conda-forge/gymnasium-feedstock/pull/32)
