### PR TITLE
Add (A)syncVectorEnv support for sub-envs with different obs spaces

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -159,7 +159,7 @@ class AsyncVectorEnv(VectorEnv):
                     [env.observation_space for env in self.env_fns]
                 )
             else:
-                raise ValueError
+                raise ValueError("Need to pass in mode for batching observations")
         self.action_space = batch_space(self.single_action_space, self.num_envs)
 
         dummy_env.close()

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -744,7 +744,9 @@ def _async_worker(
                         (
                             (data[0] == observation_space)
                             or (
-                                np.any(
+                                hasattr(observation_space, "low")
+                                and hasattr(observation_space, "high")
+                                and np.any(
                                     np.all(observation_space.low == data[0].low, axis=1)
                                 )
                                 and np.any(

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -99,7 +99,7 @@ class AsyncVectorEnv(VectorEnv):
             ]
             | None
         ) = None,
-        observation_mode: str or Space = "same",
+        observation_mode: str | Space = "same",
     ):
         """Vectorized environment that runs multiple environments in parallel.
 
@@ -115,6 +115,9 @@ class AsyncVectorEnv(VectorEnv):
                 so for some environments you may want to have it set to ``False``.
             worker: If set, then use that worker in a subprocess instead of a default one.
                 Can be useful to override some inner vector env logic, for instance, how resets on termination or truncation are handled.
+            observation_mode: Defines how environment observation spaces should be batched. 'same' defines that there should be ``n`` copies of identical spaces.
+                'different' defines that there can be multiple observation spaces with the same length but different high/low values batched together. Passing a ``Space`` object
+                allows the user to set some custom observation space mode not covered by 'same' or 'different.'
 
         Warnings:
             worker is an advanced mode option. It provides a high degree of flexibility and a high chance
@@ -155,7 +158,8 @@ class AsyncVectorEnv(VectorEnv):
                 self.observation_space = batch_differing_spaces(
                     [env.observation_space for env in self.env_fns]
                 )
-
+            else:
+                raise ValueError
         self.action_space = batch_space(self.single_action_space, self.num_envs)
 
         dummy_env.close()

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -14,7 +14,7 @@ from typing import Any, Callable, Sequence
 
 import numpy as np
 
-from gymnasium import logger, Space
+from gymnasium import Space, logger
 from gymnasium.core import ActType, Env, ObsType, RenderFrame
 from gymnasium.error import (
     AlreadyPendingCallError,
@@ -33,6 +33,7 @@ from gymnasium.vector.utils import (
     read_from_shared_memory,
     write_to_shared_memory,
 )
+from gymnasium.vector.utils.batched_spaces import batch_differing_spaces
 from gymnasium.vector.vector_env import ArrayType, VectorEnv
 
 
@@ -98,7 +99,7 @@ class AsyncVectorEnv(VectorEnv):
             ]
             | None
         ) = None,
-        observation_mode: str or Space = 'same',
+        observation_mode: str or Space = "same",
     ):
         """Vectorized environment that runs multiple environments in parallel.
 
@@ -146,11 +147,11 @@ class AsyncVectorEnv(VectorEnv):
         if isinstance(observation_mode, Space):
             self.observation_space = observation_mode
         else:
-            if observation_mode == 'same':
+            if observation_mode == "same":
                 self.observation_space = batch_space(
                     self.single_observation_space, self.num_envs
                 )
-            elif observation_mode == 'different':
+            elif observation_mode == "different":
                 self.observation_space = batch_differing_spaces(
                     [env.observation_space for env in self.env_fns]
                 )

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -58,14 +58,16 @@ class SyncVectorEnv(VectorEnv):
         self,
         env_fns: Iterator[Callable[[], Env]] | Sequence[Callable[[], Env]],
         copy: bool = True,
-        observation_mode: str or Space = "same",
+        observation_mode: str | Space = "same",
     ):
         """Vectorized environment that serially runs multiple environments.
 
         Args:
             env_fns: iterable of callable functions that create the environments.
             copy: If ``True``, then the :meth:`reset` and :meth:`step` methods return a copy of the observations.
-
+            observation_mode: Defines how environment observation spaces should be batched. 'same' defines that there should be ``n`` copies of identical spaces.
+                'different' defines that there can be multiple observation spaces with the same length but different high/low values batched together. Passing a ``Space`` object
+                allows the user to set some custom observation space mode not covered by 'same' or 'different.'
         Raises:
             RuntimeError: If the observation space of some sub-environment does not match observation_space
                 (or, by default, the observation space of the first sub-environment).
@@ -100,6 +102,8 @@ class SyncVectorEnv(VectorEnv):
                 self.observation_space = batch_differing_spaces(
                     [env.observation_space for env in self.envs]
                 )
+            else:
+                raise ValueError
 
         self.action_space = batch_space(self.single_action_space, self.num_envs)
 

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -103,7 +103,7 @@ class SyncVectorEnv(VectorEnv):
                     [env.observation_space for env in self.envs]
                 )
             else:
-                raise ValueError
+                raise ValueError("Need to pass in mode for batching observations")
 
         self.action_space = batch_space(self.single_action_space, self.num_envs)
 

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -303,7 +303,9 @@ class SyncVectorEnv(VectorEnv):
         for env in self.envs:
             if not (env.observation_space == self.single_observation_space):
                 if not (
-                    np.any(
+                    hasattr(env.observation_space, "low")
+                    and hasattr(env.observation_space, "high")
+                    and np.any(
                         np.all(
                             env.observation_space.low
                             == self.single_observation_space.low,

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -10,6 +10,7 @@ import numpy as np
 from gymnasium import Env, Space
 from gymnasium.core import ActType, ObsType, RenderFrame
 from gymnasium.vector.utils import batch_space, concatenate, create_empty_array, iterate
+from gymnasium.vector.utils.batched_spaces import batch_differing_spaces
 from gymnasium.vector.vector_env import ArrayType, VectorEnv
 
 
@@ -57,7 +58,7 @@ class SyncVectorEnv(VectorEnv):
         self,
         env_fns: Iterator[Callable[[], Env]] | Sequence[Callable[[], Env]],
         copy: bool = True,
-        observation_mode: str or Space = 'same',
+        observation_mode: str or Space = "same",
     ):
         """Vectorized environment that serially runs multiple environments.
 
@@ -91,11 +92,11 @@ class SyncVectorEnv(VectorEnv):
         if isinstance(observation_mode, Space):
             self.observation_space = observation_mode
         else:
-            if observation_mode == 'same':
+            if observation_mode == "same":
                 self.observation_space = batch_space(
                     self.single_observation_space, self.num_envs
                 )
-            elif observation_mode == 'different':
+            elif observation_mode == "different":
                 self.observation_space = batch_differing_spaces(
                     [env.observation_space for env in self.envs]
                 )

--- a/gymnasium/vector/utils/batched_spaces.py
+++ b/gymnasium/vector/utils/batched_spaces.py
@@ -106,3 +106,36 @@ def _batch_differing_spaces_dict(spaces: list[Dict]):
 @batch_differing_spaces.register(OneOf)
 def _batch_spaces_undefined(spaces: list[Graph | Text | Sequence | OneOf]):
     return Tuple(spaces, seed=deepcopy(spaces[0].np_random))
+
+
+def all_spaces_have_same_shape(spaces):
+    """Check if all spaces have the same size."""
+    if not spaces:
+        return True  # An empty list is considered to have the same shape
+
+    def get_space_shape(space):
+        if isinstance(space, Box):
+            return space.shape
+        elif isinstance(space, Discrete):
+            return ()  # Discrete spaces are considered scalar
+        elif isinstance(space, Dict):
+            return tuple(get_space_shape(s) for s in space.spaces.values())
+        elif isinstance(space, Tuple):
+            return tuple(get_space_shape(s) for s in space.spaces)
+        else:
+            raise ValueError(f"Unsupported space type: {type(space)}")
+
+    first_shape = get_space_shape(spaces[0])
+    return all(get_space_shape(space) == first_shape for space in spaces[1:])
+
+
+def all_spaces_have_same_type(spaces):
+    """Check if all spaces have the same space type (Box, Discrete, etc)."""
+    if not spaces:
+        return True  # An empty list is considered to have the same type
+
+    # Get the type of the first space
+    first_type = type(spaces[0])
+
+    # Check if all spaces have the same type as the first one
+    return all(isinstance(space, first_type) for space in spaces)

--- a/gymnasium/vector/utils/batched_spaces.py
+++ b/gymnasium/vector/utils/batched_spaces.py
@@ -1,0 +1,105 @@
+from copy import deepcopy
+from functools import singledispatch
+
+import numpy as np
+import pytest
+
+from gymnasium import Space
+from gymnasium.spaces import (
+    Box,
+    Dict,
+    Discrete,
+    Graph,
+    MultiBinary,
+    MultiDiscrete,
+    OneOf,
+    Sequence,
+    Text,
+    Tuple,
+)
+from gymnasium.vector.utils import batch_space, iterate
+
+@singledispatch
+def batch_differing_spaces(spaces: list[Space]):
+    """Batch a Sequence of spaces that allows the subspaces to contain minor differences."""
+    assert len(spaces) > 0
+    assert all(isinstance(space, type(spaces[0])) for space in spaces)
+    assert type(spaces[0]) in batch_differing_spaces.registry
+
+    return batch_differing_spaces.dispatch(type(spaces[0]))(spaces)
+
+
+@batch_differing_spaces.register(Box)
+def _batch_differing_spaces_box(spaces: list[Box]):
+    assert all(spaces[0].dtype == space for space in spaces)
+
+    return Box(
+        low=np.array([space.low for space in spaces]),
+        high=np.array([space.high for space in spaces]),
+        dtype=spaces[0].dtype,
+        seed=deepcopy(spaces[0].np_random),
+    )
+
+
+@batch_differing_spaces.register(Discrete)
+def _batch_differing_spaces_discrete(spaces: list[Discrete]):
+    return MultiDiscrete(
+        nvec=np.array([space.n for space in spaces]),
+        start=np.array([space.start for space in spaces]),
+        seed=deepcopy(spaces[0].np_random),
+    )
+
+
+@batch_differing_spaces.register(MultiDiscrete)
+def _batch_differing_spaces_multi_discrete(spaces: list[MultiDiscrete]):
+    return Box(
+        low=np.array([space.start for space in spaces]),
+        high=np.array([space.start + space.nvec for space in spaces]) - 1,
+        dtype=spaces[0].dtype,
+        seed=deepcopy(spaces[0].np_random),
+    )
+
+
+@batch_differing_spaces.register(MultiBinary)
+def _batch_differing_spaces_multi_binary(spaces: list[MultiBinary]):
+    assert all(spaces[0].shape == space.shape for space in spaces)
+
+    return Box(
+        low=0,
+        high=1,
+        shape=(len(spaces),) + spaces[0].shape,
+        dtype=spaces[0].dtype,
+        seed=deepcopy(spaces[0].np_random),
+    )
+
+
+@batch_differing_spaces.register(Tuple)
+def _batch_differing_spaces_tuple(spaces: list[Tuple]):
+    return Tuple(
+        tuple(
+            batch_differing_spaces(subspaces)
+            for subspaces in zip(*[space.spaces for space in spaces])
+        ),
+        seed=deepcopy(spaces[0].np_random),
+    )
+
+
+@batch_differing_spaces.register(Dict)
+def _batch_differing_spaces_dict(spaces: list[Dict]):
+    assert all(spaces[0].keys() == space.keys() for space in spaces)
+
+    return Dict(
+        {
+            key: batch_differing_spaces([space[key] for space in spaces])
+            for key in spaces[0].keys()
+        },
+        seed=deepcopy(spaces[0].np_random),
+    )
+
+
+@batch_differing_spaces.register(Graph)
+@batch_differing_spaces.register(Text)
+@batch_differing_spaces.register(Sequence)
+@batch_differing_spaces.register(OneOf)
+def _batch_spaces_undefined(spaces: list[Graph | Text | Sequence | OneOf]):
+    return Tuple(spaces, seed=deepcopy(spaces[0].np_random))

--- a/gymnasium/vector/utils/batched_spaces.py
+++ b/gymnasium/vector/utils/batched_spaces.py
@@ -1,5 +1,7 @@
 """Batching support for Spaces of same type but possibly varying low/high values."""
 
+from __future__ import annotations
+
 from copy import deepcopy
 from functools import singledispatch
 
@@ -21,7 +23,7 @@ from gymnasium.spaces import (
 
 
 @singledispatch
-def batch_differing_spaces(spaces: "list[Space]"):
+def batch_differing_spaces(spaces: list[Space]):
     """Batch a Sequence of spaces that allows the subspaces to contain minor differences."""
     assert len(spaces) > 0
     assert all(isinstance(space, type(spaces[0])) for space in spaces)
@@ -31,7 +33,7 @@ def batch_differing_spaces(spaces: "list[Space]"):
 
 
 @batch_differing_spaces.register(Box)
-def _batch_differing_spaces_box(spaces: "list[Box]"):
+def _batch_differing_spaces_box(spaces: list[Box]):
     assert all(spaces[0].dtype == space for space in spaces)
 
     return Box(
@@ -43,7 +45,7 @@ def _batch_differing_spaces_box(spaces: "list[Box]"):
 
 
 @batch_differing_spaces.register(Discrete)
-def _batch_differing_spaces_discrete(spaces: "list[Discrete]"):
+def _batch_differing_spaces_discrete(spaces: list[Discrete]):
     return MultiDiscrete(
         nvec=np.array([space.n for space in spaces]),
         start=np.array([space.start for space in spaces]),
@@ -52,7 +54,7 @@ def _batch_differing_spaces_discrete(spaces: "list[Discrete]"):
 
 
 @batch_differing_spaces.register(MultiDiscrete)
-def _batch_differing_spaces_multi_discrete(spaces: "list[MultiDiscrete]"):
+def _batch_differing_spaces_multi_discrete(spaces: list[MultiDiscrete]):
     return Box(
         low=np.array([space.start for space in spaces]),
         high=np.array([space.start + space.nvec for space in spaces]) - 1,
@@ -62,7 +64,7 @@ def _batch_differing_spaces_multi_discrete(spaces: "list[MultiDiscrete]"):
 
 
 @batch_differing_spaces.register(MultiBinary)
-def _batch_differing_spaces_multi_binary(spaces: "list[MultiBinary]"):
+def _batch_differing_spaces_multi_binary(spaces: list[MultiBinary]):
     assert all(spaces[0].shape == space.shape for space in spaces)
 
     return Box(
@@ -75,7 +77,7 @@ def _batch_differing_spaces_multi_binary(spaces: "list[MultiBinary]"):
 
 
 @batch_differing_spaces.register(Tuple)
-def _batch_differing_spaces_tuple(spaces: "list[Tuple]"):
+def _batch_differing_spaces_tuple(spaces: list[Tuple]):
     return Tuple(
         tuple(
             batch_differing_spaces(subspaces)
@@ -86,7 +88,7 @@ def _batch_differing_spaces_tuple(spaces: "list[Tuple]"):
 
 
 @batch_differing_spaces.register(Dict)
-def _batch_differing_spaces_dict(spaces: "list[Dict]"):
+def _batch_differing_spaces_dict(spaces: list[Dict]):
     assert all(spaces[0].keys() == space.keys() for space in spaces)
 
     return Dict(
@@ -102,5 +104,5 @@ def _batch_differing_spaces_dict(spaces: "list[Dict]"):
 @batch_differing_spaces.register(Text)
 @batch_differing_spaces.register(Sequence)
 @batch_differing_spaces.register(OneOf)
-def _batch_spaces_undefined(spaces: "list[Graph | Text | Sequence | OneOf]"):
+def _batch_spaces_undefined(spaces: list[Graph | Text | Sequence | OneOf]):
     return Tuple(spaces, seed=deepcopy(spaces[0].np_random))

--- a/gymnasium/vector/utils/batched_spaces.py
+++ b/gymnasium/vector/utils/batched_spaces.py
@@ -21,7 +21,7 @@ from gymnasium.spaces import (
 
 
 @singledispatch
-def batch_differing_spaces(spaces: list[Space]):
+def batch_differing_spaces(spaces: "list[Space]"):
     """Batch a Sequence of spaces that allows the subspaces to contain minor differences."""
     assert len(spaces) > 0
     assert all(isinstance(space, type(spaces[0])) for space in spaces)
@@ -31,7 +31,7 @@ def batch_differing_spaces(spaces: list[Space]):
 
 
 @batch_differing_spaces.register(Box)
-def _batch_differing_spaces_box(spaces: list[Box]):
+def _batch_differing_spaces_box(spaces: "list[Box]"):
     assert all(spaces[0].dtype == space for space in spaces)
 
     return Box(
@@ -43,7 +43,7 @@ def _batch_differing_spaces_box(spaces: list[Box]):
 
 
 @batch_differing_spaces.register(Discrete)
-def _batch_differing_spaces_discrete(spaces: list[Discrete]):
+def _batch_differing_spaces_discrete(spaces: "list[Discrete]"):
     return MultiDiscrete(
         nvec=np.array([space.n for space in spaces]),
         start=np.array([space.start for space in spaces]),
@@ -52,7 +52,7 @@ def _batch_differing_spaces_discrete(spaces: list[Discrete]):
 
 
 @batch_differing_spaces.register(MultiDiscrete)
-def _batch_differing_spaces_multi_discrete(spaces: list[MultiDiscrete]):
+def _batch_differing_spaces_multi_discrete(spaces: "list[MultiDiscrete]"):
     return Box(
         low=np.array([space.start for space in spaces]),
         high=np.array([space.start + space.nvec for space in spaces]) - 1,
@@ -62,7 +62,7 @@ def _batch_differing_spaces_multi_discrete(spaces: list[MultiDiscrete]):
 
 
 @batch_differing_spaces.register(MultiBinary)
-def _batch_differing_spaces_multi_binary(spaces: list[MultiBinary]):
+def _batch_differing_spaces_multi_binary(spaces: "list[MultiBinary]"):
     assert all(spaces[0].shape == space.shape for space in spaces)
 
     return Box(
@@ -75,7 +75,7 @@ def _batch_differing_spaces_multi_binary(spaces: list[MultiBinary]):
 
 
 @batch_differing_spaces.register(Tuple)
-def _batch_differing_spaces_tuple(spaces: list[Tuple]):
+def _batch_differing_spaces_tuple(spaces: "list[Tuple]"):
     return Tuple(
         tuple(
             batch_differing_spaces(subspaces)
@@ -86,7 +86,7 @@ def _batch_differing_spaces_tuple(spaces: list[Tuple]):
 
 
 @batch_differing_spaces.register(Dict)
-def _batch_differing_spaces_dict(spaces: list[Dict]):
+def _batch_differing_spaces_dict(spaces: "list[Dict]"):
     assert all(spaces[0].keys() == space.keys() for space in spaces)
 
     return Dict(
@@ -102,5 +102,5 @@ def _batch_differing_spaces_dict(spaces: list[Dict]):
 @batch_differing_spaces.register(Text)
 @batch_differing_spaces.register(Sequence)
 @batch_differing_spaces.register(OneOf)
-def _batch_spaces_undefined(spaces: list[Graph | Text | Sequence | OneOf]):
+def _batch_spaces_undefined(spaces: "list[Graph | Text | Sequence | OneOf]"):
     return Tuple(spaces, seed=deepcopy(spaces[0].np_random))

--- a/gymnasium/vector/utils/batched_spaces.py
+++ b/gymnasium/vector/utils/batched_spaces.py
@@ -1,8 +1,9 @@
+"""Batching support for Spaces of same type but possibly varying low/high values."""
+
 from copy import deepcopy
 from functools import singledispatch
 
 import numpy as np
-import pytest
 
 from gymnasium import Space
 from gymnasium.spaces import (
@@ -17,7 +18,7 @@ from gymnasium.spaces import (
     Text,
     Tuple,
 )
-from gymnasium.vector.utils import batch_space, iterate
+
 
 @singledispatch
 def batch_differing_spaces(spaces: list[Space]):

--- a/tests/vector/test_batch_spaces.py
+++ b/tests/vector/test_batch_spaces.py
@@ -44,8 +44,8 @@ class TestVectorEnvObservationModes:
             Dict({"a": Discrete(2), "b": Box(low=0, high=1, shape=(2,))}),
         ]
         with pytest.raises(
-            RuntimeError,
-            match="Some environments have an observation space different from `Box(0.0, 1.0, (3,), float32)`. In order to batch observations, the observation spaces from all environments must be equal.",
+            AssertionError,
+            match="Low & High values for observation spaces can be different but shapes need to be the same",
         ):
             VectorEnv(
                 [create_env(space) for space in spaces], observation_mode="different"

--- a/tests/vector/test_batch_spaces.py
+++ b/tests/vector/test_batch_spaces.py
@@ -1,0 +1,76 @@
+import pytest
+
+import gymnasium as gym
+from gymnasium.spaces import Box, Dict, Discrete
+from gymnasium.vector import AsyncVectorEnv, SyncVectorEnv
+from gymnasium.vector.utils import batch_space
+from gymnasium.vector.utils.batched_spaces import batch_differing_spaces
+
+
+class CustomEnv(gym.Env):
+    def __init__(self, observation_space):
+        super().__init__()
+        self.observation_space = observation_space
+        self.action_space = Discrete(2)  # Dummy action space
+
+    def reset(self, seed=None, options=None):
+        return self.observation_space.sample(), {}
+
+    def step(self, action):
+        return self.observation_space.sample(), 0, False, False, {}
+
+
+def create_env(obs_space):
+    return lambda: CustomEnv(obs_space)
+
+
+# Test cases for both SyncVectorEnv and AsyncVectorEnv
+@pytest.mark.parametrize("VectorEnv", [SyncVectorEnv, AsyncVectorEnv])
+class TestVectorEnvObservationModes:
+
+    def test_invalid_observation_mode(self, VectorEnv):
+        with pytest.raises(
+            ValueError, match="Need to pass in mode for batching observations"
+        ):
+            VectorEnv(
+                [create_env(Box(low=0, high=1, shape=(5,))) for _ in range(3)],
+                observation_mode="invalid",
+            )
+
+    def test_mixed_observation_spaces(self, VectorEnv):
+        spaces = [
+            Box(low=0, high=1, shape=(3,)),
+            Discrete(5),
+            Dict({"a": Discrete(2), "b": Box(low=0, high=1, shape=(2,))}),
+        ]
+        with pytest.raises(
+            RuntimeError,
+            match="Some environments have an observation space different from `Box(0.0, 1.0, (3,), float32)`. In order to batch observations, the observation spaces from all environments must be equal.",
+        ):
+            VectorEnv(
+                [create_env(space) for space in spaces], observation_mode="different"
+            )
+
+    def test_default_observation_mode(self, VectorEnv):
+        single_space = Box(low=0, high=1, shape=(5,))
+        env = VectorEnv(
+            [create_env(single_space) for _ in range(3)]
+        )  # No observation_mode specified
+        assert env.observation_space == batch_space(single_space, 3)
+
+    def test_different_observation_mode_same_shape(self, VectorEnv):
+        spaces = [Box(low=0, high=i, shape=(5,)) for i in range(1, 4)]
+        env = VectorEnv(
+            [create_env(space) for space in spaces], observation_mode="different"
+        )
+        assert env.observation_space == batch_differing_spaces(spaces)
+
+    def test_different_observation_mode_different_shapes(self, VectorEnv):
+        spaces = [Box(low=0, high=1, shape=(i + 1,)) for i in range(3)]
+        with pytest.raises(
+            AssertionError,
+            match="Low & High values for observation spaces can be different but shapes need to be the same",
+        ):
+            VectorEnv(
+                [create_env(space) for space in spaces], observation_mode="different"
+            )

--- a/tests/vector/utils/test_space_utils.py
+++ b/tests/vector/utils/test_space_utils.py
@@ -3,17 +3,16 @@
 import copy
 import re
 from typing import Iterable
-import numpy as np
 
+import numpy as np
 import pytest
 
 from gymnasium import Space
 from gymnasium.error import CustomSpaceError
-from gymnasium.spaces import Tuple, Box
+from gymnasium.spaces import Box, Tuple
 from gymnasium.utils.env_checker import data_equivalence
 from gymnasium.vector.utils import batch_space, concatenate, create_empty_array, iterate
 from gymnasium.vector.utils.batched_spaces import batch_differing_spaces
-
 from tests.spaces.utils import TESTING_SPACES, TESTING_SPACES_IDS, CustomSpace
 from tests.vector.utils.utils import is_rng_equal
 
@@ -152,6 +151,7 @@ def test_custom_space():
 
     empty_array = create_empty_array(custom_space)
     assert empty_array is None
+
 
 @pytest.mark.parametrize(
     "spaces,expected_space",

--- a/tests/vector/utils/test_space_utils.py
+++ b/tests/vector/utils/test_space_utils.py
@@ -3,14 +3,17 @@
 import copy
 import re
 from typing import Iterable
+import numpy as np
 
 import pytest
 
 from gymnasium import Space
 from gymnasium.error import CustomSpaceError
-from gymnasium.spaces import Tuple
+from gymnasium.spaces import Tuple, Box
 from gymnasium.utils.env_checker import data_equivalence
 from gymnasium.vector.utils import batch_space, concatenate, create_empty_array, iterate
+from gymnasium.vector.utils.batched_spaces import batch_differing_spaces
+
 from tests.spaces.utils import TESTING_SPACES, TESTING_SPACES_IDS, CustomSpace
 from tests.vector.utils.utils import is_rng_equal
 
@@ -149,3 +152,34 @@ def test_custom_space():
 
     empty_array = create_empty_array(custom_space)
     assert empty_array is None
+
+@pytest.mark.parametrize(
+    "spaces,expected_space",
+    [
+        (
+            (
+                Box(low=0, high=1, shape=(2,), dtype=np.float32),
+                Box(low=2, high=np.array([3, 5], dtype=np.float32)),
+            ),
+            Box(low=np.array([[0, 0], [2, 2]]), high=np.array([[1, 1], [3, 5]])),
+        ),
+    ],
+)
+def test_varying_spaces(spaces: list[Space], expected_space):
+    """Test the batch spaces function."""
+    batched_space = batch_differing_spaces(spaces)
+    assert batched_space == expected_space
+
+    batch_samples = batched_space.sample()
+    for sub_space, sub_sample in zip(spaces, iterate(batched_space, batch_samples)):
+        assert sub_sample in sub_space
+
+
+@pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
+@pytest.mark.parametrize("n", [1, 3])
+def test_batch_spaces_vs_batch_space(space, n):
+    """Test the batch_spaces and batch_space functions."""
+    batched_space = batch_space(space, n)
+    batched_spaces = batch_differing_spaces([copy.deepcopy(space) for _ in range(n)])
+
+    assert batched_space == batched_spaces, f"{batched_space=}, {batched_spaces=}"

--- a/tests/vector/utils/test_space_utils.py
+++ b/tests/vector/utils/test_space_utils.py
@@ -165,7 +165,7 @@ def test_custom_space():
         ),
     ],
 )
-def test_varying_spaces(spaces: list[Space], expected_space):
+def test_varying_spaces(spaces: "list[Space]", expected_space):
     """Test the batch spaces function."""
     batched_space = batch_differing_spaces(spaces)
     assert batched_space == expected_space


### PR DESCRIPTION
# Description

In order to add Meta-World environments to use the Sync/Async Gymnasium methods, a change needed to be made in order to batch observations that have different low/high values.

This change allows the user to specify one of 3 modes for batching observations:
- 'same': current method of having the same observation space for all environments
- 'different': method that allows for different observation spaces to be batched together, given the observation spaces are the same size 
- gym.Space object: allows the user to input a specific method not covered by the 2 above modes

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
