### PR TITLE
Check that `MultiDiscrete.dtype` is not None

### DIFF
--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -59,6 +59,19 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
             seed: Optionally, you can use this argument to seed the RNG that is used to sample from the space.
             start: Optionally, the starting value the element of each class will take (defaults to 0).
         """
+        # determine dtype
+        if dtype is None:
+            raise ValueError(
+                "MultiDiscrete dtype must be explicitly provided, cannot be None."
+            )
+        self.dtype = np.dtype(dtype)
+
+        #  * check that dtype is an accepted dtype
+        if not (np.issubdtype(self.dtype, np.integer)):
+            raise ValueError(
+                f"Invalid MultiDiscrete dtype ({self.dtype}), must be an integer dtype"
+            )
+
         self.nvec = np.array(nvec, dtype=dtype, copy=True)
         if start is not None:
             self.start = np.array(start, dtype=dtype, copy=True)
@@ -70,7 +83,7 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
         ), "start and nvec (counts) should have the same shape"
         assert (self.nvec > 0).all(), "nvec (counts) have to be positive"
 
-        super().__init__(self.nvec.shape, dtype, seed)
+        super().__init__(self.nvec.shape, self.dtype, seed)
 
     @property
     def shape(self) -> tuple[int, ...]:


### PR DESCRIPTION
# Description

Removing support for dtype=None but only Integer dtype.

Fixes # (issue)
#1195 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
