### PR TITLE
doc(FrozenLake_tuto): update policy exploitation logic to handle variable sets of maximum Q-values

### DIFF
--- a/docs/tutorials/training_agents/FrozenLake_tuto.py
+++ b/docs/tutorials/training_agents/FrozenLake_tuto.py
@@ -161,12 +161,10 @@ class EpsilonGreedy:
         # Exploitation (taking the biggest Q-value for this state)
         else:
             # Break ties randomly
-            # If all actions are the same for this state we choose a random one
-            # (otherwise `np.argmax()` would always take the first one)
-            if np.all(qtable[state, :]) == qtable[state, 0]:
-                action = action_space.sample()
-            else:
-                action = np.argmax(qtable[state, :])
+            # Find the indices where the Q-value equals the maximum value
+            # Choose a random action from the indices where the Q-value is maximum
+            max_ids = np.where(qtable[state, :] == max(qtable[state, :]))[0]
+            action = rng.choice(max_ids)
         return action
 
 


### PR DESCRIPTION
# Description

Small change to the logic in the `docs/tutorial/FrozenLake_tuto.py`, the existing exploitation logic only randomly chooses an action if all actions have the same q-value. Whereas it's possible for a subset of actions to have a maximum q-value.

Updating the logic to retrieve an index of q-values which are equal to the max value, and then randomly selecting an action to take.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
