### PR TITLE
Check the determinism of `env.reset(seed=42); env.reset()`

### DIFF
--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -91,33 +91,51 @@ def check_reset_seed_determinism(env: gym.Env):
             assert (
                 env.unwrapped._np_random is not None
             ), "Expects the random number generator to have been generated given a seed was passed to reset. Most likely the environment reset function does not call `super().reset(seed=seed)`."
-            seed_123_rng = deepcopy(env.unwrapped._np_random)
-
-            obs_2, info = env.reset(seed=123)
+            seed_123_rng_1 = deepcopy(env.unwrapped._np_random)
+            
+            obs_2, info = env.reset()
             assert (
                 obs_2 in env.observation_space
+            ), "The observation returned by `env.reset()` is not within the observation space."
+
+            obs_3, info = env.reset(seed=123)
+            assert (
+                obs_3 in env.observation_space
             ), "The observation returned by `env.reset(seed=123)` is not within the observation space."
+            seed_123_rng_3 = deepcopy(env.unwrapped._np_random)
+
+            obs_4, info = env.reset()
+            assert (
+                obs_4 in env.observation_space
+            ), "The observation returned by `env.reset()` is not within the observation space."
+
             if env.spec is not None and env.spec.nondeterministic is False:
                 assert data_equivalence(
-                    obs_1, obs_2
+                    obs_1, obs_3
                 ), "Using `env.reset(seed=123)` is non-deterministic as the observations are not equivalent."
-                if not data_equivalence(obs_1, obs_2, exact=True):
+                assert data_equivalence(
+                    obs_2, obs_4
+                ), "Using `env.reset(seed=123)` then `env.reset()` is non-deterministic as the observations are not equivalent."
+                if not data_equivalence(obs_1, obs_3, exact=True):
                     logger.warn(
                         "Using `env.reset(seed=123)` observations are not equal although similar."
                     )
+                if not data_equivalence(obs_2, obs_4, exact=True):
+                    logger.warn(
+                        "Using `env.reset(seed=123)` then `env.reset()` observations are not equal although similar."
+                    )
 
             assert (
-                env.unwrapped._np_random.bit_generator.state
-                == seed_123_rng.bit_generator.state
+                seed_123_rng_1.bit_generator.state == seed_123_rng_3.bit_generator.state
             ), "Most likely the environment reset function does not call `super().reset(seed=seed)` as the random generates are not same when the same seeds are passed to `env.reset`."
 
-            obs_3, info = env.reset(seed=456)
+            obs_5, info = env.reset(seed=456)
             assert (
-                obs_3 in env.observation_space
+                obs_5 in env.observation_space
             ), "The observation returned by `env.reset(seed=456)` is not within the observation space."
             assert (
                 env.unwrapped._np_random.bit_generator.state
-                != seed_123_rng.bit_generator.state
+                != seed_123_rng_1.bit_generator.state
             ), "Most likely the environment reset function does not call `super().reset(seed=seed)` as the random number generators are not different when different seeds are passed to `env.reset`."
 
         except TypeError as e:

--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -92,7 +92,7 @@ def check_reset_seed_determinism(env: gym.Env):
                 env.unwrapped._np_random is not None
             ), "Expects the random number generator to have been generated given a seed was passed to reset. Most likely the environment reset function does not call `super().reset(seed=seed)`."
             seed_123_rng_1 = deepcopy(env.unwrapped._np_random)
-            
+
             obs_2, info = env.reset()
             assert (
                 obs_2 in env.observation_space

--- a/tests/testing_env.py
+++ b/tests/testing_env.py
@@ -20,7 +20,7 @@ def basic_reset_func(
 ) -> tuple[ObsType, dict]:
     """A basic reset function that will pass the environment check using random actions from the observation space."""
     super(GenericTestEnv, self).reset(seed=seed)
-    self.observation_space.seed(seed)
+    self.observation_space.seed(self.np_random_seed)
     return self.observation_space.sample(), {"options": options}
 
 

--- a/tests/utils/test_env_checker.py
+++ b/tests/utils/test_env_checker.py
@@ -70,7 +70,7 @@ def _super_reset_fixed(self, seed=None, options=None):
     return self.observation_space.sample(), {}
 
 
-def _reset_default_seed(self: GenericTestEnv, seed="Error", options=None):
+def _reset_default_seed(self: GenericTestEnv, seed=23, options=None):
     super(GenericTestEnv, self).reset(seed=seed)
     self.observation_space._np_random = (  # pyright: ignore [reportPrivateUsage]
         self.np_random
@@ -104,7 +104,7 @@ def _reset_default_seed(self: GenericTestEnv, seed="Error", options=None):
         [
             UserWarning,
             _reset_default_seed,
-            "The default seed argument in reset should be `None`, otherwise the environment will by default always be deterministic. Actual default: Error",
+            "The default seed argument in reset should be `None`, otherwise the environment will by default always be deterministic. Actual default: 23",
         ],
     ],
 )


### PR DESCRIPTION
# Description

Fixes #1084 (see the issue for the description)

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation 

-> No need, already documented

- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works -> 

-> No, but catching the non-determinism of `env.reset` was not part of the test, so I let this for further improvement coverage.
You can still check that the new feature works with the code provided in #1084 (the error is now catched by the env checker):

```log
Traceback (most recent call last):
  File "/Users/quentingallouedec/Gymnasium/t.py", line 32, in <module>
    check_env(gym.make("MyEnv-v0"))  # Passes but:
  File "/Users/quentingallouedec/Gymnasium/gymnasium/utils/env_checker.py", line 412, in check_env
    check_reset_seed_determinism(env)
  File "/Users/quentingallouedec/Gymnasium/gymnasium/utils/env_checker.py", line 116, in check_reset_seed_determinism
    assert data_equivalence(
AssertionError: Using `env.reset(seed=123)` then `env.reset()` is non-deterministic as the observations are not equivalent.
```


- [x] New and existing unit tests pass locally with my changes

