### PR TITLE
Raise error for `pusher-v4` environment when `mujoco>=3`

### DIFF
--- a/gymnasium/envs/mujoco/pusher_v4.py
+++ b/gymnasium/envs/mujoco/pusher_v4.py
@@ -1,3 +1,4 @@
+import mujoco
 import numpy as np
 
 from gymnasium import utils
@@ -22,7 +23,9 @@ class PusherEnv(MujocoEnv, utils.EzPickle):
     }
 
     def __init__(self, **kwargs):
+        assert mujoco.__version__ < "3.0.0", "`Pusher-v4` is only supported on `mujuco<3`."
         utils.EzPickle.__init__(self, **kwargs)
+        
         observation_space = Box(low=-np.inf, high=np.inf, shape=(23,), dtype=np.float64)
         MujocoEnv.__init__(
             self,

--- a/gymnasium/envs/mujoco/pusher_v4.py
+++ b/gymnasium/envs/mujoco/pusher_v4.py
@@ -25,7 +25,7 @@ class PusherEnv(MujocoEnv, utils.EzPickle):
     def __init__(self, **kwargs):
         assert (
             mujoco.__version__ < "3.0.0"
-        ), "`Pusher-v4` is only supported on `mujuco<3`."
+        ), "`Pusher-v4` is only supported on `mujuco<3`, for more information https://github.com/Farama-Foundation/Gymnasium/issues/950."
         utils.EzPickle.__init__(self, **kwargs)
 
         observation_space = Box(low=-np.inf, high=np.inf, shape=(23,), dtype=np.float64)

--- a/gymnasium/envs/mujoco/pusher_v4.py
+++ b/gymnasium/envs/mujoco/pusher_v4.py
@@ -23,9 +23,11 @@ class PusherEnv(MujocoEnv, utils.EzPickle):
     }
 
     def __init__(self, **kwargs):
-        assert mujoco.__version__ < "3.0.0", "`Pusher-v4` is only supported on `mujuco<3`."
+        assert (
+            mujoco.__version__ < "3.0.0"
+        ), "`Pusher-v4` is only supported on `mujuco<3`."
         utils.EzPickle.__init__(self, **kwargs)
-        
+
         observation_space = Box(low=-np.inf, high=np.inf, shape=(23,), dtype=np.float64)
         MujocoEnv.__init__(
             self,

--- a/gymnasium/envs/mujoco/pusher_v4.py
+++ b/gymnasium/envs/mujoco/pusher_v4.py
@@ -23,9 +23,10 @@ class PusherEnv(MujocoEnv, utils.EzPickle):
     }
 
     def __init__(self, **kwargs):
-        assert (
-            mujoco.__version__ < "3.0.0"
-        ), "`Pusher-v4` is only supported on `mujuco<3`, for more information https://github.com/Farama-Foundation/Gymnasium/issues/950."
+        if mujoco.__version__ >= "3.0.0":
+            raise ImportError(
+                "`Pusher-v4` is only supported on `mujuco<3`, for more information https://github.com/Farama-Foundation/Gymnasium/issues/950"
+            )
         utils.EzPickle.__init__(self, **kwargs)
 
         observation_space = Box(low=-np.inf, high=np.inf, shape=(23,), dtype=np.float64)

--- a/tests/envs/mujoco/test_mujoco_v5.py
+++ b/tests/envs/mujoco/test_mujoco_v5.py
@@ -586,17 +586,18 @@ def test_model_object_count(version: str):
     assert env.model.ngeom == 3
     assert env.model.ntendon == 0
 
-    env = gym.make(f"Pusher-{version}").unwrapped
-    assert isinstance(env, (BaseMujocoEnv, BaseMujocoPyEnv))
-    assert env.model.nq == 11
-    assert env.model.nv == 11
-    assert env.model.nu == 7
-    assert env.model.nbody == 13
-    if mujoco.__version__ >= "3.1.2":
-        assert env.model.nbvh == 8
-    assert env.model.njnt == 11
-    assert env.model.ngeom == 21
-    assert env.model.ntendon == 0
+    if not (version == "v4" and mujoco.__version__ >= "3.0.0"):
+        env = gym.make(f"Pusher-{version}").unwrapped
+        assert isinstance(env, (BaseMujocoEnv, BaseMujocoPyEnv))
+        assert env.model.nq == 11
+        assert env.model.nv == 11
+        assert env.model.nu == 7
+        assert env.model.nbody == 13
+        if mujoco.__version__ >= "3.1.2":
+            assert env.model.nbvh == 8
+        assert env.model.njnt == 11
+        assert env.model.ngeom == 21
+        assert env.model.ntendon == 0
 
     env = gym.make(f"Reacher-{version}").unwrapped
     assert isinstance(env, (BaseMujocoEnv, BaseMujocoPyEnv))

