### PR TITLE
Fix Lunar Lander Observation space bound

### DIFF
--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -78,7 +78,7 @@ class ContactDetector(contactListener):
 
 
 class LunarLander(gym.Env, EzPickle):
-    """
+    f"""
     ## Description
     This environment is a classic rocket trajectory optimization problem.
     According to Pontryagin's maximum principle, it is optimal to fire the

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -178,10 +178,11 @@ class LunarLander(gym.Env, EzPickle):
      The recommended value for `turbulence_power` is between 0.0 and 2.0.
 
     ## Version History
-    - v3: Reset wind and turbulence offset (`C`) whenever the environment is reset to ensure statistical independence between consecutive episodes (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/954)).
+    - v3: 
+	    - Reset wind and turbulence offset (`C`) whenever the environment is reset to ensure statistical independence between consecutive episodes (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/954)).
+        - Changed observation space for `x`, `y`  coordinates from $\pm 1.5$ to $\pm 1.6$ (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/752)).
     - v2: Count energy spent and in v0.24, added turbulence with wind power and turbulence_power parameters
-    - v1: Legs contact with ground added in state vector; contact with ground give +10 reward points,
-          and -10 if then lose contact; reward renormalized to 200; harder initial random push.
+    - v1: Legs contact with ground added in state vector; contact with ground give +10 reward points, and -10 if then lose contact; reward renormalized to 200; harder initial random push.
     - v0: Initial version
 
     ## Notes
@@ -266,8 +267,8 @@ class LunarLander(gym.Env, EzPickle):
                 # these are bounds for position
                 # realistically the environment should have ended
                 # long before we reach more than 50% outside
-                -1.5,
-                -1.5,
+                -1.6,
+                -1.6,
                 # velocity bounds is 5x rated speed
                 -5.0,
                 -5.0,
@@ -282,8 +283,8 @@ class LunarLander(gym.Env, EzPickle):
                 # these are bounds for position
                 # realistically the environment should have ended
                 # long before we reach more than 50% outside
-                1.5,
-                1.5,
+                1.6,
+                1.6,
                 # velocity bounds is 5x rated speed
                 5.0,
                 5.0,

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -268,13 +268,13 @@ class LunarLander(gym.Env, EzPickle):
                 # these are bounds for position
                 # realistically the environment should have ended
                 # long before we reach more than 50% outside
-                -1.6,
-                -1.6,
+                -2.5,  # x coordinate
+                -2.5,  # y coordinate
                 # velocity bounds is 5x rated speed
-                -5.0,
-                -5.0,
-                -math.pi,
-                -5.0,
+                -10.0,
+                -10.0,
+                -2*math.pi,
+                -10.0,
                 -0.0,
                 -0.0,
             ]
@@ -284,13 +284,13 @@ class LunarLander(gym.Env, EzPickle):
                 # these are bounds for position
                 # realistically the environment should have ended
                 # long before we reach more than 50% outside
-                1.6,
-                1.6,
+                2.5,  # x coordinate
+                2.5,  # y coordinate
                 # velocity bounds is 5x rated speed
-                5.0,
-                5.0,
-                math.pi,
-                5.0,
+                10.0,
+                10.0,
+                2*math.pi,
+                10.0,
                 1.0,
                 1.0,
             ]

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -179,8 +179,9 @@ class LunarLander(gym.Env, EzPickle):
 
     ## Version History
     - v3: 
