### PR TITLE
`env_checker` to use exact data_equivilance

### DIFF
--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -99,7 +99,7 @@ def check_reset_seed_determinism(env: gym.Env):
             ), "The observation returned by `env.reset(seed=123)` is not within the observation space."
             if env.spec is not None and env.spec.nondeterministic is False:
                 assert data_equivalence(
-                    obs_1, obs_2
+                    obs_1, obs_2, exact=True
                 ), "Using `env.reset(seed=123)` is non-deterministic as the observations are not equivalent."
             assert (
                 env.unwrapped._np_random.bit_generator.state
@@ -189,13 +189,13 @@ def check_step_determinism(env: gym.Env, seed=123):
         env.unwrapped._np_random.bit_generator.state  # pyright: ignore [reportOptionalMemberAccess]
         == seeded_rng.bit_generator.state
     ), "The `.np_random` is not properly been updated after step."
-    assert data_equivalence(obs_0, obs_1), "step observation is not deterministic."
-    assert data_equivalence(rew_0, rew_1), "step reward is not deterministic."
-    assert data_equivalence(term_0, term_0), "step terminal is not deterministic."
+    assert data_equivalence(obs_0, obs_1, True), "step observation is not deterministic."
+    assert data_equivalence(rew_0, rew_1, True), "step reward is not deterministic."
+    assert data_equivalence(term_0, term_0, True), "step terminal is not deterministic."
     assert (
         trunc_0 is False and trunc_1 is False
     ), "Environment truncates after 1 step, something has gone very wrong."
-    assert data_equivalence(info_0, info_1), "step info is not deterministic."
+    assert data_equivalence(info_0, info_1, True), "step info is not deterministic."
 
 
 def check_reset_return_info_deprecation(env: gym.Env):

--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -189,15 +189,26 @@ def check_step_determinism(env: gym.Env, seed=123):
         env.unwrapped._np_random.bit_generator.state  # pyright: ignore [reportOptionalMemberAccess]
         == seeded_rng.bit_generator.state
     ), "The `.np_random` is not properly been updated after step."
-    assert data_equivalence(
-        obs_0, obs_1, True
-    ), "step observation is not deterministic."
-    assert data_equivalence(rew_0, rew_1, True), "step reward is not deterministic."
+
+    if not data_equivalence(obs_0, obs_1, exact=True):
+        logger.warn("step observation is not deterministic.")
+    assert data_equivalence(obs_0, obs_1), "step observation is not deterministic."
+
+    if not data_equivalence(rew_0, rew_1, exact=True):
+        logger.warn("step reward is not deterministic.")
+    assert data_equivalence(rew_0, rew_1), "step reward is not deterministic."
+
     assert data_equivalence(term_0, term_0, True), "step terminal is not deterministic."
     assert (
         trunc_0 is False and trunc_1 is False
     ), "Environment truncates after 1 step, something has gone very wrong."
-    assert data_equivalence(info_0, info_1, True), "step info is not deterministic."
+
+    if not data_equivalence(info_0, info_1, exact=True):
+        logger.warn("step info is not deterministic.")
+    assert data_equivalence(
+        info_0,
+        info_1,
+    ), "step info is not deterministic."
 
 
 def check_reset_return_info_deprecation(env: gym.Env):

--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -101,10 +101,11 @@ def check_reset_seed_determinism(env: gym.Env):
                 assert data_equivalence(
                     obs_1, obs_2
                 ), "Using `env.reset(seed=123)` is non-deterministic as the observations are not equivalent."
-                if data_equivalence(obs_1, obs_2, exact=True):
+                if not data_equivalence(obs_1, obs_2, exact=True):
                     logger.warn(
-                        "Using `env.reset(seed=123)` is non-deterministic as the observations are not equal."
+                        "Using `env.reset(seed=123)` observations are not equal although similar."
                     )
+
             assert (
                 env.unwrapped._np_random.bit_generator.state
                 == seed_123_rng.bit_generator.state
@@ -169,11 +170,11 @@ def check_reset_options(env: gym.Env):
 def check_step_determinism(env: gym.Env, seed=123):
     """Check that the environment steps deterministically after reset.
 
-    Note: This check assumes that seeded `reset()` is derministic (it must have passed `check_reset_seed`) and that `step()` returns valid values (passed `env_step_passive_checker`).
+    Note: This check assumes that seeded `reset()` is deterministic (it must have passed `check_reset_seed`) and that `step()` returns valid values (passed `env_step_passive_checker`).
     Note: A single step should be enough to assert that the state transition function is deterministic (at least for most environments).
 
     Raises:
-        AssertionError: The environment cannot be step determistially after resetting with a random seed,
+        AssertionError: The environment cannot be step deterministically after resetting with a random seed,
             or it truncates after 1 step.
     """
     if env.spec is not None and env.spec.nondeterministic is True:
@@ -194,31 +195,37 @@ def check_step_determinism(env: gym.Env, seed=123):
         == seeded_rng.bit_generator.state
     ), "The `.np_random` is not properly been updated after step."
 
-    if not data_equivalence(obs_0, obs_1, exact=True):
-        logger.warn("step observation is not deterministic (not equal).")
     assert data_equivalence(
         obs_0, obs_1
-    ), "step observation is not deterministic (not close)."
+    ), "Deterministic step observations are not equivalent for the same seed and action"
+    if not data_equivalence(obs_0, obs_1, exact=True):
+        logger.warn(
+            "Step observations are not equal although similar given the same seed and action"
+        )
 
