### PR TITLE
output edge_space in edge_space assert instead of node_space

### DIFF
--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -71,7 +71,7 @@ class Graph(Space[GraphInstance]):
         if edge_space is not None:
             assert isinstance(
                 edge_space, (Box, Discrete)
-            ), f"Values of the edge_space should be instances of None Box or Discrete, got {type(node_space)}"
+            ), f"Values of the edge_space should be instances of None Box or Discrete, got {type(edge_space)}"
 
         self.node_space = node_space
         self.edge_space = edge_space


### PR DESCRIPTION
# Description

Minor fix to have the proper space in the assertion fail message. Must have been a copy paste error.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
