### PR TITLE
Fix reading shared memory for `Tuple` and `Dict` spaces

### DIFF
--- a/gymnasium/vector/utils/shared_memory.py
+++ b/gymnasium/vector/utils/shared_memory.py
@@ -148,19 +148,24 @@ def _read_base_from_shared_memory(
 
 @read_from_shared_memory.register(Tuple)
 def _read_tuple_from_shared_memory(space: Tuple, shared_memory, n: int = 1):
-    return tuple(
+    subspace_samples = tuple(
         read_from_shared_memory(subspace, memory, n=n)
         for (memory, subspace) in zip(shared_memory, space.spaces)
     )
+    return tuple(zip(*subspace_samples))
 
 
 @read_from_shared_memory.register(Dict)
 def _read_dict_from_shared_memory(space: Dict, shared_memory, n: int = 1):
-    return OrderedDict(
+    subspace_samples = OrderedDict(
         [
             (key, read_from_shared_memory(subspace, shared_memory[key], n=n))
             for (key, subspace) in space.spaces.items()
         ]
+    )
+    return tuple(
+        OrderedDict({key: subspace_samples[key][i] for key in space.keys()})
+        for i in range(n)
     )
 
 

--- a/tests/vector/utils/test_shared_memory.py
+++ b/tests/vector/utils/test_shared_memory.py
@@ -22,7 +22,7 @@ from tests.spaces.utils import TESTING_SPACES, TESTING_SPACES_IDS
     "ctx", [None, "fork", "spawn"], ids=["default", "fork", "spawn"]
 )
 def test_shared_memory_create_read_write(space, num, ctx):
-    """Test the shared memory functions, create, read and write for all of the testing spaces."""
+    """Test the shared memory functions, create, read and write for all testing spaces."""
     if ctx not in mp.get_all_start_methods():
         pytest.skip(
             f"Multiprocessing start method {ctx} not available on this platform."
@@ -41,7 +41,7 @@ def test_shared_memory_create_read_write(space, num, ctx):
 
     read_samples = read_from_shared_memory(space, shared_memory, n=num)
     for read_sample, sample in zip(read_samples, samples):
-        data_equivalence(read_sample, sample)
+        assert data_equivalence(read_sample, sample)
 
 
 def test_custom_space():


### PR DESCRIPTION
# Description

Soooo shared memory with `Tuple` or `Dict` spaces has been broken since the original implementation (5 years old).
We didn't catch this as the expected tests should be `assert data_equivalence(read_samples, samples)` and were actually just `data_equivalence(...)`. (yes I have checked and can't find anymore instances of this bug in testing)

As a result, the returned samples were roundtripped are
```python
space = Tuple((Discrete(3), Discrete(4)))

num = 2
samples = (space.sample() for _ in range(num))  # ((2, 0), (2, 3))
shared_memory = create_shared_memory(space, n=num, ctx=mp)

for i, sample in enumerate(samples):
    write_to_shared_memory(space, i, sample, shared_memory)

read_samples = read_from_shared_memory(space, shared_memory, n=num)  # ((2, 2), (0, 3))
```

This PR fixes the bug