### PR TITLE
Add stacktrace reporting to `AsyncVectorEnv`

### DIFF
--- a/gymnasium/logger.py
+++ b/gymnasium/logger.py
@@ -1,41 +1,19 @@
 """Set of functions for logging messages."""
 
-import sys
 import warnings
 from typing import Optional, Type
 
 from gymnasium.utils import colorize
 
 
-DEBUG = 10
-INFO = 20
 WARN = 30
 ERROR = 40
-DISABLED = 50
 
 min_level = 30
 
 
 # Ensure DeprecationWarning to be displayed (#2685, #3059)
 warnings.filterwarnings("once", "", DeprecationWarning, module=r"^gymnasium\.")
-
-
-def set_level(level: int):
-    """Set logging threshold on current logger."""
-    global min_level
-    min_level = level
-
-
-def debug(msg: str, *args: object):
-    """Logs a debug message to the user."""
-    if min_level <= DEBUG:
-        print(f"DEBUG: {msg % args}", file=sys.stderr)
-
-
-def info(msg: str, *args: object):
-    """Logs an info message to the user."""
-    if min_level <= INFO:
-        print(f"INFO: {msg % args}", file=sys.stderr)
 
 
 def warn(
@@ -68,8 +46,4 @@ def deprecation(msg: str, *args: object):
 def error(msg: str, *args: object):
     """Logs an error message if min_level <= ERROR in red on the sys.stderr."""
     if min_level <= ERROR:
-        print(colorize(f"ERROR: {msg % args}", "red"), file=sys.stderr)
-
-
-# DEPRECATED:
-setLevel = set_level
+        warnings.warn(colorize(f"ERROR: {msg % args}", "red"), stacklevel=3)


### PR DESCRIPTION
# Description

Originally discussed in https://github.com/Farama-Foundation/Gymnasium/issues/182 with reminded in https://github.com/Farama-Foundation/Gymnasium/issues/1114 that the error reporting in `AsyncVectorEnv` is bad as the error occurs in another process. 
To solve this problem, previously the exception type and string were printed however the most important detail is the tracestack.
The problem is that the traceback object can't be passed back

Therefore, this PR converts the traceback to a string that can be passed back which is printed. 
Additionally, testing was added for this feature