### PR TITLE
Fixed `wrappers.vector.RecordEpisodeStatistics` episode length computation from new autoreset api

### DIFF
--- a/tests/wrappers/vector/test_record_episode_statistics.py
+++ b/tests/wrappers/vector/test_record_episode_statistics.py
@@ -35,7 +35,7 @@ def test_record_episode_statistics(num_envs, env_id="CartPole-v1", num_steps=100
     assert data_equivalence(wrapper_vector_obs, vector_wrapper_obs)
     assert data_equivalence(wrapper_vector_info, vector_wrapper_info)
 
-    for _ in range(num_steps):
+    for t in range(1, num_steps + 1):
         action = wrapper_vector_env.action_space.sample()
         (
             wrapper_vector_obs,
@@ -52,20 +52,22 @@ def test_record_episode_statistics(num_envs, env_id="CartPole-v1", num_steps=100
             vector_wrapper_info,
         ) = vector_wrapper_env.step(action)
 
-        data_equivalence(wrapper_vector_obs, vector_wrapper_obs)
-        data_equivalence(wrapper_vector_reward, vector_wrapper_reward)
-        data_equivalence(wrapper_vector_terminated, vector_wrapper_terminated)
-        data_equivalence(wrapper_vector_truncated, vector_wrapper_truncated)
+        assert data_equivalence(wrapper_vector_obs, vector_wrapper_obs)
+        assert data_equivalence(wrapper_vector_reward, vector_wrapper_reward)
+        assert data_equivalence(wrapper_vector_terminated, vector_wrapper_terminated)
+        assert data_equivalence(wrapper_vector_truncated, vector_wrapper_truncated)
 
         if "episode" in wrapper_vector_info:
-            assert "episode" in vector_wrapper_info
-
             wrapper_vector_time = wrapper_vector_info["episode"].pop("t")
             vector_wrapper_time = vector_wrapper_info["episode"].pop("t")
             assert wrapper_vector_time.shape == vector_wrapper_time.shape
             assert wrapper_vector_time.dtype == vector_wrapper_time.dtype
 
-        data_equivalence(wrapper_vector_info, vector_wrapper_info)
+            vector_wrapper_info["episode"].pop("_l")
+            vector_wrapper_info["episode"].pop("_r")
+            vector_wrapper_info["episode"].pop("_t")
+
+        assert data_equivalence(wrapper_vector_info, vector_wrapper_info)
 
     wrapper_vector_env.close()
     vector_wrapper_env.close()


### PR DESCRIPTION
# Description

Fixed wrappers.vector.RecordEpisodeStatistics episode length computation.

Fixes #1017

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
