### PR TITLE
Add more helpful error messages if users use a mixture of Gym and Gymnasium

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -754,6 +754,21 @@ def make(
                 f"{e} was raised from the environment creator for {env_spec.id} with kwargs ({env_spec_kwargs})"
             )
 
+    if not isinstance(env, gym.Env):
+        if (
+            str(env.__class__.__base__) == "<class 'gym.core.Env'>"
+            or str(env.__class__.__base__) == "<class 'gym.core.Wrapper'>"
+        ):
+            raise TypeError(
+                "Gym is incompatible with Gymnasium, please update the environment class to `gymnasium.Env`. "
+                "See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
+            )
+        else:
+            raise TypeError(
+                f"The environment must inherit from the gymnasium.Env class, actual class: {type(env)}. "
+                "See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
+            )
+
     # Set the minimal env spec for the environment.
     env.unwrapped.spec = EnvSpec(
         id=env_spec.id,

--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -305,15 +305,17 @@ def check_env(
         )
 
     # ============= Check the spaces (observation and action) ================
-    assert hasattr(
-        env, "action_space"
-    ), "The environment must specify an action space. See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
+    if not hasattr(env, "action_space"):
+        raise AttributeError(
+            "The environment must specify an action space. See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
+        )
     check_action_space(env.action_space)
     check_space_limit(env.action_space, "action")
 
-    assert hasattr(
-        env, "observation_space"
-    ), "The environment must specify an observation space. See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
+    if not hasattr(env, "observation_space"):
+        raise AttributeError(
+            "The environment must specify an observation space. See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
+        )
     check_observation_space(env.observation_space)
     check_space_limit(env.observation_space, "observation")
 

--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -285,10 +285,20 @@ def check_env(
     if warn is not None:
         logger.warn("`check_env(warn=...)` parameter is now ignored.")
 
-    assert isinstance(
-        env, gym.Env
-    ), "The environment must inherit from the gymnasium.Env class. See https://gymnasium.farama.org/tutorials/gymnasium_basics/environment_creation/ for more info."
-
+    if not isinstance(env, gym.Env):
+        if (
+            str(env.__class__.__base__) == "<class 'gym.core.Env'>"
+            or str(env.__class__.__base__) == "<class 'gym.core.Wrapper'>"
+        ):
+            raise TypeError(
+                "Gym is incompatible with Gymnasium, please update the environment class to `gymnasium.Env`. "
+                "See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
+            )
+        else:
+            raise TypeError(
+                f"The environment must inherit from the gymnasium.Env class, actual class: {type(env)}. "
+                "See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
+            )
     if env.unwrapped is not env:
         logger.warn(
             f"The environment ({env}) is different from the unwrapped version ({env.unwrapped}). This could effect the environment checker as the environment most likely has a wrapper applied to it. We recommend using the raw environment for `check_env` using `env.unwrapped`."
@@ -297,13 +307,13 @@ def check_env(
     # ============= Check the spaces (observation and action) ================
     assert hasattr(
         env, "action_space"
-    ), "The environment must specify an action space. See https://gymnasium.farama.org/tutorials/gymnasium_basics/environment_creation/ for more info."
+    ), "The environment must specify an action space. See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
     check_action_space(env.action_space)
     check_space_limit(env.action_space, "action")
 
     assert hasattr(
         env, "observation_space"
-    ), "The environment must specify an observation space. See https://gymnasium.farama.org/tutorials/gymnasium_basics/environment_creation/ for more info."
+    ), "The environment must specify an observation space. See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
     check_observation_space(env.observation_space)
     check_space_limit(env.observation_space, "observation")
 
@@ -331,7 +341,7 @@ def check_env(
                 new_env.close()
         else:
             logger.warn(
-                "Not able to test alternative render modes due to the environment not having a spec. Try instantialising the environment through gymnasium.make"
+                "Not able to test alternative render modes due to the environment not having a spec. Try instantiating the environment through `gymnasium.make`"
             )
 
     if not skip_close_check and env.spec is not None:

--- a/gymnasium/utils/passive_env_checker.py
+++ b/gymnasium/utils/passive_env_checker.py
@@ -67,9 +67,14 @@ def check_space(
 ):
     """A passive check of the environment action space that should not affect the environment."""
     if not isinstance(space, spaces.Space):
-        raise AssertionError(
-            f"{space_type} space does not inherit from `gymnasium.spaces.Space`, actual type: {type(space)}"
-        )
+        if str(space.__class__.__base__) == "<class 'gym.spaces.space.Space'>":
+            raise TypeError(
+                f"Gym is incompatible with Gymnasium, please update the environment {space_type}_space to `{str(space.__class__.__base__).replace('gym', 'gymnasium')}`."
+            )
+        else:
+            raise TypeError(
+                f"{space_type} space does not inherit from `gymnasium.spaces.Space`, actual type: {type(space)}"
+            )
 
     elif isinstance(space, spaces.Box):
         check_box_space_fn(space)

--- a/gymnasium/wrappers/common.py
+++ b/gymnasium/wrappers/common.py
@@ -254,13 +254,25 @@ class PassiveEnvChecker(
         gym.utils.RecordConstructorArgs.__init__(self)
         gym.Wrapper.__init__(self, env)
 
+        if not isinstance(env, gym.Env):
+            if str(env.__class__.__base__) == "<class 'gym.core.Env'>":
+                raise TypeError(
+                    "Gym is incompatible with Gymnasium, please update the environment class to `gymnasium.Env`. "
+                    "See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
+                )
+            else:
+                raise TypeError(
+                    f"The environment must inherit from the gymnasium.Env class, actual class: {type(env)}. "
+                    "See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
+                )
+
         assert hasattr(
             env, "action_space"
-        ), "The environment must specify an action space. https://gymnasium.farama.org/tutorials/gymnasium_basics/environment_creation/"
+        ), "The environment must specify an action space. https://gymnasium.farama.org/introduction/create_custom_env/"
         check_action_space(env.action_space)
         assert hasattr(
             env, "observation_space"
-        ), "The environment must specify an observation space. https://gymnasium.farama.org/tutorials/gymnasium_basics/environment_creation/"
+        ), "The environment must specify an observation space. https://gymnasium.farama.org/introduction/create_custom_env/"
         check_observation_space(env.observation_space)
 
         self.checked_reset: bool = False

--- a/gymnasium/wrappers/common.py
+++ b/gymnasium/wrappers/common.py
@@ -266,13 +266,16 @@ class PassiveEnvChecker(
                     "See https://gymnasium.farama.org/introduction/create_custom_env/ for more info."
                 )
 
-        assert hasattr(
-            env, "action_space"
-        ), "The environment must specify an action space. https://gymnasium.farama.org/introduction/create_custom_env/"
+        if not hasattr(env, "action_space"):
+            raise AttributeError(
+                "The environment must specify an action space. https://gymnasium.farama.org/introduction/create_custom_env/"
+            )
         check_action_space(env.action_space)
-        assert hasattr(
-            env, "observation_space"
-        ), "The environment must specify an observation space. https://gymnasium.farama.org/introduction/create_custom_env/"
+
+        if not hasattr(env, "observation_space"):
+            raise AttributeError(
+                "The environment must specify an observation space. https://gymnasium.farama.org/introduction/create_custom_env/"
+            )
         check_observation_space(env.observation_space)
 
         self.checked_reset: bool = False

--- a/tests/utils/test_env_checker.py
+++ b/tests/utils/test_env_checker.py
@@ -240,23 +240,26 @@ def test_check_reset_options():
 
 
 @pytest.mark.parametrize(
-    "env,message",
+    "env, error_type, message",
     [
         [
             "Error",
-            "The environment must inherit from the gymnasium.Env class. See https://gymnasium.farama.org/tutorials/gymnasium_basics/environment_creation/ for more info.",
+            TypeError,
+            "The environment must inherit from the gymnasium.Env class, actual class: <class 'str'>. See https://gymnasium.farama.org/introduction/create_custom_env/ for more info.",
         ],
         [
             GenericTestEnv(action_space=None),
-            "The environment must specify an action space. See https://gymnasium.farama.org/tutorials/gymnasium_basics/environment_creation/ for more info.",
+            AttributeError,
+            "The environment must specify an action space. See https://gymnasium.farama.org/introduction/create_custom_env/ for more info.",
         ],
         [
             GenericTestEnv(observation_space=None),
-            "The environment must specify an observation space. See https://gymnasium.farama.org/tutorials/gymnasium_basics/environment_creation/ for more info.",
+            AttributeError,
+            "The environment must specify an observation space. See https://gymnasium.farama.org/introduction/create_custom_env/ for more info.",
         ],
     ],
 )
-def test_check_env(env: gym.Env, message: str):
+def test_check_env(env: gym.Env, error_type, message: str):
     """Tests the check_env function works as expected."""
-    with pytest.raises(AssertionError, match=f"^{re.escape(message)}$"):
+    with pytest.raises(error_type, match=f"^{re.escape(message)}$"):
         check_env(env)

--- a/tests/utils/test_env_checker_with_gym.py
+++ b/tests/utils/test_env_checker_with_gym.py
@@ -1,0 +1,111 @@
+import re
+
+import pytest
+
+import gymnasium
+from gymnasium.utils.env_checker import check_env
+
+
+gym = pytest.importorskip("gym")
+
+
+class NoClassEnv:
+    def __init__(self):
+        self.action_space = gym.spaces.Discrete(2)
+        self.observation_space = gym.spaces.Discrete(2)
+
+
+class IncorrectEnv(gym.Env):
+    def __init__(self):
+        self.action_space = gym.spaces.Discrete(2)
+        self.observation_space = gym.spaces.Discrete(2)
+
+
+class IncorrectAction(gymnasium.Env):
+    def __init__(self):
+        self.action_space = gym.spaces.Discrete(2)
+        self.observation_space = gymnasium.spaces.Discrete(2)
+
+
+class IncorrectObs(gymnasium.Env):
+    def __init__(self):
+        self.action_space = gymnasium.spaces.Discrete(2)
+        self.observation_space = gym.spaces.Discrete(2)
+
+
+def test_check_env_with_gym():
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "The environment must inherit from the gymnasium.Env class, actual class: <class"
+        ),
+    ):
+        check_env(NoClassEnv())
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Gym is incompatible with Gymnasium, please update the environment class to `gymnasium.Env`."
+        ),
+    ):
+        check_env(IncorrectEnv())
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Gym is incompatible with Gymnasium, please update the environment observation_space to `<class 'gymnasium.spaces.space.Space'>`."
+        ),
+    ):
+        check_env(IncorrectObs())
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Gym is incompatible with Gymnasium, please update the environment action_space to `<class 'gymnasium.spaces.space.Space'>`."
+        ),
+    ):
+        check_env(IncorrectAction())
+
+
+def test_passive_env_checker_with_gym():
+    gymnasium.register("NoClassEnv", NoClassEnv)
+    gymnasium.register("IncorrectEnv", IncorrectEnv)
+    gymnasium.register("IncorrectObs", IncorrectObs)
+    gymnasium.register("IncorrectAction", IncorrectAction)
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "The environment must inherit from the gymnasium.Env class, actual class: <class"
+        ),
+    ):
+        gymnasium.make("NoClassEnv")
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Gym is incompatible with Gymnasium, please update the environment class to `gymnasium.Env`."
+        ),
+    ):
+        gymnasium.make("IncorrectEnv")
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Gym is incompatible with Gymnasium, please update the environment observation_space to `<class 'gymnasium.spaces.space.Space'>`."
+        ),
+    ):
+        gymnasium.make("IncorrectObs")
+
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "Gym is incompatible with Gymnasium, please update the environment action_space to `<class 'gymnasium.spaces.space.Space'>`."
+        ),
+    ):
+        gymnasium.make("IncorrectAction")
+
+    gymnasium.registry.pop("NoClassEnv")
+    gymnasium.registry.pop("IncorrectEnv")
+    gymnasium.registry.pop("IncorrectObs")
+    gymnasium.registry.pop("IncorrectAction")

