### PR TITLE
Fix tutorials written in MD not showing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,6 +130,7 @@ sphinx_gallery_conf = {
     "ignore_pattern": r"__init__\.py",
     "examples_dirs": "./tutorials",
     "gallery_dirs": "./tutorials",
+    "copyfile_regex": r"./tutorials/.*\.md",
     "show_signature": False,
     "show_memory": False,
     "min_reported_time": float("inf"),

--- a/docs/tutorials/gymnasium_basics/README.rst
+++ b/docs/tutorials/gymnasium_basics/README.rst
@@ -1,2 +1,7 @@
 Gymnasium Basics
 ----------------
+
+.. toctree::
+   :hidden:
+
+   /tutorials/gymnasium_basics/load_quadruped_model.md


### PR DESCRIPTION
# Description

Fixes `load_quadruped_model` tutorial not being listed. #902

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