-    if not data_equivalence(rew_0, rew_1, exact=True):
-        logger.warn("step reward is not deterministic (not equal).")
     assert data_equivalence(
         rew_0, rew_1
-    ), "step reward is not deterministic (not close)."
+    ), "Deterministic step rewards are not equivalent for the same seed and action"
+    if not data_equivalence(rew_0, rew_1, exact=True):
+        logger.warn(
+            "Step rewards are not equal although similar given the same seed and action"
+        )
 
     assert data_equivalence(
         term_0, term_0, exact=True
-    ), "step terminal is not deterministic."
+    ), "Deterministic step termination are not equivalent for the same seed and action"
     assert (
         trunc_0 is False and trunc_1 is False
     ), "Environment truncates after 1 step, something has gone very wrong."
 
-    if not data_equivalence(info_0, info_1, exact=True):
-        logger.warn("step info is not deterministic (not equal).")
     assert data_equivalence(
         info_0,
         info_1,
-    ), "step info is not deterministic (not close)."
+    ), "Deterministic step info are not equivalent for the same seed and action"
+    if not data_equivalence(info_0, info_1, exact=True):
+        logger.warn(
+            "Step info are not equal although similar given the same seed and action"
+        )
 
 
 def check_reset_return_info_deprecation(env: gym.Env):

--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -99,8 +99,12 @@ def check_reset_seed_determinism(env: gym.Env):
             ), "The observation returned by `env.reset(seed=123)` is not within the observation space."
             if env.spec is not None and env.spec.nondeterministic is False:
                 assert data_equivalence(
-                    obs_1, obs_2, exact=True
+                    obs_1, obs_2
                 ), "Using `env.reset(seed=123)` is non-deterministic as the observations are not equivalent."
+                if data_equivalence(obs_1, obs_2, exact=True):
+                    logger.warn(
+                        "Using `env.reset(seed=123)` is non-deterministic as the observations are not equal."
+                    )
             assert (
                 env.unwrapped._np_random.bit_generator.state
                 == seed_123_rng.bit_generator.state
@@ -191,24 +195,30 @@ def check_step_determinism(env: gym.Env, seed=123):
     ), "The `.np_random` is not properly been updated after step."
 
     if not data_equivalence(obs_0, obs_1, exact=True):
-        logger.warn("step observation is not deterministic.")
-    assert data_equivalence(obs_0, obs_1), "step observation is not deterministic."
+        logger.warn("step observation is not deterministic (not equal).")
+    assert data_equivalence(
+        obs_0, obs_1
+    ), "step observation is not deterministic (not close)."
 
     if not data_equivalence(rew_0, rew_1, exact=True):
-        logger.warn("step reward is not deterministic.")
-    assert data_equivalence(rew_0, rew_1), "step reward is not deterministic."
+        logger.warn("step reward is not deterministic (not equal).")
+    assert data_equivalence(
+        rew_0, rew_1
+    ), "step reward is not deterministic (not close)."
 
-    assert data_equivalence(term_0, term_0, True), "step terminal is not deterministic."
+    assert data_equivalence(
+        term_0, term_0, exact=True
+    ), "step terminal is not deterministic."
     assert (
         trunc_0 is False and trunc_1 is False
     ), "Environment truncates after 1 step, something has gone very wrong."
 
     if not data_equivalence(info_0, info_1, exact=True):
-        logger.warn("step info is not deterministic.")
+        logger.warn("step info is not deterministic (not equal).")
     assert data_equivalence(
         info_0,
         info_1,
-    ), "step info is not deterministic."
+    ), "step info is not deterministic (not close)."
 
 
 def check_reset_return_info_deprecation(env: gym.Env):

--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -189,7 +189,9 @@ def check_step_determinism(env: gym.Env, seed=123):
         env.unwrapped._np_random.bit_generator.state  # pyright: ignore [reportOptionalMemberAccess]
         == seeded_rng.bit_generator.state
     ), "The `.np_random` is not properly been updated after step."
-    assert data_equivalence(obs_0, obs_1, True), "step observation is not deterministic."
+    assert data_equivalence(
+        obs_0, obs_1, True
+    ), "step observation is not deterministic."
     assert data_equivalence(rew_0, rew_1, True), "step reward is not deterministic."
     assert data_equivalence(term_0, term_0, True), "step terminal is not deterministic."
     assert (

--- a/tests/utils/test_env_checker.py
+++ b/tests/utils/test_env_checker.py
@@ -246,17 +246,17 @@ def test_check_reset_options():
         [
             AssertionError,
             lambda self, action: (np.random.normal(), 0, False, False, {}),
-            "step observation is not deterministic.",
+            "Deterministic step observations are not equivalent for the same seed and action",
         ],
         [
             AssertionError,
             lambda self, action: (0, np.random.normal(), False, False, {}),
-            "step reward is not deterministic.",
+            "Deterministic step rewards are not equivalent for the same seed and action",
         ],
         [
             AssertionError,
             lambda self, action: (0, 0, False, False, {"value": np.random.normal()}),
-            "step info is not deterministic.",
+            "Deterministic step info are not equivalent for the same seed and action",
         ],
     ],
 )


### PR DESCRIPTION
# Description

fixes https://github.com/Farama-Foundation/Gymnasium/issues/927
## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
