### PR TITLE
'HumanRendering' object has no attribute 'window' (#1078)

### DIFF
--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -472,16 +472,16 @@ class HumanRendering(
         gym.utils.RecordConstructorArgs.__init__(self)
         gym.Wrapper.__init__(self, env)
 
+        self.screen_size = None
+        self.window = None  # Has to be initialized before asserts, as self.window is used in auto close
+        self.clock = None
+
         assert (
             self.env.render_mode in self.ACCEPTED_RENDER_MODES
         ), f"Expected env.render_mode to be one of {self.ACCEPTED_RENDER_MODES} but got '{env.render_mode}'"
         assert (
             "render_fps" in self.env.metadata
         ), "The base environment must specify 'render_fps' to be used with the HumanRendering wrapper"
-
-        self.screen_size = None
-        self.window = None
-        self.clock = None
 
         if "human" not in self.metadata["render_modes"]:
             self.metadata = deepcopy(self.env.metadata)

--- a/gymnasium/wrappers/vector/rendering.py
+++ b/gymnasium/wrappers/vector/rendering.py
@@ -31,17 +31,17 @@ class HumanRendering(VectorWrapper):
         """
         VectorWrapper.__init__(self, env)
 
+        self.screen_size = screen_size
+        self.scaled_subenv_size, self.num_rows, self.num_cols = None, None, None
+        self.window = None  # Has to be initialized before asserts, as self.window is used in auto close
+        self.clock = None
+
         assert (
             self.env.render_mode in self.ACCEPTED_RENDER_MODES
         ), f"Expected env.render_mode to be one of {self.ACCEPTED_RENDER_MODES} but got '{env.render_mode}'"
         assert (
             "render_fps" in self.env.metadata
         ), "The base environment must specify 'render_fps' to be used with the HumanRendering wrapper"
-
-        self.screen_size = screen_size
-        self.scaled_subenv_size, self.num_rows, self.num_cols = None, None, None
-        self.window = None
-        self.clock = None
 
         if "human" not in self.metadata["render_modes"]:
             self.metadata = deepcopy(self.env.metadata)


### PR DESCRIPTION
# Description

Place initialization before asserts to avoid exit/close code to access uninitialized instance variables.

Fixes # (1078)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
