### PR TITLE
Fix `OneOf` shared memory and add `pytest.skip` to tests

### DIFF
--- a/gymnasium/spaces/oneof.py
+++ b/gymnasium/spaces/oneof.py
@@ -140,14 +140,17 @@ class OneOf(Space[Any]):
     ) -> list[list[Any]]:
         """Convert a batch of samples from this space to a JSONable data type."""
         return [
-            [i, self.spaces[i].to_jsonable([subsample])[0]]
+            [int(i), self.spaces[i].to_jsonable([subsample])[0]]
             for (i, subsample) in sample_n
         ]
 
     def from_jsonable(self, sample_n: list[list[Any]]) -> list[tuple[Any, ...]]:
         """Convert a JSONable data type to a batch of samples from this space."""
         return [
-            (space_idx, self.spaces[space_idx].from_jsonable([jsonable_sample])[0])
+            (
+                np.int64(space_idx),
+                self.spaces[space_idx].from_jsonable([jsonable_sample])[0],
+            )
             for space_idx, jsonable_sample in sample_n
         ]
 

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -421,7 +421,7 @@ def _unflatten_sequence(space: Sequence, x: tuple[Any, ...]) -> tuple[Any, ...] 
 
 @unflatten.register(OneOf)
 def _unflatten_oneof(space: OneOf, x: NDArray[Any]) -> tuple[int, Any]:
-    idx = int(x[0])
+    idx = np.int64(x[0])
     sub_space = space.spaces[idx]
 
     original_size = flatdim(sub_space)

--- a/tests/envs/mujoco/test_mujoco_v5.py
+++ b/tests/envs/mujoco/test_mujoco_v5.py
@@ -436,7 +436,7 @@ def test_observation_structure(env_name: str, version: str):
     env = gym.make(f"{env_name}-{version}").unwrapped
     assert isinstance(env, MujocoEnv)
     if not hasattr(env, "observation_structure"):
-        return
+        pytest.skip("Environment doesn't have an `observation_structure` attribute")
 
     obs_struct = env.observation_structure
 

--- a/tests/envs/test_action_dim_check.py
+++ b/tests/envs/test_action_dim_check.py
@@ -71,7 +71,8 @@ def test_discrete_actions_out_of_bound(env: gym.Env):
         env (gym.Env): the gymnasium environment
     """
     if env.metadata.get("jax", False):
-        return
+        assert env.spec is not None
+        pytest.skip(f"Skipping jax-based environment ({env.spec.id})")
 
     assert isinstance(env.action_space, spaces.Discrete)
     upper_bound = env.action_space.start + env.action_space.n - 1
@@ -106,7 +107,8 @@ def test_box_actions_out_of_bound(env: gym.Env):
         env (gym.Env): the gymnasium environment
     """
     if env.metadata.get("jax", False):
-        return
+        assert env.spec is not None
+        pytest.skip(f"Skipping jax-based environment ({env.spec.id})")
 
     env.reset(seed=42)
 

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -63,7 +63,7 @@ def test_all_env_passive_env_checker(spec):
 
     for warning in caught_warnings:
         if not passive_check_pattern.search(str(warning.message)):
-            print(f"Unexpected warning: {warning.message}")
+            raise ValueError(f"Unexpected warning: {warning.message}")
 
 
 # Note that this precludes running this test in multiple threads.
@@ -90,7 +90,7 @@ def test_env_determinism_rollout(env_spec: EnvSpec):
     """
     # Don't check rollout equality if it's a nondeterministic environment.
     if env_spec.nondeterministic is True:
-        return
+        pytest.skip(f"Skipping {env_spec.id} as it is non-deterministic")
 
     env_1 = env_spec.make(disable_env_checker=True)
     env_2 = env_spec.make(disable_env_checker=True)

--- a/tests/spaces/test_oneof.py
+++ b/tests/spaces/test_oneof.py
@@ -62,6 +62,10 @@ def test_oneof_contains():
     assert (0, np.array([0.5], dtype=np.float32)) in space
     assert (1, np.array([-0.5, -0.5], dtype=np.float32)) in space
 
+    assert (np.int64(0), np.array([0.5], dtype=np.float32)) in space
+
+    assert (np.int32(0), np.array([0.5], dtype=np.float32)) not in space
+
 
 def test_bad_oneof_seed():
     space = OneOf([Box(0, 1), Box(0, 1)])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -118,7 +118,7 @@ def test_example_wrapper(example_env):
             "Can't access `_np_random` of a wrapper, use `.unwrapped._np_random` or `.np_random`."
         ),
     ):
-        print(wrapper_env.access_hidden_np_random())
+        _ = wrapper_env.access_hidden_np_random()
 
 
 class ExampleRewardWrapper(RewardWrapper):

--- a/tests/vector/utils/test_shared_memory.py
+++ b/tests/vector/utils/test_shared_memory.py
@@ -33,8 +33,12 @@ def test_shared_memory_create_read_write(space, num, ctx):
 
     try:
         shared_memory = create_shared_memory(space, n=num, ctx=ctx)
-    except TypeError:
-        return
+    except TypeError as err:
+        assert (
+            "has a dynamic shape so its not possible to make a static shared memory."
+            in str(err)
+        )
+        pytest.skip("Skipping space with dynamic shape")
 
     for i, sample in enumerate(samples):
         write_to_shared_memory(space, i, sample, shared_memory)

--- a/tests/wrappers/test_jax_to_torch.py
+++ b/tests/wrappers/test_jax_to_torch.py
@@ -96,9 +96,6 @@ class ExampleNamedTuple(NamedTuple):
 )
 def test_roundtripping(value, expected_value):
     """We test numpy -> jax -> numpy as this is direction in the NumpyToJax wrapper."""
-    print(f"{value=}")
-    print(f"{torch_to_jax(value)=}")
-    print(f"{jax_to_torch(torch_to_jax(value))=}")
     roundtripped_value = jax_to_torch(torch_to_jax(value))
     assert torch_data_equivalence(roundtripped_value, expected_value)
 


### PR DESCRIPTION
# Description

I noticed that some tests had `return` as a way of stopping a test for various reasons. 
In changing this to `pytest.skip` logging the reason, I found that `OneOf` shared memory actually was broken for various reasons. 

This PR, adds the `pytest.skip` and fixes `OneOf` shared memory by only modifying the sample's subspace memory