--- a/tests/envs/mujoco/test_mujoco_v5.py
+++ b/tests/envs/mujoco/test_mujoco_v5.py
@@ -331,7 +331,7 @@ env_conf = collections.namedtuple("env_conf", "env_name, obs, rew, term, info")
         env_conf("HumanoidStandup", True, False, False, "superset"),
         env_conf("InvertedDoublePendulum", True, True, False, "superset"),
         env_conf("InvertedPendulum", False, True, False, "superset"),
-        env_conf("Pusher", False, True, False, "keys-superset"),
+        env_conf("Pusher", True, True, False, "keys-superset"),
         env_conf("Reacher", True, True, False, "keys-equivalence"),
         env_conf("Swimmer", False, False, False, "skip"),
         env_conf("Walker2d", True, True, True, "keys-superset"),
@@ -339,6 +339,8 @@ env_conf = collections.namedtuple("env_conf", "env_name, obs, rew, term, info")
 )
 def test_identical_behaviour_v45(env_conf):
     """Verify that v4 -> v5 transition. Does not change the behaviour of the environments in any unexpected way."""
+    if env_conf.env_name == "Pusher" and mujoco.__version__ >= "3.0.0":
+        exit()
     NUM_STEPS = 100
     env_v4 = gym.make(f"{env_conf.env_name}-v4")
     env_v5 = gym.make(f"{env_conf.env_name}-v5")

--- a/tests/envs/mujoco/test_mujoco_v5.py
+++ b/tests/envs/mujoco/test_mujoco_v5.py
@@ -331,17 +331,17 @@ env_conf = collections.namedtuple("env_conf", "env_name, obs, rew, term, info")
         env_conf("HumanoidStandup", True, False, False, "superset"),
         env_conf("InvertedDoublePendulum", True, True, False, "superset"),
         env_conf("InvertedPendulum", False, True, False, "superset"),
-        env_conf("Pusher", True, True, False, "keys-superset"),
+        env_conf("Pusher", True, True, False, "keys-superset"),  # pusher-v4
         env_conf("Reacher", True, True, False, "keys-equivalence"),
         env_conf("Swimmer", False, False, False, "skip"),
         env_conf("Walker2d", True, True, True, "keys-superset"),
     ],
 )
-def test_identical_behaviour_v45(env_conf):
+def test_identical_behaviour_v45(env_conf, NUM_STEPS: int = 100):
     """Verify that v4 -> v5 transition. Does not change the behaviour of the environments in any unexpected way."""
     if env_conf.env_name == "Pusher" and mujoco.__version__ >= "3.0.0":
-        exit()
-    NUM_STEPS = 100
+        pytest.skip("Pusher-v4 is not compatible with mujoco >= 3")
+
     env_v4 = gym.make(f"{env_conf.env_name}-v4")
     env_v5 = gym.make(f"{env_conf.env_name}-v5")
 
@@ -709,5 +709,8 @@ def test_reset_noise_scale(env_id):
 @pytest.mark.parametrize("version", ["v5", "v4"])
 def test_reset_state(env_name: str, version: str):
     """Asserts that `reset()` properly resets the internal state."""
+    if env_name == "Pusher" and version == "v4" and mujoco.__version__ >= "3.0.0":
+        pytest.skip("Skipping Pusher-v4 as not compatible with mujoco >= 3.0")
+
     env = gym.make(f"{env_name}-{version}")
     check_mujoco_reset_state(env)


### PR DESCRIPTION
# Description

https://github.com/Farama-Foundation/Gymnasium/issues/950 noticed that pusher-v4 had collision issues which was isolated to a bug fixed in mujoco==3.0.0
This collision issue has a major implement on performance, therefore, raising an error for pusher-v4 when mujoco>=3
The issue will be fixed in pusher-v5
