### PR TITLE
Update docstring of normalize reward

### DIFF
--- a/gymnasium/wrappers/stateful_reward.py
+++ b/gymnasium/wrappers/stateful_reward.py
@@ -19,8 +19,9 @@ __all__ = ["NormalizeReward"]
 class NormalizeReward(
     gym.Wrapper[ObsType, ActType, ObsType, ActType], gym.utils.RecordConstructorArgs
 ):
-    r"""Scales immediate rewards such that their exponential moving average has a fixed variance.
+    r"""This wrapper will scale rewards s.t. the discounted returns has a mean of 0 and std of 1.
 
+    In a nutshell, the rewards are divided through by the standard deviation of a rolling discounted sum of the reward.
     The exponential moving average will have variance :math:`(1 - \gamma)^2`.
 
     The property `_update_running_mean` allows to freeze/continue the running mean calculation of the reward
@@ -31,7 +32,8 @@ class NormalizeReward(
 
     Important note:
         Contrary to what the name suggests, this wrapper does not normalize the rewards to have a mean of 0 and a standard
-        deviation of 1. Instead, it scales the rewards such that their exponential moving average has a fixed variance.
+        deviation of 1. Instead, it scales the rewards such that **discounted returns** have approximately unit variance.
+        See [Engstrom et al.](https://openreview.net/forum?id=r1etN1rtPB) on "reward scaling" for more information.
 
     Note:
         In v0.27, NormalizeReward was updated as the forward discounted reward estimate was incorrectly computed in Gym v0.25+.

--- a/gymnasium/wrappers/stateful_reward.py
+++ b/gymnasium/wrappers/stateful_reward.py
@@ -19,7 +19,7 @@ __all__ = ["NormalizeReward"]
 class NormalizeReward(
     gym.Wrapper[ObsType, ActType, ObsType, ActType], gym.utils.RecordConstructorArgs
 ):
-    r"""Normalizes immediate rewards such that their exponential moving average has a fixed variance.
+    r"""Scales immediate rewards such that their exponential moving average has a fixed variance.
 
     The exponential moving average will have variance :math:`(1 - \gamma)^2`.
 
@@ -28,6 +28,10 @@ class NormalizeReward(
     If False, the calculated statistics are used but not updated anymore; this may be used during evaluation.
 
     A vector version of the wrapper exists :class:`gymnasium.wrappers.vector.NormalizeReward`.
+
+    Important note:
+        Contrary to what the name suggests, this wrapper does not normalize the rewards to have a mean of 0 and a standard
+        deviation of 1. Instead, it scales the rewards such that their exponential moving average has a fixed variance.
 
     Note:
         In v0.27, NormalizeReward was updated as the forward discounted reward estimate was incorrectly computed in Gym v0.25+.

--- a/gymnasium/wrappers/stateful_reward.py
+++ b/gymnasium/wrappers/stateful_reward.py
@@ -19,7 +19,7 @@ __all__ = ["NormalizeReward"]
 class NormalizeReward(
     gym.Wrapper[ObsType, ActType, ObsType, ActType], gym.utils.RecordConstructorArgs
 ):
-    r"""This wrapper will scale rewards s.t. the discounted returns has a mean of 0 and std of 1.
+    r"""This wrapper will scale rewards s.t. the discounted returns have a mean of 0 and std of 1.
 
     In a nutshell, the rewards are divided through by the standard deviation of a rolling discounted sum of the reward.
     The exponential moving average will have variance :math:`(1 - \gamma)^2`.

--- a/gymnasium/wrappers/vector/stateful_reward.py
+++ b/gymnasium/wrappers/vector/stateful_reward.py
@@ -18,13 +18,17 @@ __all__ = ["NormalizeReward"]
 
 
 class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
-    r"""This wrapper will normalize immediate rewards s.t. their exponential moving average has a fixed variance.
+    r"""This wrapper will scale immediate rewards s.t. their exponential moving average has a fixed variance.
 
     The exponential moving average will have variance :math:`(1 - \gamma)^2`.
 
     The property `_update_running_mean` allows to freeze/continue the running mean calculation of the reward
     statistics. If `True` (default), the `RunningMeanStd` will get updated every time `self.normalize()` is called.
     If False, the calculated statistics are used but not updated anymore; this may be used during evaluation.
+
+    Important note:
+        Contrary to what the name suggests, this wrapper does not normalize the rewards to have a mean of 0 and a standard
+        deviation of 1. Instead, it scales the rewards such that their exponential moving average has a fixed variance.
 
     Note:
         The scaling depends on past trajectories and rewards will not be scaled correctly if the wrapper was newly

--- a/gymnasium/wrappers/vector/stateful_reward.py
+++ b/gymnasium/wrappers/vector/stateful_reward.py
@@ -18,8 +18,9 @@ __all__ = ["NormalizeReward"]
 
 
 class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
-    r"""This wrapper will scale immediate rewards s.t. their exponential moving average has a fixed variance.
+    r"""This wrapper will scale rewards s.t. the discounted returns has a mean of 0 and std of 1.
 
+    In a nutshell, the rewards are divided through by the standard deviation of a rolling discounted sum of the reward.
     The exponential moving average will have variance :math:`(1 - \gamma)^2`.
 
     The property `_update_running_mean` allows to freeze/continue the running mean calculation of the reward
@@ -28,7 +29,8 @@ class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
 
     Important note:
         Contrary to what the name suggests, this wrapper does not normalize the rewards to have a mean of 0 and a standard
-        deviation of 1. Instead, it scales the rewards such that their exponential moving average has a fixed variance.
+        deviation of 1. Instead, it scales the rewards such that **discounted returns** have approximately unit variance.
+        See [Engstrom et al.](https://openreview.net/forum?id=r1etN1rtPB) on "reward scaling" for more information.
 
     Note:
         The scaling depends on past trajectories and rewards will not be scaled correctly if the wrapper was newly

--- a/gymnasium/wrappers/vector/stateful_reward.py
+++ b/gymnasium/wrappers/vector/stateful_reward.py
@@ -18,7 +18,7 @@ __all__ = ["NormalizeReward"]
 
 
 class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
-    r"""This wrapper will scale rewards s.t. the discounted returns has a mean of 0 and std of 1.
+    r"""This wrapper will scale rewards s.t. the discounted returns have a mean of 0 and std of 1.
 
     In a nutshell, the rewards are divided through by the standard deviation of a rolling discounted sum of the reward.
     The exponential moving average will have variance :math:`(1 - \gamma)^2`.


### PR DESCRIPTION
# Description

As discussed in https://discord.com/channels/961771112864313344/1243134869559578675/1270855568336359435
I updated the docstring to reflect the fact that it does not normalize.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
