### PR TITLE
Fix test_dict_info_to_list test on Windows

### DIFF
--- a/tests/wrappers/vector/test_dict_info_to_list.py
+++ b/tests/wrappers/vector/test_dict_info_to_list.py
@@ -60,9 +60,13 @@ def test_update_info():
         "_e": np.array([True]),
     }
     _, list_info = env.reset(options=vector_infos)
+
+    # The return dtype of np.array([0]) is platform dependent
+    np_array_int_default_dtype = np.array([0]).dtype.type
+
     expected_list_info = [
         {
-            "a": np.int64(0),
+            "a": np_array_int_default_dtype(0),
             "b": np.float64(0.0),
             "c": None,
             "d": np.zeros((2,)),
@@ -90,21 +94,21 @@ def test_update_info():
     _, list_info = env.reset(options=vector_infos)
     expected_list_info = [
         {
-            "a": np.int64(0),
+            "a": np_array_int_default_dtype(0),
             "b": np.float64(0.0),
             "c": None,
             "d": np.zeros((2,)),
             "e": Discrete(1),
         },
         {
-            "a": np.int64(1),
+            "a": np_array_int_default_dtype(1),
             "b": np.float64(1.0),
             "c": None,
             "d": np.zeros((2,)),
             "e": Discrete(2),
         },
         {
-            "a": np.int64(2),
+            "a": np_array_int_default_dtype(2),
             "b": np.float64(2.0),
             "c": None,
             "d": np.zeros((2,)),
@@ -134,7 +138,7 @@ def test_update_info():
     }
     _, list_info = env.reset(options=vector_infos)
     expected_list_info = [
-        {"a": np.int64(1), "b": np.float64(1.0)},
+        {"a": np_array_int_default_dtype(1), "b": np.float64(1.0)},
         {"c": None, "d": np.zeros((2,))},
         {"e": Discrete(3)},
     ]
@@ -156,8 +160,11 @@ def test_update_info():
     }
     _, list_info = env.reset(options=vector_infos)
     expected_list_info = [
-        {"episode": {"a": np.int64(1), "b": np.float64(1.0)}},
-        {"episode": {"a": np.int64(2), "b": np.float64(2.0)}, "a": np.int64(1)},
-        {"a": np.int64(2)},
+        {"episode": {"a": np_array_int_default_dtype(1), "b": np.float64(1.0)}},
+        {
+            "episode": {"a": np_array_int_default_dtype(2), "b": np.float64(2.0)},
+            "a": np_array_int_default_dtype(1),
+        },
+        {"a": np_array_int_default_dtype(2)},
     ]
     assert data_equivalence(list_info, expected_list_info)


### PR DESCRIPTION
# Description

The dtype value of a np.array created from a list of integers is platform dependent, i.e.:
* `np.array([0]).dtype` is `np.int64` on Linux/macOS or
* `np.array([0]).dtype` is `np.int32` on Windows

The `test_dict_info_to_list` hardcodes the expectation that `np.array([0]).dtype` is `np.int64`, this PR fixes this to fix the `test_dict_info_to_list` test on Windows.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
