### PR TITLE
Update Atari documentation for 0.9.0

### DIFF
--- a/docs/_scripts/gen_atari_table.py
+++ b/docs/_scripts/gen_atari_table.py
@@ -1,20 +1,26 @@
 import itertools
 import json
 
+import ale_py
 import tabulate
-from ale_py.roms import utils as rom_utils
-from shimmy.utils.envs_configs import ALL_ATARI_GAMES
+from ale_py.registration import _rom_id_to_name
 from tqdm import tqdm
 
 import gymnasium
 
 
-# Necessary for v1.0.0 without ale-py gymnasium support
-# from shimmy import registration
-# registration._register_atari_envs()
+gymnasium.register_envs(ale_py)
 
+impossible_roms = {"maze_craze", "joust", "warlords", "combat"}
+ALL_ATARI_GAMES = {
+    env_spec.kwargs["game"]
+    for env_spec in gymnasium.registry.values()
+    if isinstance(env_spec.entry_point, str)
+    and "ale_py" in env_spec.entry_point
+    and env_spec.kwargs["game"] not in impossible_roms
+}
 
-# # Generate the list of all atari games on atari.md
+# Generate the list of all atari games on atari.md
 for rom_id in sorted(ALL_ATARI_GAMES):
     print(f"atari/{rom_id}")
 
