### PR TITLE
Remove ordereddict in favour of python dict

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -1,4 +1,3 @@
-import collections
 import os
 import time
 from typing import Optional
@@ -27,13 +26,11 @@ def _import_osmesa(width, height):
     return GLContext(width, height)
 
 
-_ALL_RENDERERS = collections.OrderedDict(
-    [
-        ("glfw", _import_glfw),
-        ("egl", _import_egl),
-        ("osmesa", _import_osmesa),
-    ]
-)
+_ALL_RENDERERS = {
+    "glfw": _import_glfw,
+    "egl": _import_egl,
+    "osmesa": _import_osmesa,
+}
 
 
 class BaseRender:

--- a/gymnasium/vector/utils/shared_memory.py
+++ b/gymnasium/vector/utils/shared_memory.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import multiprocessing as mp
-from collections import OrderedDict
 from ctypes import c_bool
 from functools import singledispatch
 from typing import Any
@@ -81,12 +80,10 @@ def _create_tuple_shared_memory(space: Tuple, n: int = 1, ctx=mp):
 
 @create_shared_memory.register(Dict)
 def _create_dict_shared_memory(space: Dict, n: int = 1, ctx=mp):
-    return OrderedDict(
-        [
-            (key, create_shared_memory(subspace, n=n, ctx=ctx))
-            for (key, subspace) in space.spaces.items()
-        ]
-    )
+    return {
+        key: create_shared_memory(subspace, n=n, ctx=ctx)
+        for (key, subspace) in space.spaces.items()
+    }
 
 
 @create_shared_memory.register(Text)
@@ -163,15 +160,12 @@ def _read_tuple_from_shared_memory(space: Tuple, shared_memory, n: int = 1):
 
 @read_from_shared_memory.register(Dict)
 def _read_dict_from_shared_memory(space: Dict, shared_memory, n: int = 1):
-    subspace_samples = OrderedDict(
-        [
-            (key, read_from_shared_memory(subspace, shared_memory[key], n=n))
-            for (key, subspace) in space.spaces.items()
-        ]
-    )
+    subspace_samples = {
+        key: read_from_shared_memory(subspace, shared_memory[key], n=n)
+        for (key, subspace) in space.spaces.items()
+    }
     return tuple(
-        OrderedDict({key: subspace_samples[key][i] for key in space.keys()})
-        for i in range(n)
+        {key: subspace_samples[key][i] for key in space.keys()} for i in range(n)
     )
 
 

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -162,9 +162,9 @@ def iterate(space: Space[T_cov], items: Iterable[T_cov]) -> Iterator:
         >>> items = space.sample()
         >>> it = iterate(space, items)
         >>> next(it)
-        OrderedDict([('position', array([0.77395606, 0.43887845, 0.85859793], dtype=float32)), ('velocity', array([0.77395606, 0.43887845], dtype=float32))])
+        {'position': array([0.77395606, 0.43887845, 0.85859793], dtype=float32), 'velocity': array([0.77395606, 0.43887845], dtype=float32)}
         >>> next(it)
-        OrderedDict([('position', array([0.697368  , 0.09417735, 0.97562236], dtype=float32)), ('velocity', array([0.85859793, 0.697368  ], dtype=float32))])
+        {'position': array([0.697368  , 0.09417735, 0.97562236], dtype=float32), 'velocity': array([0.85859793, 0.697368  ], dtype=float32)}
         >>> next(it)
         Traceback (most recent call last):
             ...
@@ -327,9 +327,9 @@ def create_empty_array(
         ... 'position': Box(low=0, high=1, shape=(3,), dtype=np.float32),
         ... 'velocity': Box(low=0, high=1, shape=(2,), dtype=np.float32)})
         >>> create_empty_array(space, n=2, fn=np.zeros)
-        OrderedDict([('position', array([[0., 0., 0.],
-               [0., 0., 0.]], dtype=float32)), ('velocity', array([[0., 0.],
-               [0., 0.]], dtype=float32))])
+        {'position': array([[0., 0., 0.],
+               [0., 0., 0.]], dtype=float32), 'velocity': array([[0., 0.],
+               [0., 0.]], dtype=float32)}
     """
     raise TypeError(
         f"The space provided to `create_empty_array` is not a gymnasium Space instance, type: {type(space)}, {space}"

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -7,7 +7,6 @@
 """
 from __future__ import annotations
 
