### PR TITLE
use different `mujoco-py` build options(under testing)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ accept-rom-license = ["autorom[accept-rom-license] ~=0.4.2"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
-mujoco-py = ["mujoco-py@https://github.com/Kallinteris-Andreas/mujoco-py"]
-mujoco_py = ["mujoco-py@https://github.com/Kallinteris-Andreas/mujoco-py"]       # kept for backward compatibility
+mujoco-py = ["mujoco-py@https://github.com/Kallinteris-Andreas/mujoco-py.git"]
+mujoco_py = ["mujoco-py@https://github.com/Kallinteris-Andreas/mujoco-py.git"]       # kept for backward compatibility
 mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]         # kept for backward compatibility
@@ -64,7 +64,7 @@ all = [
     # classic-control
     "pygame >=2.1.3",
     # mujoco-py
-    "mujoco-py@https://github.com/Kallinteris-Andreas/mujoco-py",
+    "mujoco-py@https://github.com/Kallinteris-Andreas/mujoco-py.git",
     # mujoco
     "mujoco >=2.1.5",
     "imageio >=2.14.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ accept-rom-license = ["autorom[accept-rom-license] ~=0.4.2"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
-mujoco-py = ["mujoco-py >=2.1,<2.2", "cython<3"]
-mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]       # kept for backward compatibility
+mujoco-py = ["mujoco-py@https://github.com/Kallinteris-Andreas/mujoco-py"]
+mujoco_py = ["mujoco-py@https://github.com/Kallinteris-Andreas/mujoco-py"]       # kept for backward compatibility
 mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]         # kept for backward compatibility
@@ -64,8 +64,7 @@ all = [
     # classic-control
     "pygame >=2.1.3",
     # mujoco-py
-    "mujoco-py >=2.1,<2.2",
-    "cython<3",
+    "mujoco-py@https://github.com/Kallinteris-Andreas/mujoco-py",
     # mujoco
     "mujoco >=2.1.5",
     "imageio >=2.14.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,8 @@ accept-rom-license = ["autorom[accept-rom-license] ~=0.4.2"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
-mujoco-py = ["mujoco-py@https://github.com/Kallinteris-Andreas/mujoco-py.git"]
-mujoco_py = ["mujoco-py@https://github.com/Kallinteris-Andreas/mujoco-py.git"]       # kept for backward compatibility
+mujoco-py = ["mujoco-py@git+https://github.com/Kallinteris-Andreas/mujoco-py.git"]
+mujoco_py = ["mujoco-py@git+https://github.com/Kallinteris-Andreas/mujoco-py.git"]       # kept for backward compatibility
 mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]         # kept for backward compatibility
@@ -64,7 +64,7 @@ all = [
     # classic-control
     "pygame >=2.1.3",
     # mujoco-py
-    "mujoco-py@https://github.com/Kallinteris-Andreas/mujoco-py.git",
+    "mujoco-py@git+https://github.com/Kallinteris-Andreas/mujoco-py.git",
     # mujoco
     "mujoco >=2.1.5",
     "imageio >=2.14.1",


### PR DESCRIPTION
https://github.com/Kallinteris-Andreas/mujoco-py is a soft fork `mujoco-py` that simply changes the build flags

if this gets merged or a similar solution is found, we can delay https://github.com/Farama-Foundation/Gymnasium/issues/993


```py
>>> import gymnasium
>>> import cython
>>> cython.__version__
'3.0.10'
>>> env = gymnasium.make("Ant-v2")
/home/master-andreas/temp/Gymnasium/gymnasium/envs/registration.py:518: DeprecationWarning: WARN: The environment Ant-v2 is out of date. You should consider upgrading to version `v5`.
  logger.deprecation(
/home/master-andreas/temp/Gymnasium/gymnasium/envs/mujoco/mujoco_py_env.py:217: DeprecationWarning: WARN: This version of the mujoco environments depends on the mujoco-py bindings, which are no longer maintained and may stop working. Please upgrade to the v5 or v4 versions of the environments (which depend on the mujoco python bindings instead), unless you are trying to precisely replicate previous works).
  logger.deprecation(
```

# Advantages
- removes the requirement for  `cython <3`

# Downsides
- if the user runs `pip gymnasium[mujoco-py]` or `pip gymnasium[all]` with `mujoco-py` pre-installed, it will re-install `mujoco-py` potentially changing the version they had installed
- other unknown downsides I can not foresee

# Alternatives
make a `pypi` package for this soft fork `mujoc-py-updated`???, but I would rather not do that 
