### PR TITLE
Fix missing `raise`.

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -161,7 +161,7 @@ class EnvSpec:
 
         for key, value in env_spec.items():
             if callable(value):
-                ValueError(
+                raise ValueError(
                     f"Callable found in {spec_name} for {key} attribute with value={value}. Currently, Gymnasium does not support serialising callables."
                 )
 

--- a/tests/envs/registration/test_spec.py
+++ b/tests/envs/registration/test_spec.py
@@ -93,3 +93,18 @@ def test_spec_default_lookups():
 
     assert gym.spec("test/TestEnv") is not None
     del gym.registry["test/TestEnv"]
+
+
+def test_check_can_jsonify():
+    def no_entry_point():
+        pass
+
+    gym.register(id="test/TestEnv-v0", entry_point=no_entry_point)
+    with pytest.raises(
+        ValueError,
+        match="^Callable found in test/TestEnv-v0 for entry_point attribute "
+        "with value=<.*>. Currently, Gymnasium does not support "
+        "serialising callables.$",
+    ):
+        gym.spec("test/TestEnv-v0").to_json()
+    del gym.registry["test/TestEnv-v0"]


### PR DESCRIPTION
# Description

While forking the `.envs.registration` module for another project, I noticed that the check in `EnvSpec._check_can_jsonify()` doesn't actually do anything due to a missing `raise`.

Fixes #1030

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Please attach before and after screenshots of the change if applicable.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