-from collections import OrderedDict
 from copy import deepcopy
 from functools import singledispatch
 from typing import Any, Iterable, Iterator
@@ -226,7 +225,7 @@ def _iterate_dict(space: Dict, items: dict[str, Any]):
         ]
     )
     for item in zip(*values):
-        yield OrderedDict({key: value for key, value in zip(keys, item)})
+        yield {key: value for key, value in zip(keys, item)}
 
 
 @singledispatch
@@ -287,12 +286,10 @@ def _concatenate_tuple(
 def _concatenate_dict(
     space: Dict, items: Iterable, out: dict[str, Any]
 ) -> dict[str, Any]:
-    return OrderedDict(
-        {
-            key: concatenate(subspace, [item[key] for item in items], out[key])
-            for key, subspace in space.items()
-        }
-    )
+    return {
+        key: concatenate(subspace, [item[key] for item in items], out[key])
+        for key, subspace in space.items()
+    }
 
 
 @concatenate.register(Graph)
@@ -356,12 +353,9 @@ def _create_empty_array_tuple(space: Tuple, n: int = 1, fn=np.zeros) -> tuple[An
 
 @create_empty_array.register(Dict)
 def _create_empty_array_dict(space: Dict, n: int = 1, fn=np.zeros) -> dict[str, Any]:
-    return OrderedDict(
-        {
-            key: create_empty_array(subspace, n=n, fn=fn)
-            for key, subspace in space.items()
-        }
-    )
+    return {
+        key: create_empty_array(subspace, n=n, fn=fn) for key, subspace in space.items()
+    }
 
 
 @create_empty_array.register(Graph)

--- a/gymnasium/wrappers/utils.py
+++ b/gymnasium/wrappers/utils.py
@@ -1,5 +1,4 @@
 """Utility functions for the wrappers."""
-from collections import OrderedDict
 from functools import singledispatch
 
 import numpy as np
@@ -119,9 +118,7 @@ def _create_tuple_zero_array(space: Tuple):
 
 @create_zero_array.register(Dict)
 def _create_dict_zero_array(space: Dict):
-    return OrderedDict(
-        {key: create_zero_array(subspace) for key, subspace in space.spaces.items()}
-    )
+    return {key: create_zero_array(subspace) for key, subspace in space.spaces.items()}
 
 
 @create_zero_array.register(Sequence)

--- a/gymnasium/wrappers/vector/vectorize_observation.py
+++ b/gymnasium/wrappers/vector/vectorize_observation.py
@@ -189,10 +189,10 @@ class FilterObservation(VectorizeTransformObservation):
         >>> obs, info = envs.reset(seed=123)
         >>> envs.close()
         >>> obs
-        OrderedDict([('obs', array([[ 0.01823519, -0.0446179 , -0.02796401, -0.03156282],
+        {'obs': array([[ 0.01823519, -0.0446179 , -0.02796401, -0.03156282],
                [ 0.02852531,  0.02858594,  0.0469136 ,  0.02480598],
                [ 0.03517495, -0.000635  , -0.01098382, -0.03203924]],
-              dtype=float32))])
+              dtype=float32)}
     """
 
     def __init__(self, env: VectorEnv, filter_keys: Sequence[str | int]):

--- a/tests/spaces/test_dict.py
+++ b/tests/spaces/test_dict.py
@@ -10,7 +10,7 @@ from gymnasium.spaces import Box, Dict, Discrete
 
 def test_dict_init():
     with pytest.raises(
-        AssertionError,
+        TypeError,
         match=r"^Unexpected Dict space input, expecting dict, OrderedDict or Sequence, actual type: ",
     ):
         Dict(Discrete(2))


### PR DESCRIPTION
# Description

`OrderedDict` were used for legacy reasons when `dict` where no insertion ordered (which `OrderedDict` are).
However, in Python 3.6, python dict were updated for speed and in the process added insertion ordering. 

Therefore, this PR updates the return type of `Dict` space to be a python dict.
However, we probably cannot remove the `self.spaces = sorted(spaces)` as this could break old code that might flatten the dictionary or use `next`, making this bug very difficult to discover

Original issue: https://github.com/Farama-Foundation/Gymnasium/issues/940