### PR TITLE
Add Buffalo-gym to external environments

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -173,8 +173,7 @@ EV2Gym is a fully customizable and easily configurable environment for Electric 
 ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.29.1-blue)
 ![GitHub stars](https://img.shields.io/github/stars/foreverska/buffalo-gym)
 
-Buffalo-Gym is a Multi-Armed Bandit (MAB) gymnasium built primarily to assist in debugging RL implementations.  MABs are often easy to reason about what the agent is learning and if it is learning correctly.  Buffalo-gym encompases Bandits, Contextual bandits and contextual bandits with aliasing.
-
+Buffalo-Gym is a Multi-Armed Bandit (MAB) gymnasium built primarily to assist in debugging RL implementations. MABs are often easy to reason about what the agent is learning and whether it is correct. Buffalo-gym encompasses Bandits, Contextual bandits, and contextual bandits with aliasing.
 ## Third-Party Environments using Gym
 
 There are a large number of third-party environments using various versions of [Gym](https://github.com/openai/gym).

--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -168,6 +168,13 @@ tmrl is a distributed framework for training Deep Reinforcement Learning AIs in 
 
 EV2Gym is a fully customizable and easily configurable environment for Electric Vehicle (EV) smart charging simulations on a small and large scale. Also, includes non-RL baseline implementations such as mathematical programming, model predictive control, and heuristics.
 
+### [Buffalo-Gym: Multi-Armed Bandit Gymnasium](https://github.com/foreverska/buffalo-gym)
+
+![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.29.1-blue)
+![GitHub stars](https://img.shields.io/github/stars/foreverska/buffalo-gym)
+
+Buffalo-Gym is a Multi-Armed Bandit (MAB) gymnasium built primarily to assist in debugging RL implementations.  MABs are often easy to reason about what the agent is learning and if it is learning correctly.  Buffalo-gym encompases Bandits, Contextual bandits and contextual bandits with aliasing.
+
 ## Third-Party Environments using Gym
 
 There are a large number of third-party environments using various versions of [Gym](https://github.com/openai/gym).


### PR DESCRIPTION
Adding Buffalo-Gym to external environments

# Description

Buffalo-gym is a MAB environment and I would appreciate if it was added to the external environments list.

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
