### PR TITLE
Fix RescaleObservation on Windows

### DIFF
--- a/gymnasium/wrappers/transform_observation.py
+++ b/gymnasium/wrappers/transform_observation.py
@@ -517,9 +517,14 @@ class RescaleObservation(
         self.max_obs = max_obs
 
         # Imagine the x-axis between the old Box and the y-axis being the new Box
+        # float128 is not available everywhere
+        try:
+            high_low_diff_dtype = np.float128
+        except AttributeError:
+            high_low_diff_dtype = np.float64
         high_low_diff = np.array(
-            env.observation_space.high, dtype=np.float128
-        ) - np.array(env.observation_space.low, dtype=np.float128)
+            env.observation_space.high, dtype=high_low_diff_dtype
+        ) - np.array(env.observation_space.low, dtype=high_low_diff_dtype)
         gradient = np.array(
             (max_obs - min_obs) / high_low_diff, dtype=env.observation_space.dtype
         )


### PR DESCRIPTION
# Description

`np.float128` is not available on all platforms (in particular is missing on Windows). This PR uses `np.float128` on the platforms in which it is available, but fallbacks to `np.float64` if `np.float128` is not available.

Fix https://github.com/conda-forge/gymnasium-feedstock/pull/36#issuecomment-2125356983 .

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
