### PR TITLE
Fix pusher-v2 entry-point

### DIFF
--- a/gymnasium/envs/__init__.py
+++ b/gymnasium/envs/__init__.py
@@ -197,7 +197,7 @@ register(
 
 register(
     id="Pusher-v2",
-    entry_point="gymnasium.envs.mujoco.pucher:PusherEnv",
+    entry_point="gymnasium.envs.mujoco.pusher:PusherEnv",
     max_episode_steps=100,
     reward_threshold=0.0,
 )


### PR DESCRIPTION
# Description

pusher-v2 entry-point was `pucher` not `pusher` meaning that it was not being tested. 
Found through reading the pytest logs