### PR TITLE
Error `make_vec` for vector entry point with non-empty additional wrappers 

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -934,9 +934,13 @@ def make_vec(
             raise error.Error(
                 f"Custom vector environment can be passed arguments only through kwargs and `vector_kwargs` is not empty ({vector_kwargs})"
             )
-        if len(wrappers) > 0:
+        elif len(wrappers) > 0:
             raise error.Error(
-                "Cannot use `vector_entry_point` vectorization mode with the wrappers argument."
+                f"Cannot use `vector_entry_point` vectorization mode with the wrappers argument ({wrappers})."
+            )
+        elif len(env_spec.additional_wrappers) > 0:
+            raise error.Error(
+                f"Cannot use `vector_entry_point` vectorization mode with the additional_wrappers parameter in spec being not empty ({env_spec.additional_wrappers})."
             )
 
         entry_point = env_spec.vector_entry_point

--- a/tests/envs/registration/test_make_vec.py
+++ b/tests/envs/registration/test_make_vec.py
@@ -4,7 +4,7 @@ import re
 import pytest
 
 import gymnasium as gym
-from gymnasium import VectorizeMode
+from gymnasium import VectorizeMode, wrappers
 from gymnasium.envs.classic_control import CartPoleEnv
 from gymnasium.envs.classic_control.cartpole import CartPoleVectorEnv
 from gymnasium.vector import AsyncVectorEnv, SyncVectorEnv
@@ -230,5 +230,25 @@ def test_async_with_dynamically_registered_env(ctx):
     gym.make_vec(
         "TestEnv-v0", vectorization_mode="async", vector_kwargs=dict(context=ctx)
     )
+
+    del gym.registry["TestEnv-v0"]
+
+
+def test_make_vec_with_spec_additional_wrappers():
+    gym.register(
+        "TestEnv-v0",
+        entry_point=CartPoleEnv,
+        additional_wrappers=(
+            wrappers.ClipReward.wrapper_spec(min_reward=-0.5, max_reward=0.5),
+        ),
+    )
+
+    env = gym.make("TestEnv-v0")
+    print(f"{env=}")
+    assert isinstance(env, wrappers.ClipReward)
+
+    envs = gym.make_vec("TestEnv-v0")
+    print(f"{envs=}")
+    assert isinstance(envs.envs[0], wrappers.ClipReward)
 
     del gym.registry["TestEnv-v0"]


### PR DESCRIPTION
# Description

With `EnvSpec` adding `additional_wrappers`, this was not disabled for `make_vec(..., vectorisation="vector_entry_point")` 
This PR just checks this and raises an error if this is the case