### PR TITLE
Update requirement list and add quotes around pip install for macos users

### DIFF
--- a/gymnasium/envs/__init__.py
+++ b/gymnasium/envs/__init__.py
@@ -449,7 +449,7 @@ register(
 # --- For shimmy compatibility
 def _raise_shimmy_error(*args: Any, **kwargs: Any):
     raise ImportError(
-        "To use the gym compatibility environments, run `pip install shimmy[gym-v21]` or `pip install shimmy[gym-v26]`"
+        'To use the gym compatibility environments, run `pip install "shimmy[gym-v21]"` or `pip install "shimmy[gym-v26]"`'
     )
 
 

--- a/gymnasium/envs/box2d/bipedal_walker.py
+++ b/gymnasium/envs/box2d/bipedal_walker.py
@@ -23,7 +23,7 @@ try:
     )
 except ImportError as e:
     raise DependencyNotInstalled(
-        "Box2D is not installed, run `pip install gymnasium[box2d]`"
+        'Box2D is not installed, run `pip install "gymnasium[box2d]"`'
     ) from e
 
 
@@ -628,7 +628,7 @@ class BipedalWalker(gym.Env, EzPickle):
             from pygame import gfxdraw
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[box2d]`"
+                'pygame is not installed, run `pip install "gymnasium[box2d]"`'
             ) from e
 
         if self.screen is None and self.render_mode == "human":

--- a/gymnasium/envs/box2d/car_dynamics.py
+++ b/gymnasium/envs/box2d/car_dynamics.py
@@ -19,7 +19,7 @@ try:
     from Box2D.b2 import fixtureDef, polygonShape, revoluteJointDef
 except ImportError as e:
     raise DependencyNotInstalled(
-        "Box2D is not installed, run `pip install gymnasium[box2d]`"
+        'Box2D is not installed, run `pip install "gymnasium[box2d]"`'
     ) from e
 
 

--- a/gymnasium/envs/box2d/car_racing.py
+++ b/gymnasium/envs/box2d/car_racing.py
@@ -17,7 +17,7 @@ try:
     from Box2D.b2 import contactListener, fixtureDef, polygonShape
 except ImportError as e:
     raise DependencyNotInstalled(
-        "Box2D is not installed, run `pip install gymnasium[box2d]`"
+        'Box2D is not installed, run `pip install "gymnasium[box2d]"`'
     ) from e
 
 try:
@@ -27,7 +27,7 @@ try:
     from pygame import gfxdraw
 except ImportError as e:
     raise DependencyNotInstalled(
-        "pygame is not installed, run `pip install gymnasium[box2d]`"
+        'pygame is not installed, run `pip install "gymnasium[box2d]"`'
     ) from e
 
 

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -24,7 +24,7 @@ try:
     )
 except ImportError as e:
     raise DependencyNotInstalled(
-        "Box2D is not installed, run `pip install gymnasium[box2d]`"
+        'Box2D is not installed, run `pip install "gymnasium[box2d]"`'
     ) from e
 
 
@@ -683,7 +683,7 @@ class LunarLander(gym.Env, EzPickle):
             from pygame import gfxdraw
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[box2d]`"
+                'pygame is not installed, run `pip install "gymnasium[box2d]"`'
             ) from e
 
         if self.screen is None and self.render_mode == "human":

--- a/gymnasium/envs/classic_control/acrobot.py
+++ b/gymnasium/envs/classic_control/acrobot.py
@@ -298,7 +298,7 @@ class AcrobotEnv(Env):
             from pygame import gfxdraw
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic-control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic-control]"`'
             ) from e
 
         if self.screen is None:

--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -265,7 +265,7 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
             from pygame import gfxdraw
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic-control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic-control]"`'
             ) from e
 
         if self.screen is None:
@@ -528,7 +528,7 @@ class CartPoleVectorEnv(VectorEnv):
             from pygame import gfxdraw
         except ImportError:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic_control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             )
 
         if self.screens is None:

--- a/gymnasium/envs/classic_control/continuous_mountain_car.py
+++ b/gymnasium/envs/classic_control/continuous_mountain_car.py
@@ -212,7 +212,7 @@ class Continuous_MountainCarEnv(gym.Env):
             from pygame import gfxdraw
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic-control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             ) from e
 
         if self.screen is None:

--- a/gymnasium/envs/classic_control/mountain_car.py
+++ b/gymnasium/envs/classic_control/mountain_car.py
@@ -187,7 +187,7 @@ class MountainCarEnv(gym.Env):
             from pygame import gfxdraw
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic-control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             ) from e
 
         if self.screen is None:

