### PR TITLE
Update `env.model.nbvh` for mujoco>=3.1.4

### DIFF
--- a/tests/envs/mujoco/test_mujoco_v5.py
+++ b/tests/envs/mujoco/test_mujoco_v5.py
@@ -593,8 +593,12 @@ def test_model_object_count(version: str):
         assert env.model.nv == 11
         assert env.model.nu == 7
         assert env.model.nbody == 13
-        if mujoco.__version__ >= "3.1.2":
+        if mujoco.__version__ >= "3.1.4":
+            assert env.model.nbvh == 7
+        elif mujoco.__version__ >= "3.1.2":
             assert env.model.nbvh == 8
+        else:
+            assert env.model.nbvh == 18
         assert env.model.njnt == 11
         assert env.model.ngeom == 21
         assert env.model.ntendon == 0


### PR DESCRIPTION
# Description

Mujoco == 3.1.4 caused the CI to fail due to the updated test. 
In reporting this to mujoco, they say this is just an unreported value 
https://github.com/google-deepmind/mujoco/issues/1589

Therefore, updating for mujoco >= 3.1.4
