### PR TITLE
Fix outdated docs for TimeLimit max_episode_steps and add validation.

### DIFF
--- a/gymnasium/wrappers/common.py
+++ b/gymnasium/wrappers/common.py
@@ -96,8 +96,11 @@ class TimeLimit(
 
         Args:
             env: The environment to apply the wrapper
-            max_episode_steps: An optional max episode steps (if ``None``, ``env.spec.max_episode_steps`` is used)
+            max_episode_steps: the environment step after which the episode is truncated (``elapsed >= max_episode_steps``)
         """
+        assert (
+            isinstance(max_episode_steps, int) and max_episode_steps > 0
+        ), f"Expect the `max_episode_steps` to be positive, actually: {max_episode_steps}"
         gym.utils.RecordConstructorArgs.__init__(
             self, max_episode_steps=max_episode_steps
         )

--- a/tests/wrappers/test_time_limit.py
+++ b/tests/wrappers/test_time_limit.py
@@ -57,3 +57,24 @@ def test_termination_on_last_step(double_wrap):
     _, _, terminated, truncated, _ = env.step(env.action_space.sample())
     assert terminated is True
     assert truncated is True
+
+
+def test_max_episode_steps():
+    env = gym.make("CartPole-v1", disable_env_checker=True)
+
+    assert env.spec.max_episode_steps == 500
+    assert TimeLimit(env, max_episode_steps=10).spec.max_episode_steps == 10
+
+    with pytest.raises(
+        AssertionError,
+        match="Expect the `max_episode_steps` to be positive, actually: -1",
+    ):
+        TimeLimit(env, max_episode_steps=-1)
+
+    with pytest.raises(
+        AssertionError,
+        match="Expect the `max_episode_steps` to be positive, actually: None",
+    ):
+        TimeLimit(env, max_episode_steps=None)
+
+    env.close()


### PR DESCRIPTION
# Description

- update docstring of `TimeLimit.__init__()`
- add `assert isinstance(max_episode_steps, int) and max_episode_steps > 0`
- I assume `max_episode_steps==0` can be safely disallowed?
- add tests for both assertions

Fixes #1147

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