--- a/gymnasium/envs/classic_control/pendulum.py
+++ b/gymnasium/envs/classic_control/pendulum.py
@@ -187,7 +187,7 @@ class PendulumEnv(gym.Env):
             from pygame import gfxdraw
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic-control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             ) from e
 
         if self.screen is None:

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -13,8 +13,7 @@ try:
     import mujoco
 except ImportError as e:
     raise error.DependencyNotInstalled(
-        "Could not import mujoco"
-        "(HINT: you need to install mujoco, run `pip install gymnasium[mujoco]`.)"
+        'MuJoCo is not installed, run `pip install "gymnasium[mujoco]"`'
     ) from e
 
 

--- a/gymnasium/envs/phys2d/cartpole.py
+++ b/gymnasium/envs/phys2d/cartpole.py
@@ -145,7 +145,7 @@ class CartPoleFunctional(
             from pygame import gfxdraw
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic-control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             ) from e
         screen, clock = render_state
 
@@ -217,7 +217,7 @@ class CartPoleFunctional(
             import pygame
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic-control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             ) from e
 
         pygame.init()
@@ -232,7 +232,7 @@ class CartPoleFunctional(
             import pygame
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic-control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             ) from e
         pygame.display.quit()
         pygame.quit()

--- a/gymnasium/envs/phys2d/pendulum.py
+++ b/gymnasium/envs/phys2d/pendulum.py
@@ -117,7 +117,7 @@ class PendulumFunctional(
             from pygame import gfxdraw
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic-control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             ) from e
         screen, clock, last_u = render_state
 
@@ -191,7 +191,7 @@ class PendulumFunctional(
             import pygame
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic-control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             ) from e
 
         pygame.init()
@@ -210,7 +210,7 @@ class PendulumFunctional(
             import pygame
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic-control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             ) from e
         pygame.display.quit()
         pygame.quit()

--- a/gymnasium/envs/tabular/blackjack.py
+++ b/gymnasium/envs/tabular/blackjack.py
@@ -353,7 +353,7 @@ class BlackjackFunctional(
             import pygame
         except ImportError:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic_control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             )
 
         rng = seeding.np_random(0)[0]
@@ -377,7 +377,7 @@ class BlackjackFunctional(
             import pygame
         except ImportError:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[toy_text]`"
+                'pygame is not installed, run `pip install "gymnasium[toy_text]"`'
             )
         screen, dealer_top_card_value_str, dealer_top_card_suit = render_state
 
@@ -483,7 +483,7 @@ class BlackjackFunctional(
             import pygame
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic_control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             ) from e
         pygame.display.quit()
         pygame.quit()

--- a/gymnasium/envs/tabular/cliffwalking.py
+++ b/gymnasium/envs/tabular/cliffwalking.py
@@ -218,7 +218,7 @@ class CliffWalkingFunctional(
             import pygame
         except ImportError:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[classic_control]`"
+                'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             )
 
         cell_size = (60, 60)
@@ -302,7 +302,7 @@ class CliffWalkingFunctional(
             import pygame
         except ImportError:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[toy_text]`"
+                'pygame is not installed, run `pip install "gymnasium[toy_text]"`'
             )
         (
             window_surface,
@@ -349,7 +349,7 @@ class CliffWalkingFunctional(
             import pygame
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[toy-text]`"
+                'pygame is not installed, run `pip install "gymnasium[toy-text]"`'
             ) from e
         pygame.display.quit()
         pygame.quit()

--- a/gymnasium/envs/toy_text/blackjack.py
+++ b/gymnasium/envs/toy_text/blackjack.py
@@ -238,7 +238,7 @@ class BlackjackEnv(gym.Env):
             import pygame
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[toy-text]`"
+                'pygame is not installed, run `pip install "gymnasium[toy-text]"`'
             ) from e
 
         player_sum, dealer_card_value, usable_ace = self._get_obs()

--- a/gymnasium/envs/toy_text/cliffwalking.py
+++ b/gymnasium/envs/toy_text/cliffwalking.py
@@ -211,7 +211,7 @@ class CliffWalkingEnv(Env):
             import pygame
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[toy-text]`"
+                'pygame is not installed, run `pip install "gymnasium[toy-text]"`'
             ) from e
         if self.window_surface is None:
             pygame.init()

--- a/gymnasium/envs/toy_text/frozen_lake.py
+++ b/gymnasium/envs/toy_text/frozen_lake.py
@@ -343,7 +343,7 @@ class FrozenLakeEnv(Env):
             import pygame
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[toy-text]`"
+                'pygame is not installed, run `pip install "gymnasium[toy-text]"`'
             ) from e
 
         if self.window_surface is None:

--- a/gymnasium/envs/toy_text/taxi.py
+++ b/gymnasium/envs/toy_text/taxi.py
@@ -328,7 +328,7 @@ class TaxiEnv(Env):
             import pygame  # dependency to pygame only if rendering with human
         except ImportError as e:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[toy-text]`"
