### PR TITLE
Cliffwalking should terminate when running into cliff

### DIFF
--- a/gymnasium/envs/toy_text/cliffwalking.py
+++ b/gymnasium/envs/toy_text/cliffwalking.py
@@ -10,7 +10,6 @@ from gymnasium import Env, spaces
 from gymnasium.envs.toy_text.utils import categorical_sample
 from gymnasium.error import DependencyNotInstalled
 
-
 UP = 0
 RIGHT = 1
 DOWN = 2
@@ -164,7 +163,7 @@ class CliffWalkingEnv(Env):
         new_position = self._limit_coordinates(new_position).astype(int)
         new_state = np.ravel_multi_index(tuple(new_position), self.shape)
         if self._cliff[tuple(new_position)]:
-            return [(1.0, self.start_state_index, -100, False)]
+            return [(1.0, self.start_state_index, -100, True)]
 
         terminal_state = (self.shape[0] - 1, self.shape[1] - 1)
         is_terminated = tuple(new_position) == terminal_state


### PR DESCRIPTION
# Description

The Cliffwalking environment as inspired from Richard and Sutton's RL book does not currently terminate when the agent walks into the Cliff. However, this is not the intended behaviour as outlined by Sutton. Running into the cliff should be considered a terminal state with a -100 reward.

I know this to be the case because I tried re-creating the graphs in the RL book. Only by terminating at the cliff can I reproduce the results by Sutton.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
