### PR TITLE
Fix wrappers tutorial link

### DIFF
--- a/gymnasium/wrappers/__init__.py
+++ b/gymnasium/wrappers/__init__.py
@@ -43,7 +43,7 @@ Such wrappers can be easily implemented by inheriting from :class:`gymnasium.Act
 :class:`gymnasium.ObservationWrapper`, or :class:`gymnasium.RewardWrapper` and implementing the respective transformation.
 If you need a wrapper to do more complicated tasks, you can inherit from the :class:`gymnasium.Wrapper` class directly.
 
-If you'd like to implement your own custom wrapper, check out `the corresponding tutorial <../../tutorials/implementing_custom_wrappers>`_.
+If you'd like to implement your own custom wrapper, check out `the corresponding tutorial <../../tutorials/gymnasium_basics/implementing_custom_wrappers>`_.
 """
 
 # pyright: reportUnsupportedDunderAll=false


### PR DESCRIPTION
# Description

A small fix to the broken link when clicking on "<ins>the corresponding tutorial</ins>" at the end of [Wrappers section](https://gymnasium.farama.org/api/wrappers/#wrappers). I didn't add an explicit issue for this.

## Type of change

- [x] Documentation only change (no code changed)
- [x] This change requires a documentation update

### Screenshots

After clicking <ins>the corresponding tutorial</ins> at the end of [Wrappers](https://gymnasium.farama.org/api/wrappers/#wrappers):

| Before | After |
| ------ | ----- |
| ![before](https://github.com/Farama-Foundation/Gymnasium/assets/56790921/7ec5d256-9ae8-48f4-aa9b-962dbe136455) | ![after](https://github.com/Farama-Foundation/Gymnasium/assets/56790921/38a9ea2c-9280-42ae-b879-6015e91ce5ee) |

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