+                'pygame is not installed, run `pip install "gymnasium[toy-text]"`'
             ) from e
 
         if self.window is None:

--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -18,7 +18,7 @@ try:
     from pygame.event import Event
 except ImportError as e:
     raise gym.error.DependencyNotInstalled(
-        "pygame is not installed, run `pip install gymnasium[classic-control]`"
+        'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
     ) from e
 
 try:
@@ -27,7 +27,7 @@ try:
     matplotlib.use("TkAgg")
     import matplotlib.pyplot as plt
 except ImportError:
-    logger.warn("matplotlib is not installed, run `pip install gymnasium[other]`")
+    logger.warn('matplotlib is not installed, run `pip install "gymnasium[other]"`')
     matplotlib, plt = None, None
 
 
@@ -358,7 +358,7 @@ class PlayPlot:
 
         if plt is None:
             raise DependencyNotInstalled(
-                "matplotlib is not installed, run `pip install gymnasium[other]`"
+                'matplotlib is not installed, run `pip install "gymnasium[other]"`'
             )
 
         num_plots = len(self.plot_names)
@@ -411,6 +411,6 @@ class PlayPlot:
 
         if plt is None:
             raise DependencyNotInstalled(
-                "matplotlib is not installed, run `pip install gymnasium[other]`"
+                'matplotlib is not installed, run `pip install "gymnasium[other]"`'
             )
         plt.pause(0.000001)

--- a/gymnasium/utils/save_video.py
+++ b/gymnasium/utils/save_video.py
@@ -12,7 +12,7 @@ try:
     from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
 except ImportError as e:
     raise gym.error.DependencyNotInstalled(
-        "moviepy is not installed, run `pip install moviepy`"
+        'moviepy is not installed, run `pip install "gymnasium[other]"`'
     ) from e
 
 

--- a/gymnasium/wrappers/atari_preprocessing.py
+++ b/gymnasium/wrappers/atari_preprocessing.py
@@ -90,7 +90,7 @@ class AtariPreprocessing(gym.Wrapper, gym.utils.RecordConstructorArgs):
             import cv2  # noqa: F401
         except ImportError:
             raise gym.error.DependencyNotInstalled(
-                "opencv-python package not installed, run `pip install gymnasium[other]` to get dependencies for atari"
+                'opencv-python package not installed, run `pip install "gymnasium[other]"` to get dependencies for atari'
             )
 
         assert frame_skip > 0

--- a/gymnasium/wrappers/jax_to_numpy.py
+++ b/gymnasium/wrappers/jax_to_numpy.py
@@ -18,7 +18,7 @@ try:
     import jax.numpy as jnp
 except ImportError:
     raise DependencyNotInstalled(
-        "Jax is not installed therefore cannot call `numpy_to_jax`, run `pip install gymnasium[jax]`"
+        'Jax is not installed therefore cannot call `numpy_to_jax`, run `pip install "gymnasium[jax]"`'
     )
 
 __all__ = ["JaxToNumpy", "jax_to_numpy", "numpy_to_jax"]
