### PR TITLE
[Proposal] Default metadata in BaseMujocoEnv

### DIFF
--- a/gymnasium/envs/mujoco/ant_v4.py
+++ b/gymnasium/envs/mujoco/ant_v4.py
@@ -17,7 +17,7 @@ class AntEnv(MujocoEnv, utils.EzPickle):
             "rgb_array",
             "depth_array",
         ],
-        "render_fps": 20,
+        "render_fps": 30,
     }
 
     def __init__(

--- a/gymnasium/envs/mujoco/ant_v4.py
+++ b/gymnasium/envs/mujoco/ant_v4.py
@@ -17,7 +17,7 @@ class AntEnv(MujocoEnv, utils.EzPickle):
             "rgb_array",
             "depth_array",
         ],
-        "render_fps": 30,
+        "render_fps": 20,
     }
 
     def __init__(

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -88,7 +88,7 @@ class MujocoEnv(gym.Env):
                 "rgb_array",
                 "depth_array",
             ],
-            "render_fps": int(np.round(1.0 / self.dt))
+            "render_fps": int(np.round(1.0 / self.dt)),
         }
 
         if observation_space is not None:

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -90,8 +90,13 @@ class MujocoEnv(gym.Env):
 
         self.frame_skip = frame_skip
 
-        if "render_fps" not in self.metadata:
+        if "render_fps" in self.metadata:
+            assert (
+                int(np.round(1.0 / self.dt)) == self.metadata["render_fps"]
+            ), f'Expected value: {int(np.round(1.0 / self.dt))}, Actual value: {self.metadata["render_fps"]}'
+        else:
             self.metadata["render_fps"] = int(np.round(1.0 / self.dt))
+
 
         if observation_space is not None:
             self.observation_space = observation_space

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -37,14 +37,6 @@ def expand_model_path(model_path: str) -> str:
 class MujocoEnv(gym.Env):
     """Superclass for MuJoCo based environments."""
 
-    metadata = {
-        "render_modes": [
-            "human",
-            "rgb_array",
-            "depth_array",
-        ]
-    }
-
     def __init__(
         self,
         model_path: str,
@@ -90,14 +82,14 @@ class MujocoEnv(gym.Env):
 
         self.frame_skip = frame_skip
 
-        if "render_fps" in self.metadata:
-            assert (
-                int(np.round(1.0 / self.dt)) == self.metadata["render_fps"]
-            ), f'Expected value: {int(np.round(1.0 / self.dt))}, Actual value: {self.metadata["render_fps"]}'
-        else:
-            # Make a copy of the dictionary to avoid modifying the class variable
-            self.metadata = self.metadata.copy()
-            self.metadata["render_fps"] = int(np.round(1.0 / self.dt))
+        self.metadata = {
+            "render_modes": [
+                "human",
+                "rgb_array",
+                "depth_array",
+            ],
+            "render_fps": int(np.round(1.0 / self.dt))
+        }
 
         if observation_space is not None:
             self.observation_space = observation_space

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -82,15 +82,13 @@ class MujocoEnv(gym.Env):
 
         self.frame_skip = frame_skip
 
-        assert self.metadata["render_modes"] == [
-            "human",
-            "rgb_array",
-            "depth_array",
-        ], self.metadata["render_modes"]
-        if "render_fps" in self.metadata:
-            assert (
-                int(np.round(1.0 / self.dt)) == self.metadata["render_fps"]
-            ), f'Expected value: {int(np.round(1.0 / self.dt))}, Actual value: {self.metadata["render_fps"]}'
+        self.metadata["render_modes"] = [
+                    "human",
+                    "rgb_array",
+                    "depth_array",
+                ]
+        self.metadata["render_fps"] = int(np.round(1.0 / self.dt))
+
         if observation_space is not None:
             self.observation_space = observation_space
         self._set_action_space()

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -37,6 +37,14 @@ def expand_model_path(model_path: str) -> str:
 class MujocoEnv(gym.Env):
     """Superclass for MuJoCo based environments."""
 
+    metadata = {
+        "render_modes": [
+            "human",
+            "rgb_array",
+            "depth_array",
+        ]
+    }
+
     def __init__(
         self,
         model_path: str,
@@ -82,12 +90,8 @@ class MujocoEnv(gym.Env):
 
         self.frame_skip = frame_skip
 
-        self.metadata["render_modes"] = [
-                    "human",
-                    "rgb_array",
-                    "depth_array",
-                ]
-        self.metadata["render_fps"] = int(np.round(1.0 / self.dt))
+        if "render_fps" not in self.metadata:
+            self.metadata["render_fps"] = int(np.round(1.0 / self.dt))
 
         if observation_space is not None:
             self.observation_space = observation_space

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -95,6 +95,8 @@ class MujocoEnv(gym.Env):
                 int(np.round(1.0 / self.dt)) == self.metadata["render_fps"]
             ), f'Expected value: {int(np.round(1.0 / self.dt))}, Actual value: {self.metadata["render_fps"]}'
         else:
+            # Make a copy of the dictionary to avoid modifying the class variable
+            self.metadata = self.metadata.copy()
             self.metadata["render_fps"] = int(np.round(1.0 / self.dt))
 
         if observation_space is not None:

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -97,7 +97,6 @@ class MujocoEnv(gym.Env):
         else:
             self.metadata["render_fps"] = int(np.round(1.0 / self.dt))
 
-
         if observation_space is not None:
             self.observation_space = observation_space
         self._set_action_space()


### PR DESCRIPTION
# Description

The current code for BaseMujocoEnv requires the env metadata dictionary to have fixed, pre-specified values. While this may be useful for future API changes, it doesn't seem very useful at the moment.

Fixes #1059 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
