### PR TITLE
Update Atari install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 # Update dependencies in `all` if any are added or removed
-atari = ["ale_py >= 0.8"]
+atari = ["ale_py >= 0.9"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
@@ -50,7 +50,7 @@ all = [
     # All dependencies above except accept-rom-license
     # NOTE: No need to manually remove the duplicates, setuptools automatically does that.
     # atari
-    "shimmy[atari] >=0.1.0,<1.0",
+    "ale_py >= 0.9",
     # box2d
     "box2d-py ==2.3.5",
     "pygame >=2.1.3",


### PR DESCRIPTION
# Description

With ale-py updated to `>=0.9` to support Gymnasium natively (instead of through shimmy). 
This PR updates the pyproject to reflect this 