@@ -145,7 +145,7 @@ class JaxToNumpy(
         """
         if jnp is None:
             raise DependencyNotInstalled(
-                "jax is not installed, run `pip install gymnasium[jax]`"
+                'Jax is not installed, run `pip install "gymnasium[jax]"`'
             )
         gym.utils.RecordConstructorArgs.__init__(self)
         gym.Wrapper.__init__(self, env)

--- a/gymnasium/wrappers/jax_to_torch.py
+++ b/gymnasium/wrappers/jax_to_torch.py
@@ -26,7 +26,7 @@ try:
     from jax import dlpack as jax_dlpack
 except ImportError:
     raise DependencyNotInstalled(
-        "Jax is not installed therefore cannot call `torch_to_jax`, run `pip install gymnasium[jax]`"
+        'Jax is not installed therefore cannot call `torch_to_jax`, run `pip install "gymnasium[jax]"`'
     )
 
 try:
@@ -36,7 +36,7 @@ try:
     Device = Union[str, torch.device]
 except ImportError:
     raise DependencyNotInstalled(
-        "Torch is not installed therefore cannot call `torch_to_jax`, run `pip install torch`"
+        'Torch is not installed therefore cannot call `torch_to_jax`, run `pip install "gymnasium[torch]"`'
     )
 
 

--- a/gymnasium/wrappers/numpy_to_torch.py
+++ b/gymnasium/wrappers/numpy_to_torch.py
@@ -19,7 +19,7 @@ try:
     Device = Union[str, torch.device]
 except ImportError:
     raise DependencyNotInstalled(
-        "Torch is not installed therefore cannot call `torch_to_numpy`, run `pip install torch`"
+        'Torch is not installed therefore cannot call `torch_to_numpy`, run `pip install "gymnasium[torch]"`'
     )
 
 

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -302,7 +302,7 @@ class RecordVideo(
             import moviepy  # noqa: F401
         except ImportError as e:
             raise error.DependencyNotInstalled(
-                "MoviePy is not installed, run `pip install moviepy`"
+                'MoviePy is not installed, run `pip install "gymnasium[other]"`'
             ) from e
 
     def _capture_frame(self):
@@ -397,7 +397,7 @@ class RecordVideo(
                 from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
             except ImportError as e:
                 raise error.DependencyNotInstalled(
-                    "MoviePy is not installed, run `pip install moviepy`"
+                    'MoviePy is not installed, run `pip install "gymnasium[other]"`'
                 ) from e
 
             clip = ImageSequenceClip(self.recorded_frames, fps=self.frames_per_sec)
@@ -510,7 +510,7 @@ class HumanRendering(
             import pygame
         except ImportError:
             raise DependencyNotInstalled(
-                "pygame is not installed, run `pip install gymnasium[box2d]`"
+                'pygame is not installed, run `pip install "gymnasium[box2d]"`'
             )
         if self.env.render_mode == "rgb_array_list":
             last_rgb_array = self.env.render()

--- a/gymnasium/wrappers/transform_observation.py
+++ b/gymnasium/wrappers/transform_observation.py
@@ -377,7 +377,7 @@ class ResizeObservation(
             import cv2
         except ImportError as e:
             raise DependencyNotInstalled(
-                "opencv (cv2) is not installed, run `pip install gymnasium[other]`"
+                'opencv (cv2) is not installed, run `pip install "gymnasium[other]"`'
             ) from e
 
         self.shape: Final[tuple[int, int]] = tuple(shape)

--- a/gymnasium/wrappers/vector/jax_to_numpy.py
+++ b/gymnasium/wrappers/vector/jax_to_numpy.py
@@ -37,7 +37,7 @@ class JaxToNumpy(VectorWrapper):
         """
         if jnp is None:
             raise DependencyNotInstalled(
-                "jax is not installed, run `pip install gymnasium[jax]`"
+                'Jax is not installed, run `pip install "gymnasium[jax]"`'
             )
         super().__init__(env)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 # Update dependencies in `all` if any are added or removed
-atari = ["shimmy[atari] >=0.1.0,<1.0"]
-accept-rom-license = ["autorom[accept-rom-license] ~=0.4.2"]
+atari = ["ale_py >= 0.8"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
@@ -45,13 +44,8 @@ mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]         # kept for backward compatibility
 jax = ["jax >=0.4.0", "jaxlib >=0.4.0", "flax >= 0.5.0"]
-other = [
-    "lz4 >=3.1.0",
-    "opencv-python >=3.0",
-    "matplotlib >=3.0",
-    "moviepy >=1.0.0",
-    "torch >=1.0.0",
-]
+torch = ["torch >=1.0.0"]
+other = ["moviepy >=1.0.0", "matplotlib >=3.0", "opencv-python >=3.0"]
 all = [
     # All dependencies above except accept-rom-license
     # NOTE: No need to manually remove the duplicates, setuptools automatically does that.
@@ -65,7 +59,7 @@ all = [
     "pygame >=2.1.3",
     # mujoco-py
     "mujoco-py >=2.1,<2.2",
-    "cython<3",
+    "cython <3",
     # mujoco
     "mujoco >=2.1.5",
     "imageio >=2.14.1",
@@ -75,17 +69,17 @@ all = [
     "jax >=0.4.0",
     "jaxlib >=0.4.0",
     "flax >= 0.5.0",
+    # torch
+    "torch >=1.0.0",
     # other
-    "lz4 >=3.1.0",
     "opencv-python >=3.0",
     "matplotlib >=3.0",
     "moviepy >=1.0.0",
-    "torch >=1.0.0",
 ]
 testing = [
     "pytest ==7.1.3",
-    "scipy >= 1.7.3",
-    "dill>=0.3.7",
+    "scipy >=1.7.3",
+    "dill >=0.3.7",
 ]
 
 [project.urls]


### PR DESCRIPTION
# Description

Inspired by https://github.com/conda-forge/gymnasium-feedstock/pull/36, this PR looks the requirement list again and updates it, adding a `torch` group to mean that users running `pip install gymnasium[other]` doesn't install torch.

Also, updates pip install instructions using groups to use quotes as without it this causes issues for macos users 
