### PR TITLE
Add shape check to MultiDiscrete __eq__ (#1044)

### DIFF
--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -207,6 +207,7 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
         return bool(
             isinstance(other, MultiDiscrete)
             and self.dtype == other.dtype
+            and self.shape == other.shape
             and np.all(self.nvec == other.nvec)
             and np.all(self.start == other.start)
         )

--- a/tests/spaces/test_multidiscrete.py
+++ b/tests/spaces/test_multidiscrete.py
@@ -157,6 +157,26 @@ def test_multidiscrete_start_contains():
     assert [13, 23, 34] not in space
 
 
+def test_multidiscrete_equality():
+    # Check if two spaces are equivalent.
+    space_a = MultiDiscrete(nvec=[2, 3, 4], start=[0, 0, 1])
+
+    space_b = MultiDiscrete(nvec=[2, 3, 4], start=[0, 0, 1])
+    assert space_a == space_b
+
+    space_b = MultiDiscrete(nvec=[2, 4, 3], start=[0, 0, 1])
+    assert space_a != space_b
+
+    space_b = MultiDiscrete(nvec=[2, 3, 4], start=[1, 0, 1])
+    assert space_a != space_b
+
+    space_b = MultiDiscrete(nvec=[2, 3, 4], start=[0, 1, 1])
+    assert space_a != space_b
+
+    space_b = MultiDiscrete(nvec=[2, 3, 4, 2], start=[1, 0, 0, 0])
+    assert space_a != space_b
+
+
 def test_space_legacy_pickling():
     """Test the legacy pickle of Discrete that is missing the `start` parameter."""
     # Test that start is corrected passed


### PR DESCRIPTION
# Description

The `__eq__` method in the MultiDiscrete space needs to also check the shape of nvec before the equivalence check. If the shapes are not the same, numpy will throw a ValueError saying operands could not be broadcast together.

The fix here is to simply include a check of the shape before the nvec equivalence check.

Fixes #1044 

I included a handful of tests for checking if MultiDiscrete spaces are equivalent or not. Including a test with different shaped nvecs that would have errored before these changes.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
