### PR TITLE
`MujocoEnv` refactor remove single line function `_reset_simulation()`

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -120,12 +120,6 @@ class BaseMujocoEnv(gym.Env[NDArray[np.float64], NDArray[np.float32]]):
         """
         raise NotImplementedError
 
-    def _reset_simulation(self) -> None:
-        """
-        Reset MuJoCo simulation data structures, mjModel and mjData.
-        """
-        raise NotImplementedError
-
     def _step_mujoco_simulation(self, ctrl, n_frames) -> None:
         """
         Step over the MuJoCo simulation.
@@ -151,7 +145,7 @@ class BaseMujocoEnv(gym.Env[NDArray[np.float64], NDArray[np.float32]]):
     ):
         super().reset(seed=seed)
 
-        self._reset_simulation()
+        mujoco.mj_resetData(self.model, self.data)
 
         ob = self.reset_model()
         info = self._get_reset_info()
@@ -243,9 +237,6 @@ class MujocoEnv(BaseMujocoEnv):
         model.vis.global_.offheight = self.height
         data = mujoco.MjData(model)
         return model, data
-
-    def _reset_simulation(self):
-        mujoco.mj_resetData(self.model, self.data)
 
     def set_state(self, qpos, qvel):
         super().set_state(qpos, qvel)


### PR DESCRIPTION
# Description
removes the `_reset_simulation()` to clean up the `MujocoEnv` code

Note: `_reset_simulation()` is not being changed in Robotics or Meta, so it should be an issue 

Validation: the `test/envs/mujoco` is enough


## Type of change
- [Refactor]
- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

