### PR TITLE
CartPole: fix vector rendering (#872)

### DIFF
--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -519,7 +519,7 @@ class CartPoleVectorEnv(VectorEnv):
                     for _ in range(self.num_envs)
                 ]
         if self.clocks is None:
-            self.clock = [pygame.time.Clock() for _ in range(self.num_envs)]
+            self.clocks = [pygame.time.Clock() for _ in range(self.num_envs)]
 
         world_width = self.x_threshold * 2
         scale = self.screen_width / world_width
@@ -531,9 +531,9 @@ class CartPoleVectorEnv(VectorEnv):
         if self.state is None:
             return None
 
-        for state, screen, clock in zip(self.state, self.screens, self.clocks):
-            x = self.state.T
-
+        for state, screen, clock, x in zip(
+            self.state, self.screens, self.clocks, self.state.T
+        ):
             self.surf = pygame.Surface((self.screen_width, self.screen_height))
             self.surf.fill((255, 255, 255))
 


### PR DESCRIPTION
Also corrected some bugs in vectorized Cartpole

# Description

This fixes some, probably breaking, issues in Chartpole
1) Testing if clocks is not set, created clock if not, resulting in a new clock array created every turn.
2) Looping over states but assigned x with full all states

Fixes # (872)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
Tests redesigned, will arrive in HumanRenderer for Vector environments
