### PR TITLE
Fix non-used device argument in `to_torch` conversion

### DIFF
--- a/gymnasium/wrappers/jax_to_torch.py
+++ b/gymnasium/wrappers/jax_to_torch.py
@@ -119,9 +119,9 @@ def _jax_iterable_to_torch(
     if hasattr(value, "_make"):
         # namedtuple - underline used to prevent potential name conflicts
         # noinspection PyProtectedMember
-        return type(value)._make(jax_to_torch(v) for v in value)
+        return type(value)._make(jax_to_torch(v, device) for v in value)
     else:
-        return type(value)(jax_to_torch(v) for v in value)
+        return type(value)(jax_to_torch(v, device) for v in value)
 
 
 class JaxToTorch(gym.Wrapper, gym.utils.RecordConstructorArgs):

--- a/gymnasium/wrappers/numpy_to_torch.py
+++ b/gymnasium/wrappers/numpy_to_torch.py
@@ -94,9 +94,9 @@ def _numpy_iterable_to_torch(
     if hasattr(value, "_make"):
         # namedtuple - underline used to prevent potential name conflicts
         # noinspection PyProtectedMember
-        return type(value)._make(numpy_to_torch(v) for v in value)
+        return type(value)._make(numpy_to_torch(v, device) for v in value)
     else:
-        return type(value)(numpy_to_torch(v) for v in value)
+        return type(value)(numpy_to_torch(v, device) for v in value)
 
 
 class NumpyToTorch(gym.Wrapper, gym.utils.RecordConstructorArgs):


### PR DESCRIPTION
# Description

A small fix that propagates the `device` argument when converting from an _Iterable_ of `numpy` or `jax` objects to an _Iterable_ or `torch.Tensor`.

Fixes #1106 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