--- a/tests/utils/test_passive_env_checker.py
+++ b/tests/utils/test_passive_env_checker.py
@@ -27,7 +27,7 @@ def _modify_space(space: spaces.Space, attribute: str, value):
     "test,space,message",
     [
         [
-            AssertionError,
+            TypeError,
             "error",
             "observation space does not inherit from `gymnasium.spaces.Space`, actual type: <class 'str'>",
         ],
@@ -98,7 +98,7 @@ def test_check_observation_space(test, space, message: str):
     "test,space,message",
     [
         [
-            AssertionError,
+            TypeError,
             "error",
             "action space does not inherit from `gymnasium.spaces.Space`, actual type: <class 'str'>",
         ],

--- a/tests/wrappers/test_passive_env_checker.py
+++ b/tests/wrappers/test_passive_env_checker.py
@@ -33,28 +33,32 @@ def test_passive_checker_wrapper_warnings(env):
 
 
 @pytest.mark.parametrize(
-    "env, message",
+    "env, error_type, message",
     [
         (
             GenericTestEnv(action_space=None),
-            "The environment must specify an action space. https://gymnasium.farama.org/tutorials/gymnasium_basics/environment_creation/",
+            AttributeError,
+            "The environment must specify an action space. https://gymnasium.farama.org/introduction/create_custom_env/",
         ),
         (
             GenericTestEnv(action_space="error"),
+            TypeError,
             "action space does not inherit from `gymnasium.spaces.Space`, actual type: <class 'str'>",
         ),
         (
             GenericTestEnv(observation_space=None),
-            "The environment must specify an observation space. https://gymnasium.farama.org/tutorials/gymnasium_basics/environment_creation/",
+            AttributeError,
+            "The environment must specify an observation space. https://gymnasium.farama.org/introduction/create_custom_env/",
         ),
         (
             GenericTestEnv(observation_space="error"),
+            TypeError,
             "observation space does not inherit from `gymnasium.spaces.Space`, actual type: <class 'str'>",
         ),
     ],
 )
-def test_initialise_failures(env, message):
-    with pytest.raises(AssertionError, match=f"^{re.escape(message)}$"):
+def test_initialise_failures(env, error_type, message):
+    with pytest.raises(error_type, match=f"^{re.escape(message)}$"):
         PassiveEnvChecker(env)
 
     env.close()


### PR DESCRIPTION
# Description

I have found several users using a mixture of Gym and gymnasium, I believe due to thinking that 
```python
import gymnasium as gym 
from gym.utils import play
```
will causes the second statement to use gymnasium not gym mistakenly. 

This PR adds more helpful error checking for `check_env`, `make` and the passive environment checker that runs in the background on `make`. 
Tests are included but will be turned off by default as the CI doesn't install gym so `pytest.importorskip` is used if users include `gym` locally
