### PR TITLE
[MuJoCo utils] fix `set_state` 

### DIFF
--- a/gymnasium/envs/mujoco/utils.py
+++ b/gymnasium/envs/mujoco/utils.py
@@ -11,7 +11,7 @@ import gymnasium
 
 def get_state(
     env: gymnasium.envs.mujoco.MujocoEnv,
-    state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_PHYSICS,
+    state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_FULLPHYSICS,
 ):
     """Gets the state of `env`.
 
@@ -29,7 +29,7 @@ def get_state(
 def set_state(
     env: gymnasium.envs.mujoco.MujocoEnv,
     state: np.ndarray,
-    state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_PHYSICS,
+    state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_FULLPHYSICS,
 ):
     """Set the state of `env`.
 
@@ -44,7 +44,7 @@ def set_state(
         env.unwrapped.model,
         env.unwrapped.data,
         state,
-        spec=mujoco.mjtState.mjSTATE_PHYSICS,
+        spec=state_type,
     )
     return state
 


### PR DESCRIPTION
Previously `set_state` ignored `state_type` argument 

also changed default `state_type` to full physics because it might be needed for third party environments 

## Type of change
- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
