### PR TITLE
Update Taxi environment documentation to clarify starting state definition

### DIFF
--- a/gymnasium/envs/toy_text/taxi.py
+++ b/gymnasium/envs/toy_text/taxi.py
@@ -96,7 +96,10 @@ class TaxiEnv(Env):
     This gives a total of 404 reachable discrete states.
 
     ## Starting State
-    The episode starts with the player in a random state.
+    The initial state is sampled uniformly from the possible states
+    where the passenger is neither at their destination nor inside the taxi.
+    There are 300 possible initial states: 25 taxi positions, 4 passenger locations (excluding inside the taxi)
+    and 3 destinations (excluding the passenger's current location).
 
     ## Rewards
     - -1 per step unless other reward is triggered.


### PR DESCRIPTION
# Description

Update the documentation to specify that the starting state is sampled uniformly over 300 states, thus excluding the 100 unreachable states and the 100 states where the passenger is already in the taxi.

Fixes #1115 

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.
N/A

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
