### PR TITLE
Update necessary-py.Dockerfile to pin the numpy version

### DIFF
--- a/bin/necessary-py.Dockerfile
+++ b/bin/necessary-py.Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get -y update \
 COPY . /usr/local/gymnasium/
 WORKDIR /usr/local/gymnasium/
 
+RUN pip install --upgrade "numpy>=1.21,<2.0"
 RUN pip install .[testing] --no-cache-dir
 
 ENTRYPOINT ["/usr/local/gymnasium/bin/docker_entrypoint"]


### PR DESCRIPTION
It seems that some CI workflows still have a problem with numpy 2.0 due to using a different dockerfile. This should hopefully handle that.