### PR TITLE
`check_mujoco_reset_state` add `state_type` argument

### DIFF
--- a/gymnasium/envs/mujoco/utils.py
+++ b/gymnasium/envs/mujoco/utils.py
@@ -49,16 +49,27 @@ def set_state(
     return state
 
 
-def check_mujoco_reset_state(env: gymnasium.envs.mujoco.MujocoEnv, seed=1234):
-    """Asserts that `env.reset` properly resets the state (not affected by previous steps), assuming `check_reset_seed` has passed."""
+def check_mujoco_reset_state(
+        env: gymnasium.envs.mujoco.MujocoEnv,
+        seed=1234
+        state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_INTEGRATION,
+    ):
+    """Asserts that `env.reset()` properly resets the state (not affected by previous steps).
+    
+    Note: assuming `check_reset_seed` has passed.
+
+    Arguments:
+        env: Environment which is being tested.
+        seed: the `seed` used in `env.reset(seed)`.
+        state_type: see the [documentation of mjtState](https://mujoco.readthedocs.io/en/stable/APIreference/APItypes.html#mjtstate)."""
     env.action_space.seed(seed)
     action = env.action_space.sample()
 
     env.reset(seed=seed)
-    first_reset_state = get_state(env, mujoco.mjtState.mjSTATE_INTEGRATION)
+    first_reset_state = get_state(env, state_type)
     env.step(action)
 
     env.reset(seed=seed)
-    second_reset_state = get_state(env, mujoco.mjtState.mjSTATE_INTEGRATION)
+    second_reset_state = get_state(env, state_type)
 
     assert np.all(first_reset_state == second_reset_state), "reset is not deterministic"

--- a/gymnasium/envs/mujoco/utils.py
+++ b/gymnasium/envs/mujoco/utils.py
@@ -50,18 +50,19 @@ def set_state(
 
 
 def check_mujoco_reset_state(
-        env: gymnasium.envs.mujoco.MujocoEnv,
-        seed=1234
-        state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_INTEGRATION,
-    ):
+    env: gymnasium.envs.mujoco.MujocoEnv,
+    seed=1234,
+    state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_INTEGRATION,
+):
     """Asserts that `env.reset()` properly resets the state (not affected by previous steps).
-    
+
     Note: assuming `check_reset_seed` has passed.
 
     Arguments:
         env: Environment which is being tested.
         seed: the `seed` used in `env.reset(seed)`.
-        state_type: see the [documentation of mjtState](https://mujoco.readthedocs.io/en/stable/APIreference/APItypes.html#mjtstate)."""
+        state_type: see the [documentation of mjtState](https://mujoco.readthedocs.io/en/stable/APIreference/APItypes.html#mjtstate).
+    """
     env.action_space.seed(seed)
     action = env.action_space.sample()
 


### PR DESCRIPTION
# Description

adds the `state_type` argument to `check_mujoco_reset_state` function

motivation: it is useful for testing, as it allows the tester to find which state element is not deterministic on `reset` (currently used to debug an issue in meta)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