-	    - Reset wind and turbulence offset (`C`) whenever the environment is reset to ensure statistical independence between consecutive episodes (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/954)).
-        - Changed observation space for `x`, `y`  coordinates from $\pm 1.5$ to $\pm 1.6$ (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/752)).
+        - Reset wind and turbulence offset (`C`) whenever the environment is reset to ensure statistical independence between consecutive episodes (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/954)).
+        - Fix non-deterministic behaviour due to not fully destroying the world (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/728)).
+	- Changed observation space for `x`, `y`  coordinates from $\pm 1.5$ to $\pm 1.6$ (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/752)).
     - v2: Count energy spent and in v0.24, added turbulence with wind power and turbulence_power parameters
     - v1: Legs contact with ground added in state vector; contact with ground give +10 reward points, and -10 if then lose contact; reward renormalized to 200; harder initial random push.
     - v0: Initial version

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -181,7 +181,7 @@ class LunarLander(gym.Env, EzPickle):
     - v3: 
         - Reset wind and turbulence offset (`C`) whenever the environment is reset to ensure statistical independence between consecutive episodes (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/954)).
         - Fix non-deterministic behaviour due to not fully destroying the world (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/728)).
-	- Changed observation space for `x`, `y`  coordinates from $\pm 1.5$ to $\pm 1.6$ (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/752)).
+	- Changed observation space for `x`, `y`  coordinates from $\pm 1.5$ to $\pm 2.5$, velocities from $\pm 5$ to $\pm 10$ and angles from $\pm \pi$ to $\pm 2\pi$ (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/752)).
     - v2: Count energy spent and in v0.24, added turbulence with wind power and turbulence_power parameters
     - v1: Legs contact with ground added in state vector; contact with ground give +10 reward points, and -10 if then lose contact; reward renormalized to 200; harder initial random push.
     - v0: Initial version

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -78,7 +78,7 @@ class ContactDetector(contactListener):
 
 
 class LunarLander(gym.Env, EzPickle):
-    f"""
+    r"""
     ## Description
     This environment is a classic rocket trajectory optimization problem.
     According to Pontryagin's maximum principle, it is optimal to fire the
@@ -178,7 +178,7 @@ class LunarLander(gym.Env, EzPickle):
      The recommended value for `turbulence_power` is between 0.0 and 2.0.
 
     ## Version History
-    - v3: 
+    - v3:
         - Reset wind and turbulence offset (`C`) whenever the environment is reset to ensure statistical independence between consecutive episodes (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/954)).
         - Fix non-deterministic behaviour due to not fully destroying the world (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/728)).
         - Changed observation space for `x`, `y`  coordinates from $\pm 1.5$ to $\pm 2.5$, velocities from $\pm 5$ to $\pm 10$ and angles from $\pm \pi$ to $\pm 2\pi$ (related [GitHub issue](https://github.com/Farama-Foundation/Gymnasium/issues/752)).
@@ -273,7 +273,7 @@ class LunarLander(gym.Env, EzPickle):
                 # velocity bounds is 5x rated speed
                 -10.0,
                 -10.0,
-                -2*math.pi,
+                -2 * math.pi,
                 -10.0,
                 -0.0,
                 -0.0,
@@ -289,7 +289,7 @@ class LunarLander(gym.Env, EzPickle):
                 # velocity bounds is 5x rated speed
                 10.0,
                 10.0,
-                2*math.pi,
+                2 * math.pi,
                 10.0,
                 1.0,
                 1.0,


### PR DESCRIPTION
# Description

Fixes https://github.com/Farama-Foundation/Gymnasium/issues/752

# validation

note: I have not strictly validated that new bounds will never cause it to be out of bounds, but it should at least be extremely rare
```py
import gymnasium as gym
import numpy as np
import math


env = gym.make('LunarLander-v2')
# chage to the new obs space
low = np.array([ -2.5, -2.5, -10.0, -10.0, -2*math.pi, -10.0, -0.0, -0.0, ]).astype(np.float32)
high = np.array( [ 2.5, 2.5, 10.0, 10.0, 2*math.pi, 10.0, 1.0, 1.0, ]).astype(np.float32)
env.unwrapped.observation_space = gym.spaces.Box(low, high)
env.reset()

for _ in range(int(100e6)):
    action = env.action_space.sample()
    obs, rew, terminated, truncated, info = env.step(action)
    assert env.observation_space.contains(obs), obs

    if terminated or truncated:
        env.reset()
```

