### PR TITLE
improving ImportError for Box2D

### DIFF
--- a/gymnasium/envs/box2d/bipedal_walker.py
+++ b/gymnasium/envs/box2d/bipedal_walker.py
@@ -23,7 +23,7 @@ try:
     )
 except ImportError as e:
     raise DependencyNotInstalled(
-        'Box2D is not installed, run `pip install "gymnasium[box2d]"`'
+        'Box2D is not installed, you can install it run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
     ) from e
 
 

--- a/gymnasium/envs/box2d/bipedal_walker.py
+++ b/gymnasium/envs/box2d/bipedal_walker.py
@@ -23,7 +23,7 @@ try:
     )
 except ImportError as e:
     raise DependencyNotInstalled(
-        'Box2D is not installed, you can install it run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
+        'Box2D is not installed, you can install it by run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
     ) from e
 
 

--- a/gymnasium/envs/box2d/car_dynamics.py
+++ b/gymnasium/envs/box2d/car_dynamics.py
@@ -19,7 +19,7 @@ try:
     from Box2D.b2 import fixtureDef, polygonShape, revoluteJointDef
 except ImportError as e:
     raise DependencyNotInstalled(
-        'Box2D is not installed, run `pip install "gymnasium[box2d]"`'
+        'Box2D is not installed, you can install it run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
     ) from e
 
 

--- a/gymnasium/envs/box2d/car_dynamics.py
+++ b/gymnasium/envs/box2d/car_dynamics.py
@@ -19,7 +19,7 @@ try:
     from Box2D.b2 import fixtureDef, polygonShape, revoluteJointDef
 except ImportError as e:
     raise DependencyNotInstalled(
-        'Box2D is not installed, you can install it run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
+        'Box2D is not installed, you can install it by run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
     ) from e
 
 

--- a/gymnasium/envs/box2d/car_racing.py
+++ b/gymnasium/envs/box2d/car_racing.py
@@ -17,7 +17,7 @@ try:
     from Box2D.b2 import contactListener, fixtureDef, polygonShape
 except ImportError as e:
     raise DependencyNotInstalled(
-        'Box2D is not installed, you can install it run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
+        'Box2D is not installed, you can install it by run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
     ) from e
 
 try:

--- a/gymnasium/envs/box2d/car_racing.py
+++ b/gymnasium/envs/box2d/car_racing.py
@@ -17,7 +17,7 @@ try:
     from Box2D.b2 import contactListener, fixtureDef, polygonShape
 except ImportError as e:
     raise DependencyNotInstalled(
-        'Box2D is not installed, run `pip install "gymnasium[box2d]"`'
+        'Box2D is not installed, you can install it run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
     ) from e
 
 try:

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -24,7 +24,7 @@ try:
     )
 except ImportError as e:
     raise DependencyNotInstalled(
-        'Box2D is not installed, you can install it run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
+        'Box2D is not installed, you can install it by run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
     ) from e
 
 

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -24,7 +24,7 @@ try:
     )
 except ImportError as e:
     raise DependencyNotInstalled(
-        'Box2D is not installed, run `pip install "gymnasium[box2d]"`'
+        'Box2D is not installed, you can install it run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
     ) from e
 
 


### PR DESCRIPTION
# Description

Since the hint for installing swig was already added to the docs in #683 to fix #662 (and many other like #988 #881 #948 #892 #735 #662 ...), I would like to improve the ImportError message.

By replacing the error message from
```python
'Box2D is not installed, run `pip install "gymnasium[box2d]"`'
```
to
```python
'Box2D is not installed, you can install it by run `pip install swig` followed by `pip install "gymnasium[box2d]"`'
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
