### PR TITLE
Add pause option to play to allow turn based games

### DIFF
--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -156,8 +156,9 @@ def play(
     noop: ActType = 0,
     wait_on_player: bool = False,
 ):
-    """Allows the user to play the environment using a keyboard.  If playing in a turn-based environment,
-    set wait_on_player to True.
+    """Allows the user to play the environment using a keyboard.
+
+    If playing in a turn-based environment, set wait_on_player to True.
 
     Args:
         env: Environment to use for playing.

--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -154,7 +154,7 @@ def play(
     keys_to_action: dict[tuple[str | int, ...] | str | int, ActType] | None = None,
     seed: int | None = None,
     noop: ActType = 0,
-    pause: bool = False,
+    wait_on_player: bool = False,
 ):
     """Allows the user to play the environment using a keyboard.
 
@@ -205,7 +205,7 @@ def play(
             If ``None``, default ``key_to_action`` mapping for that environment is used, if provided.
         seed: Random seed used when resetting the environment. If None, no seed is used.
         noop: The action used when no key input has been entered, or the entered key combination is unknown.
-        pause: Play should wait for a user action
+        wait_on_player: Play should wait for a user action
 
     Example:
         >>> import gymnasium as gym
@@ -285,7 +285,7 @@ def play(
         if done:
             done = False
             obs = env.reset(seed=seed)
-        elif pause is False or len(game.pressed_keys) > 0:
+        elif wait_on_player is False or len(game.pressed_keys) > 0:
             action = key_code_to_action.get(tuple(sorted(game.pressed_keys)), noop)
             prev_obs = obs
             obs, rew, terminated, truncated, info = env.step(action)

--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -154,6 +154,7 @@ def play(
     keys_to_action: dict[tuple[str | int, ...] | str | int, ActType] | None = None,
     seed: int | None = None,
     noop: ActType = 0,
+    pause: bool = False,
 ):
     """Allows the user to play the environment using a keyboard.
 
@@ -204,6 +205,7 @@ def play(
             If ``None``, default ``key_to_action`` mapping for that environment is used, if provided.
         seed: Random seed used when resetting the environment. If None, no seed is used.
         noop: The action used when no key input has been entered, or the entered key combination is unknown.
+        pause: Play should wait for a user action
 
     Example:
         >>> import gymnasium as gym
@@ -283,7 +285,7 @@ def play(
         if done:
             done = False
             obs = env.reset(seed=seed)
-        else:
+        elif pause is False or len(game.pressed_keys) > 0:
             action = key_code_to_action.get(tuple(sorted(game.pressed_keys)), noop)
             prev_obs = obs
             obs, rew, terminated, truncated, info = env.step(action)

--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -156,7 +156,8 @@ def play(
     noop: ActType = 0,
     wait_on_player: bool = False,
 ):
-    """Allows the user to play the environment using a keyboard.
+    """Allows the user to play the environment using a keyboard.  If playing in a turn-based environment,
+    set wait_on_player to True.
 
     Args:
         env: Environment to use for playing.


### PR DESCRIPTION
# Description

Added new option to play which requires the user to provide an input to move the environment forward.  Defaults to False to not break existing implementations.

Fixes #802 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
