### PR TITLE
mujoco_py_env: Only raise an exception if MuJocoPyEnv class is actually used

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_py_env.py
+++ b/gymnasium/envs/mujoco/mujoco_py_env.py
@@ -12,11 +12,9 @@ from gymnasium.spaces import Space
 try:
     import mujoco_py
 except ImportError as e:
-    raise error.DependencyNotInstalled(
-        "Could not import mujoco_py, which is needed for MuJoCo environments older than V4",
-        "You could either use a newer version of the environments, or install the (deprecated) mujoco-py package"
-        "following the instructions on their GitHub page.",
-    ) from e
+    MUJOCO_PY_IMPORT_ERROR = e
+else:
+    MUJOCO_PY_IMPORT_ERROR = None
 
 
 # NOTE: duplication of analogous code in mujoco_env.py
@@ -214,6 +212,14 @@ class MuJocoPyEnv(BaseMujocoPyEnv):
         camera_id: Optional[int] = None,
         camera_name: Optional[str] = None,
     ):
+        if MUJOCO_PY_IMPORT_ERROR is not None:
+            raise error.DependencyNotInstalled(
+                f"{MUJOCO_PY_IMPORT_ERROR}. "
+                "Could not import mujoco_py, which is needed for MuJoCo environments older than V4",
+                "You could either use a newer version of the environments, or install the (deprecated) mujoco-py package"
+                "following the instructions on their GitHub page.",
+            )
+
         logger.deprecation(
             "This version of the mujoco environments depends "
             "on the mujoco-py bindings, which are no longer maintained "


### PR DESCRIPTION
# Description

Before https://github.com/Farama-Foundation/Gymnasium/pull/934 just running `from gymnasium.envs.mujoco import MuJocoPyEnv` did not resulted in a `error.DependencyNotInstalled` exception, but the expection was only raised when `MuJocoPyEnv.__init__` constructor was called. 

Instead after  https://github.com/Farama-Foundation/Gymnasium/pull/934  just calling `from gymnasium.envs.mujoco.mujoco_py_env import MuJocoPyEnv` results in a `error.DependencyNotInstalled` exception, that I guess create an hard error during test collection.

This result in an hard error when collecting tests in https://github.com/conda-forge/gymnasium-feedstock/pull/36, where `mujoco_py` is not available. Note that there is a similar change in https://github.com/Farama-Foundation/Gymnasium/pull/934 related to `mujoco` module itself, but that is less problematic as it a maintained library, differently from `mujoco_py`.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Not relevant.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
