### PR TITLE
[MuJoCo] add `visual_options` rendering argument

### DIFF
--- a/docs/environments/mujoco.md
+++ b/docs/environments/mujoco.md
@@ -103,14 +103,16 @@ The all MuJoCo Environments besides the general Gymnasium arguments, and environ
 env = gymnasium.make("Ant-v5", render_mode="rgb_array", width=1280, height=720)
 ```
 
-| Parameter                   | Type          | Default      | Description                               |
-| --------------------------- | ------------- | ------------ | ----------------------------------------- |
-| `width`                     | **int**       | `480`        | The width of the render window            |
-| `height`                    | **int**       | `480`        | The height of the render window           |
-| `camera_id`                 |**int \| None**| `None`       | The camera ID used for the render window  |
-| `camera_name`               |**str \| None**| `None`       | The name of the camera used for the render window (mutally exclusive option with `camera_id`) |
-| `default_camera_config`     |**dict[str, float \| int] \| None**| `None` |  The [mjvCamera](https://mujoco.readthedocs.io/en/stable/APIreference/APItypes.html#mjvcamera) properties |
-| `max_geom`                  | **int**       | `1000`       | Max number of geometrical objects to render (useful for 3rd-party environments) |
+| Parameter                   | Type                              | Default      | Description                               |
+| --------------------------- | -------------                     | ------------ | ----------------------------------------- |
+| `width`                     | **int**                           | `480`        | The width of the render window            |
+| `height`                    | **int**                           | `480`        | The height of the render window           |
+| `camera_id`                 |**int \| None**                    | `None`       | The camera ID used for the render window  |
+| `camera_name`               |**str \| None**                    | `None`       | The name of the camera used for the render window (mutally exclusive option with `camera_id`) |
+| `default_camera_config`     |**dict[str, float \| int] \| None**| `None`       |  The [mjvCamera](https://mujoco.readthedocs.io/en/stable/APIreference/APItypes.html#mjvcamera) properties |
+| `max_geom`                  | **int**                           | `1000`       | Max number of geometrical objects to render (useful for 3rd-party environments) |
+| `visual_options`            | **Dict[int, bool]**               | `{}`         | A dictionary with [mjVisual](https://mujoco.readthedocs.io/en/stable/overview.html#mjvisual) flags and value pairs, example `{mujoco.mjtVisFlag.mjVIS_CONTACTPOINT: True, mujoco.mjtVisFlag.mjVIS_CONTACTFORCE: True}` (show contact points and forces). |
+
 
 
 <!--

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -203,6 +203,7 @@ class MujocoEnv(BaseMujocoEnv):
         camera_name: Optional[str] = None,
         default_camera_config: Optional[Dict[str, Union[float, int]]] = None,
         max_geom: int = 1000,
+        visual_option_flags: list[tuple[int, bool]] = [],
     ):
         super().__init__(
             model_path,
@@ -226,6 +227,7 @@ class MujocoEnv(BaseMujocoEnv):
             max_geom,
             camera_id,
             camera_name,
+            visual_option_flags,
         )
 
     def _initialize_simulation(

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -203,7 +203,7 @@ class MujocoEnv(BaseMujocoEnv):
         camera_name: Optional[str] = None,
         default_camera_config: Optional[Dict[str, Union[float, int]]] = None,
         max_geom: int = 1000,
-        visual_option_flags: list[tuple[int, bool]] = [],
+        visual_options: Dict[int, bool] = {},
     ):
         super().__init__(
             model_path,
@@ -227,7 +227,7 @@ class MujocoEnv(BaseMujocoEnv):
             max_geom,
             camera_id,
             camera_name,
-            visual_option_flags,
+            visual_options,
         )
 
     def _initialize_simulation(

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -1,7 +1,7 @@
 import collections
 import os
 import time
-from typing import Optional
+from typing import Dict, Optional
 
 import glfw
 import imageio
@@ -44,6 +44,7 @@ class BaseRender:
         width: int,
         height: int,
         max_geom: int = 1000,
+        visual_options: Dict[int, bool] = {},
     ):
         """Render context superclass for offscreen and window rendering."""
         self.model = model
@@ -59,6 +60,9 @@ class BaseRender:
         self.cam = mujoco.MjvCamera()
         self.vopt = mujoco.MjvOption()
         self.pert = mujoco.MjvPerturb()
+
+        for flag, value in visual_options.items():
+            self.vopt.flags[flag] = value
 
         self.make_context_current()
 
@@ -643,6 +647,7 @@ class MujocoRenderer:
         max_geom: int = 1000,
         camera_id: Optional[int] = None,
         camera_name: Optional[str] = None,
+        visual_options: Dict[int, bool] = {},
     ):
         """A wrapper for clipping continuous actions within the valid bound.
 
@@ -664,6 +669,7 @@ class MujocoRenderer:
         self.width = width
         self.height = height
         self.max_geom = max_geom
+        self._vopt = visual_options
 
         # set self.camera_id using `camera_id` or `camera_name`
         if camera_id is not None and camera_name is not None:
@@ -712,11 +718,21 @@ class MujocoRenderer:
         if self.viewer is None:
             if render_mode == "human":
                 self.viewer = WindowViewer(
-                    self.model, self.data, self.width, self.height, self.max_geom
+                    self.model,
+                    self.data,
+                    self.width,
+                    self.height,
+                    self.max_geom,
+                    self._vopt,
                 )
             elif render_mode in {"rgb_array", "depth_array"}:
                 self.viewer = OffScreenViewer(
-                    self.model, self.data, self.width, self.height, self.max_geom
+                    self.model,
+                    self.data,
+                    self.width,
+                    self.height,
+                    self.max_geom,
+                    self._vopt,
                 )
             else:
                 raise AttributeError(

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -150,11 +150,12 @@ class OffScreenViewer(BaseRender):
         width: int,
         height: int,
         max_geom: int = 1000,
+        visual_options: Dict[int, bool] = {},
     ):
         # We must make GLContext before MjrContext
         self._get_opengl_backend(width, height)
 
-        super().__init__(model, data, width, height, max_geom)
+        super().__init__(model, data, width, height, max_geom, visual_options)
 
         self._init_camera()
 
@@ -301,6 +302,7 @@ class WindowViewer(BaseRender):
         width: Optional[int] = None,
         height: Optional[int] = None,
         max_geom: int = 1000,
+        visual_options: Dict[int, bool] = {},
     ):
         glfw.init()
 
@@ -339,7 +341,7 @@ class WindowViewer(BaseRender):
         glfw.set_scroll_callback(self.window, self._scroll_callback)
         glfw.set_key_callback(self.window, self._key_callback)
 
-        super().__init__(model, data, width, height, max_geom)
+        super().__init__(model, data, width, height, max_geom, visual_options)
         glfw.swap_interval(1)
 
     def _set_mujoco_buffer(self):


### PR DESCRIPTION
# Description

Fixes https://github.com/Farama-Foundation/Gymnasium/issues/464

## Type of change
- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing
it works with `render_mode="human"` `render_mode="rgb_array"

```py
import gymnasium
import mujoco
import time
from gymnasium.wrappers import HumanRendering, RecordVideo

env = gymnasium.make("Ant-v5", render_mode="human", visual_options={mujoco.mjtVisFlag.mjVIS_CONTACTPOINT: True, mujoco.mjtVisFlag.mjVIS_CONTACTFORCE: True})
# env = gymnasium.make("Ant-v5", render_mode="rgb_array", visual_options={mujoco.mjtVisFlag.mjVIS_CONTACTPOINT: True, mujoco.mjtVisFlag.mjVIS_CONTACTFORCE: True})
# env = HumanRendering(gymnasium.make("Ant-v5", render_mode="rgb_array", visual_options={mujoco.mjtVisFlag.mjVIS_CONTACTPOINT: True, mujoco.mjtVisFlag.mjVIS_CONTACTFORCE: True}))
# env = RecordVideo(env, video_folder="./save_videos1")
env.reset()

for _ in range(1000):
    env.step(env.action_space.sample())

env.close()
```


