### PR TITLE
Fix docs toctree link (fixes #930)

### DIFF
--- a/docs/api/spaces.md
+++ b/docs/api/spaces.md
@@ -9,7 +9,6 @@ title: Spaces
 spaces/fundamental
 spaces/composite
 spaces/utils
-vector/utils
 ```
 
 ```{eval-rst}


### PR DESCRIPTION
# Description

A type in the toctree makes the spaces utils link to the vector utils

Fixes #930 

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
