### PR TITLE
naming returned values from step()

### DIFF
--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -230,7 +230,12 @@ class CartPoleEnv(gym.Env[np.ndarray, Union[int, np.ndarray]]):
         if self.render_mode == "human":
             self.render()
         # truncation=False as the time limit is handled by the `TimeLimit` wrapper added during `make`
-        return np.array(self.state, dtype=np.float32), reward, terminated, False, {}
+        # Suggestion: the output of this method gives me hell whenever I try to learn gym. Why not name the returned parameters?
+        # This could easily be done with a namedtuple:
+        # StepReturn = namedtuple("StepReturn", ["observation", "reward", "terminated", "truncated", "whatever_this_dict_is"])
+        # return StepReturn(np.array(self.state, dtype=np.float32), reward, terminated, False, {})
+        # Or even with a dict:
+        return { "observation": np.array(self.state, dtype=np.float32), "reward": reward, "terminated": terminated, "truncated": False, "whatever_this_dict_is": {}}
 
     def reset(
         self,


### PR DESCRIPTION
I've added a suggestion to name the values returned from step(), since whenever i try to learn gym I have tons of troubles with this method and it's returned values. The documentation at gymnasium.farama.org is good, but I still manage to get confused and hit walls. Besides, I believe self documenting code is way superior to documentation. I just don't know if there is any penalty to naming the values like I suggest here. If there is no, or if it is a negligible penalty, then will you please consider this for the sake of other head-bangers such as myself?