### PR TITLE
Fix PyGame settings

### DIFF
--- a/gymnasium/__init__.py
+++ b/gymnasium/__init__.py
@@ -20,6 +20,7 @@ from gymnasium.envs.registration import (
     VectorizeMode,
     register_envs,
 )
+from gymnasium import spaces, utils, vector, wrappers, error, logger, functional
 
 # Initializing pygame initializes audio connections through SDL. SDL uses alsa by default on all Linux systems
 # SDL connecting to alsa frequently create these giant lists of warnings every time you import an environment using
@@ -35,8 +36,7 @@ if sys.platform.startswith("linux"):
 os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"
 
 # necessary for `envs.__init__` which registers all gymnasium environments and loads plugins
-from gymnasium import envs
-from gymnasium import spaces, utils, vector, wrappers, error, logger, functional
+from gymnasium import envs  # noqa: E402
 
 
 __all__ = [

--- a/gymnasium/__init__.py
+++ b/gymnasium/__init__.py
@@ -21,6 +21,19 @@ from gymnasium.envs.registration import (
     register_envs,
 )
 
+# Initializing pygame initializes audio connections through SDL. SDL uses alsa by default on all Linux systems
+# SDL connecting to alsa frequently create these giant lists of warnings every time you import an environment using
+#   pygame
+# DSP is far more benign (and should probably be the default in SDL anyways)
+
+import os
+import sys
+
+if sys.platform.startswith("linux"):
+    os.environ["SDL_AUDIODRIVER"] = "dsp"
+
+os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"
+
 # necessary for `envs.__init__` which registers all gymnasium environments and loads plugins
 from gymnasium import envs
 from gymnasium import spaces, utils, vector, wrappers, error, logger, functional
@@ -54,20 +67,6 @@ __all__ = [
     "functional",
 ]
 __version__ = "1.0.0a2"
-
-
-# Initializing pygame initializes audio connections through SDL. SDL uses alsa by default on all Linux systems
-# SDL connecting to alsa frequently create these giant lists of warnings every time you import an environment using
-#   pygame
-# DSP is far more benign (and should probably be the default in SDL anyways)
-
-import os
-import sys
-
-if sys.platform.startswith("linux"):
-    os.environ["SDL_AUDIODRIVER"] = "dsp"
-
-os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"
 
 try:
     from farama_notifications import notifications


### PR DESCRIPTION
# Description

Some environments use PyGame as a default dependency, i.e. they import it on top of environment files instead of when needed as in Gymnasium envs (see for example MiniGrid https://github.com/Farama-Foundation/Minigrid/blob/master/minigrid/minigrid_env.py#L10). For this reason, the env settings for PyGame should be placed before importing the envs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] My changes generate no new warnings
