### PR TITLE
Fix `make_vec(**kwargs)` not being passed to vector entry point envs

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -915,6 +915,15 @@ def make_vec(
         )
 
     elif vectorization_mode == VectorizeMode.VECTOR_ENTRY_POINT:
+        if len(vector_kwargs) > 0:
+            raise error.Error(
+                f"Custom vector environment can be passed arguments only through kwargs and `vector_kwargs` is not empty ({vector_kwargs})"
+            )
+        if len(wrappers) > 0:
+            raise error.Error(
+                "Cannot use `vector_entry_point` vectorization mode with the wrappers argument."
+            )
+
         entry_point = env_spec.vector_entry_point
         if entry_point is None:
             raise error.Error(
@@ -925,15 +934,13 @@ def make_vec(
         else:  # Assume it's a string
             env_creator = load_env_creator(entry_point)
 
-        if len(wrappers) > 0:
-            raise error.Error(
-                "Cannot use `vector_entry_point` vectorization mode with the wrappers argument."
-            )
-        if "max_episode_steps" not in vector_kwargs:
-            assert vector_kwargs is not None
-            vector_kwargs["max_episode_steps"] = env_spec.max_episode_steps
+        if (
+            env_spec.max_episode_steps is not None
+            and "max_episode_steps" not in env_spec_kwargs
+        ):
+            env_spec_kwargs["max_episode_steps"] = env_spec.max_episode_steps
 
-        env = env_creator(num_envs=num_envs, **vector_kwargs)
+        env = env_creator(num_envs=num_envs, **env_spec_kwargs)
     else:
         raise error.Error(f"Unknown vectorization mode: {vectorization_mode}")
 

--- a/tests/envs/registration/test_make_vec.py
+++ b/tests/envs/registration/test_make_vec.py
@@ -114,6 +114,22 @@ def test_make_vec_vectorization_mode():
         gym.make_vec("CartPole-v1", vectorization_mode=123)
 
 
+def test_make_vec_render_mode():
+    envs = gym.make_vec(
+        "CartPole-v1", vectorization_mode=VectorizeMode.VECTOR_ENTRY_POINT
+    )
+    assert envs.render_mode is None
+    envs.close()
+
+    envs = gym.make_vec(
+        "CartPole-v1",
+        render_mode="rgb_array",
+        vectorization_mode=VectorizeMode.VECTOR_ENTRY_POINT,
+    )
+    assert envs.render_mode == "rgb_array"
+    envs.close()
+
+
 def test_make_vec_wrappers():
     """Tests that the `gym.make_vec` wrappers parameter works."""
     env = gym.make_vec("CartPole-v1", num_envs=2, vectorization_mode="sync")


### PR DESCRIPTION
# Description

Previously, the `render_mode` passed to vector entry point environments wouldn't work 
```python
envs = gym.make_vec("CartPole-v1", render_mode="rgb_array")
print(envs.render_mode)  # None
```

Therefore, this PR fixes this through disabling `vector_kwargs` for vector entry point environment requiring users to pass parameters with kwargs as is natural with `make` 

