### PR TITLE
Catch exception during `env.spec` if kwarg is unpickleable

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Generic, SupportsFloat, TypeVar
 
 import numpy as np
 
+import gymnasium
 from gymnasium import spaces
 from gymnasium.utils import RecordConstructorArgs, seeding
 
@@ -368,8 +369,14 @@ class Wrapper(
             )
 
             # to avoid reference issues we deepcopy the prior environments spec and add the new information
-            env_spec = deepcopy(env_spec)
-            env_spec.additional_wrappers += (wrapper_spec,)
+            try:
+                env_spec = deepcopy(env_spec)
+                env_spec.additional_wrappers += (wrapper_spec,)
+            except Exception as e:
+                gymnasium.logger.warn(
+                    f"An exception occurred ({e}) while copying the environment spec={env_spec}"
+                )
+                return None
 
         self._cached_spec = env_spec
         return env_spec

--- a/gymnasium/wrappers/common.py
+++ b/gymnasium/wrappers/common.py
@@ -149,8 +149,14 @@ class TimeLimit(
 
         env_spec = self.env.spec
         if env_spec is not None:
-            env_spec = deepcopy(env_spec)
-            env_spec.max_episode_steps = self._max_episode_steps
+            try:
+                env_spec = deepcopy(env_spec)
+                env_spec.max_episode_steps = self._max_episode_steps
+            except Exception as e:
+                gym.logger.warn(
+                    f"An exception occurred ({e}) while copying the environment spec={env_spec}"
+                )
+                return None
 
         self._cached_spec = env_spec
         return env_spec
@@ -319,8 +325,14 @@ class PassiveEnvChecker(
 
         env_spec = self.env.spec
         if env_spec is not None:
-            env_spec = deepcopy(env_spec)
-            env_spec.disable_env_checker = False
+            try:
+                env_spec = deepcopy(env_spec)
+                env_spec.disable_env_checker = False
+            except Exception as e:
+                gym.logger.warn(
+                    f"An exception occurred ({e}) while copying the environment spec={env_spec}"
+                )
+                return None
 
         self._cached_spec = env_spec
         return env_spec
@@ -424,8 +436,14 @@ class OrderEnforcing(
 
         env_spec = self.env.spec
         if env_spec is not None:
-            env_spec = deepcopy(env_spec)
-            env_spec.order_enforce = True
+            try:
+                env_spec = deepcopy(env_spec)
+                env_spec.order_enforce = True
+            except Exception as e:
+                gym.logger.warn(
+                    f"An exception occurred ({e}) while copying the environment spec={env_spec}"
+                )
+                return None
 
         self._cached_spec = env_spec
         return env_spec


### PR DESCRIPTION
# Description

Fix https://github.com/Farama-Foundation/Gymnasium/issues/555 where using environment kwargs that are unpickleable. 
For each spec that deepcopy that the `env_spec`, the function is surrounded by a try catch