@@ -54,7 +60,7 @@ headers = [
 rows = []
 
 for rom_id in tqdm(ALL_ATARI_GAMES):
-    env_name = rom_utils.rom_id_to_name(rom_id)
+    env_name = _rom_id_to_name(rom_id)
 
     env = gymnasium.make(f"ALE/{env_name}-v5").unwrapped
 
@@ -86,7 +92,7 @@ with open("atari-docs.json") as file:
     atari_data = json.load(file)
 
 for rom_id in tqdm(ALL_ATARI_GAMES):
-    env_name = rom_utils.rom_id_to_name(rom_id)
+    env_name = _rom_id_to_name(rom_id)
 
     env = gymnasium.make(f"ALE/{env_name}-v5").unwrapped
     if rom_id in atari_data:
@@ -128,7 +134,7 @@ initialization or by passing `full_action_space=True` to `gymnasium.make`."""
         [
             env_spec
             for env_spec in gymnasium.registry.values()
-            if env_name in env_spec.name and "shimmy" in env_spec.entry_point
+            if env_name in env_spec.name and "ale_py" in env_spec.entry_point
         ],
         key=lambda env_spec: f"{env_spec.version}{env_spec.name}",
     )

--- a/docs/environments/atari.md
+++ b/docs/environments/atari.md
@@ -121,13 +121,24 @@ atari/zaxxon
 
 Atari environments are simulated via the Arcade Learning Environment (ALE) [[1]](#1) through the Stella emulator.
 
-## AutoROM (installing the ROMs)
+```python
+import gymnasium as gym
+import ale_py
 
-ALE-py doesn't include the atari ROMs (`pip install gymnasium[atari]`) which are necessary to make any of the atari environments.
-To install the atari ROM, use `pip install gymnasium[accept-rom-license]` which will install AutoROM and download the ROMs, install them in the default location.
-In doing so, you agree to own a license to these Atari 2600 ROMs and agree to not distribution these ROMS.
+gym.register_envs(ale_py)
 
-It is possible to install the ROMs in an alternative location, [AutoROM](https://github.com/Farama-Foundation/AutoROM) has more information.
+env = gym.make("ALE/Pong-v5")
+# Optionally include the `gym.wrappers.AtariPreprocessing`
+
+obs, info = env.reset()
+episode_over = False
+while not episode_over:
+	action = env.action_space.sample()  # replace with your policy
+	obs, reward, terminated, truncated, info = env.step(action)
+
+	episode_over = terminated or truncated
+env.close()
+```
 
 ## Action Space
 

--- a/docs/environments/atari/adventure.md
+++ b/docs/environments/atari/adventure.md
@@ -87,6 +87,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/air_raid.md
+++ b/docs/environments/atari/air_raid.md
@@ -82,6 +82,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/alien.md
+++ b/docs/environments/atari/alien.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/amidar.md
+++ b/docs/environments/atari/amidar.md
@@ -87,6 +87,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/assault.md
+++ b/docs/environments/atari/assault.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/asterix.md
+++ b/docs/environments/atari/asterix.md
@@ -86,6 +86,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/asteroids.md
+++ b/docs/environments/atari/asteroids.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/atlantis.md
+++ b/docs/environments/atari/atlantis.md
@@ -87,6 +87,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/atlantis2.md
+++ b/docs/environments/atari/atlantis2.md
@@ -70,6 +70,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/backgammon.md
+++ b/docs/environments/atari/backgammon.md
@@ -71,6 +71,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/bank_heist.md
+++ b/docs/environments/atari/bank_heist.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/basic_math.md
+++ b/docs/environments/atari/basic_math.md
@@ -72,6 +72,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/battle_zone.md
+++ b/docs/environments/atari/battle_zone.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/beam_rider.md
+++ b/docs/environments/atari/beam_rider.md
@@ -86,6 +86,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/berzerk.md
+++ b/docs/environments/atari/berzerk.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/blackjack.md
+++ b/docs/environments/atari/blackjack.md
@@ -72,6 +72,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/bowling.md
+++ b/docs/environments/atari/bowling.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/boxing.md
+++ b/docs/environments/atari/boxing.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/breakout.md
+++ b/docs/environments/atari/breakout.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/carnival.md
+++ b/docs/environments/atari/carnival.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/casino.md
+++ b/docs/environments/atari/casino.md
@@ -72,6 +72,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/centipede.md
+++ b/docs/environments/atari/centipede.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/chopper_command.md
+++ b/docs/environments/atari/chopper_command.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/crazy_climber.md
+++ b/docs/environments/atari/crazy_climber.md
@@ -86,6 +86,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/crossbow.md
+++ b/docs/environments/atari/crossbow.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/darkchambers.md
+++ b/docs/environments/atari/darkchambers.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/defender.md
+++ b/docs/environments/atari/defender.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/demon_attack.md
+++ b/docs/environments/atari/demon_attack.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/donkey_kong.md
+++ b/docs/environments/atari/donkey_kong.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/double_dunk.md
+++ b/docs/environments/atari/double_dunk.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/earthworld.md
+++ b/docs/environments/atari/earthworld.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/elevator_action.md
+++ b/docs/environments/atari/elevator_action.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/enduro.md
+++ b/docs/environments/atari/enduro.md
@@ -86,6 +86,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/entombed.md
+++ b/docs/environments/atari/entombed.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/et.md
+++ b/docs/environments/atari/et.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/fishing_derby.md
+++ b/docs/environments/atari/fishing_derby.md
@@ -89,6 +89,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/flag_capture.md
+++ b/docs/environments/atari/flag_capture.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/freeway.md
+++ b/docs/environments/atari/freeway.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/frogger.md
+++ b/docs/environments/atari/frogger.md
@@ -72,6 +72,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/frostbite.md
+++ b/docs/environments/atari/frostbite.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/galaxian.md
+++ b/docs/environments/atari/galaxian.md
@@ -72,6 +72,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/gopher.md
+++ b/docs/environments/atari/gopher.md
@@ -86,6 +86,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/gravitar.md
+++ b/docs/environments/atari/gravitar.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/hangman.md
+++ b/docs/environments/atari/hangman.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/haunted_house.md
+++ b/docs/environments/atari/haunted_house.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/hero.md
+++ b/docs/environments/atari/hero.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/human_cannonball.md
+++ b/docs/environments/atari/human_cannonball.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/ice_hockey.md
+++ b/docs/environments/atari/ice_hockey.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/jamesbond.md
+++ b/docs/environments/atari/jamesbond.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/journey_escape.md
+++ b/docs/environments/atari/journey_escape.md
@@ -89,6 +89,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/kaboom.md
+++ b/docs/environments/atari/kaboom.md
@@ -72,6 +72,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/kangaroo.md
+++ b/docs/environments/atari/kangaroo.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/keystone_kapers.md
+++ b/docs/environments/atari/keystone_kapers.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/king_kong.md
+++ b/docs/environments/atari/king_kong.md
@@ -72,6 +72,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/klax.md
+++ b/docs/environments/atari/klax.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/koolaid.md
+++ b/docs/environments/atari/koolaid.md
@@ -73,6 +73,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/krull.md
+++ b/docs/environments/atari/krull.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/kung_fu_master.md
+++ b/docs/environments/atari/kung_fu_master.md
@@ -87,6 +87,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/laser_gates.md
+++ b/docs/environments/atari/laser_gates.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/lost_luggage.md
+++ b/docs/environments/atari/lost_luggage.md
@@ -73,6 +73,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/mario_bros.md
+++ b/docs/environments/atari/mario_bros.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/miniature_golf.md
+++ b/docs/environments/atari/miniature_golf.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/montezuma_revenge.md
+++ b/docs/environments/atari/montezuma_revenge.md
@@ -87,6 +87,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/mr_do.md
+++ b/docs/environments/atari/mr_do.md
@@ -74,6 +74,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/ms_pacman.md
+++ b/docs/environments/atari/ms_pacman.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/name_this_game.md
+++ b/docs/environments/atari/name_this_game.md
@@ -84,6 +84,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/othello.md
+++ b/docs/environments/atari/othello.md
@@ -74,6 +74,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/pacman.md
+++ b/docs/environments/atari/pacman.md
@@ -84,6 +84,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/phoenix.md
+++ b/docs/environments/atari/phoenix.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/pitfall.md
+++ b/docs/environments/atari/pitfall.md
@@ -90,6 +90,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/pitfall2.md
+++ b/docs/environments/atari/pitfall2.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/pong.md
+++ b/docs/environments/atari/pong.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/pooyan.md
+++ b/docs/environments/atari/pooyan.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/private_eye.md
+++ b/docs/environments/atari/private_eye.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/qbert.md
+++ b/docs/environments/atari/qbert.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/riverraid.md
+++ b/docs/environments/atari/riverraid.md
@@ -96,6 +96,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/road_runner.md
+++ b/docs/environments/atari/road_runner.md
@@ -95,6 +95,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/robotank.md
+++ b/docs/environments/atari/robotank.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/seaquest.md
+++ b/docs/environments/atari/seaquest.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/sir_lancelot.md
+++ b/docs/environments/atari/sir_lancelot.md
@@ -72,6 +72,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/skiing.md
+++ b/docs/environments/atari/skiing.md
@@ -84,6 +84,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/solaris.md
+++ b/docs/environments/atari/solaris.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/space_invaders.md
+++ b/docs/environments/atari/space_invaders.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/space_war.md
+++ b/docs/environments/atari/space_war.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/star_gunner.md
+++ b/docs/environments/atari/star_gunner.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/superman.md
+++ b/docs/environments/atari/superman.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/surround.md
+++ b/docs/environments/atari/surround.md
@@ -72,6 +72,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/tennis.md
+++ b/docs/environments/atari/tennis.md
@@ -88,6 +88,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/tetris.md
+++ b/docs/environments/atari/tetris.md
@@ -70,6 +70,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/tic_tac_toe_3d.md
+++ b/docs/environments/atari/tic_tac_toe_3d.md
@@ -74,6 +74,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/time_pilot.md
+++ b/docs/environments/atari/time_pilot.md
@@ -87,6 +87,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/trondead.md
+++ b/docs/environments/atari/trondead.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/turmoil.md
+++ b/docs/environments/atari/turmoil.md
@@ -74,6 +74,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/tutankham.md
+++ b/docs/environments/atari/tutankham.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/up_n_down.md
+++ b/docs/environments/atari/up_n_down.md
@@ -84,6 +84,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/venture.md
+++ b/docs/environments/atari/venture.md
@@ -87,6 +87,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/video_checkers.md
+++ b/docs/environments/atari/video_checkers.md
@@ -72,6 +72,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/video_chess.md
+++ b/docs/environments/atari/video_chess.md
@@ -74,6 +74,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/video_cube.md
+++ b/docs/environments/atari/video_cube.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/video_pinball.md
+++ b/docs/environments/atari/video_pinball.md
@@ -85,6 +85,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/wizard_of_wor.md
+++ b/docs/environments/atari/wizard_of_wor.md
@@ -86,6 +86,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/word_zapper.md
+++ b/docs/environments/atari/word_zapper.md
@@ -75,6 +75,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/yars_revenge.md
+++ b/docs/environments/atari/yars_revenge.md
@@ -87,6 +87,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/environments/atari/zaxxon.md
+++ b/docs/environments/atari/zaxxon.md
@@ -87,6 +87,6 @@ along with the default values.
 
 A thorough discussion of the intricate differences between the versions and configurations can be found in the general article on Atari environments.
 
-* v5: Stickiness was added back and stochastic frameskipping was removed. The environments are now in the "ALE" namespace.
+* v5: Stickiness was added back and stochastic frame-skipping was removed. The environments are now in the "ALE" namespace.
 * v4: Stickiness of actions was removed
 * v0: Initial versions release

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,3 +6,5 @@ git+https://github.com/Farama-Foundation/Celshast#egg=furo
 moviepy
 pygame
 sphinx_github_changelog
+ale_py
+tabulate

--- a/gymnasium/wrappers/atari_preprocessing.py
+++ b/gymnasium/wrappers/atari_preprocessing.py
@@ -36,9 +36,14 @@ class AtariPreprocessing(gym.Wrapper, gym.utils.RecordConstructorArgs):
     - Scale observation: Whether to scale the observation between [0, 1) or [0, 255), not scaled by default.
 
     Example:
-        >>> import gymnasium as gym # doctest: +SKIP
-        >>> env = gym.make("ALE/Adventure-v5") # doctest: +SKIP
-        >>> env = AtariPreprocessing(env, noop_max=10, frame_skip=0, screen_size=84, terminal_on_life_loss=True, grayscale_obs=False, grayscale_newaxis=False) # doctest: +SKIP
+        >>> import gymnasium as gym
+        >>> import ale_py
+        >>> gym.register_envs(ale_py)
+        >>> env = gym.make("ALE/Pong-v5", frameskip=1)
+        >>> env = AtariPreprocessing(env,
+        ...     noop_max=10, frame_skip=4, terminal_on_life_loss=True,
+        ...     screen_size=84, grayscale_obs=False, grayscale_newaxis=False
+        ... )
 
     Change logs:
      * Added in gym v0.12.2 (gym #1455)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 # Update dependencies in `all` if any are added or removed
-atari = ["ale_py >= 0.9"]
+atari = ["ale_py >=0.9"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
@@ -44,14 +44,14 @@ mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]       # kept for backward compa
 mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]         # kept for backward compatibility
-jax = ["jax >=0.4.0", "jaxlib >=0.4.0", "flax >= 0.5.0"]
+jax = ["jax >=0.4.0", "jaxlib >=0.4.0", "flax >=0.5.0"]
 torch = ["torch >=1.0.0"]
 other = ["moviepy >=1.0.0", "matplotlib >=3.0", "opencv-python >=3.0"]
 all = [
     # All dependencies above except accept-rom-license
     # NOTE: No need to manually remove the duplicates, setuptools automatically does that.
     # atari
-    "ale_py >= 0.9",
+    "ale_py >=0.9",
     # box2d
     "box2d-py ==2.3.5",
     "pygame >=2.1.3",
@@ -108,7 +108,6 @@ gymnasium = [
 # Linters and Test tools #######################################################
 
 [tool.black]
-safe = true
 
 [tool.isort]
 atomic = true
@@ -120,8 +119,8 @@ lines_after_imports = 2
 multi_line_output = 3
 
 [tool.pyright]
-include = ["gymnasium/**", "tests/**"]
-exclude = ["**/node_modules", "**/__pycache__"]
+include = ["gymnasium/**"]
+exclude = ["tests/**", "**/node_modules", "**/__pycache__"]
 strict = []
 
 typeCheckingMode = "basic"

--- a/tests/wrappers/test_atari_preprocessing.py
+++ b/tests/wrappers/test_atari_preprocessing.py
@@ -3,54 +3,20 @@
 import numpy as np
 import pytest
 
-from gymnasium.spaces import Box, Discrete
+import gymnasium as gym
 from gymnasium.wrappers import AtariPreprocessing
-from tests.testing_env import GenericTestEnv
 
 
-class AleTesting:
-    """A testing implementation for the ALE object in atari games."""
-
-    grayscale_obs_space = Box(low=0, high=255, shape=(210, 160), dtype=np.uint8, seed=1)
-    rgb_obs_space = Box(low=0, high=255, shape=(210, 160, 3), dtype=np.uint8, seed=1)
-
-    def lives(self) -> int:
-        """Returns the number of lives in the atari game."""
-        return 1
-
-    def getScreenGrayscale(self, buffer: np.ndarray):
-        """Updates the buffer with a random grayscale observation."""
-        buffer[...] = self.grayscale_obs_space.sample()
-
-    def getScreenRGB(self, buffer: np.ndarray):
-        """Updates the buffer with a random rgb observation."""
-        buffer[...] = self.rgb_obs_space.sample()
-
-
-class AtariTestingEnv(GenericTestEnv):
-    """A testing environment to replicate the atari (ale-py) environments."""
-
-    def __init__(self):
-        super().__init__(
-            observation_space=Box(
-                low=0, high=255, shape=(210, 160, 3), dtype=np.uint8, seed=1
-            ),
-            action_space=Discrete(3, seed=1),
-        )
-        self.ale = AleTesting()
-
-    def get_action_meanings(self):
-        """Returns the meanings of each of the actions available to the agent. First index must be 'NOOP'."""
-        return ["NOOP", "UP", "DOWN"]
+pytest.importorskip("ale_py")
 
 
 @pytest.mark.parametrize(
     "env, expected_obs_shape",
     [
-        (AtariTestingEnv(), (210, 160, 3)),
+        (gym.make("ALE/Pong-v5"), (210, 160, 3)),
         (
             AtariPreprocessing(
-                AtariTestingEnv(),
+                gym.make("ALE/Pong-v5"),
                 screen_size=84,
                 grayscale_obs=True,
                 frame_skip=1,
@@ -60,7 +26,7 @@ class AtariTestingEnv(GenericTestEnv):
         ),
         (
             AtariPreprocessing(
-                AtariTestingEnv(),
+                gym.make("ALE/Pong-v5"),
                 screen_size=84,
                 grayscale_obs=False,
                 frame_skip=1,
@@ -70,7 +36,7 @@ class AtariTestingEnv(GenericTestEnv):
         ),
         (
             AtariPreprocessing(
-                AtariTestingEnv(),
+                gym.make("ALE/Pong-v5"),
                 screen_size=84,
                 grayscale_obs=True,
                 frame_skip=1,
@@ -98,7 +64,7 @@ def test_atari_preprocessing_grayscale(env, expected_obs_shape):
 def test_atari_preprocessing_scale(grayscale, scaled, max_test_steps=10):
     # arbitrarily chosen number for stepping into env. and ensuring all observations are in the required range
     env = AtariPreprocessing(
-        AtariTestingEnv(),
+        gym.make("ALE/Pong-v5"),
         screen_size=84,
         grayscale_obs=grayscale,
         scale_obs=scaled,


### PR DESCRIPTION
# Description

With ale-py 0.9.0 release that include Gymnasium has the backend API and roms within the release, this PR updates the documentation to reflect these changes and the Atari preprocessing documentation