### PR TITLE
Allow frame stack size of 1 in FrameStack wrapper

### DIFF
--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -372,9 +372,9 @@ class FrameStackObservation(
             raise TypeError(
                 f"The stack_size is expected to be an integer, actual type: {type(stack_size)}"
             )
-        if not 1 < stack_size:
+        if not 0 < stack_size:
             raise ValueError(
-                f"The stack_size needs to be greater than one, actual value: {stack_size}"
+                f"The stack_size needs to be greater than zero, actual value: {stack_size}"
             )
         if isinstance(padding_type, str) and (
             padding_type == "reset" or padding_type == "zero"

--- a/tests/wrappers/test_frame_stack_observation.py
+++ b/tests/wrappers/test_frame_stack_observation.py
@@ -134,9 +134,11 @@ def test_stack_size_failures():
 
     with pytest.raises(
         ValueError,
-        match=re.escape("The stack_size needs to be greater than one, actual value: 1"),
+        match=re.escape(
+            "The stack_size needs to be greater than zero, actual value: 0"
+        ),
     ):
-        FrameStackObservation(env, stack_size=1)
+        FrameStackObservation(env, stack_size=0)
 
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
# Description
Stack-size of 1 is allowed in Frame Stack Observation Wrapper.

Fixes # (issue)
#1085 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes