### PR TITLE
set copyright time in documentation page automatically

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@
 import os
 import re
 import sys
+import time
 
 import sphinx_gallery.gen_rst
 from furo.gen_tutorials import generate_tutorials
@@ -27,7 +28,7 @@ import gymnasium  # noqa: E402
 
 
 project = "Gymnasium"
-copyright = "2023 Farama Foundation"
+copyright = f"{time.localtime().tm_year} Farama Foundation"
 author = "Farama Foundation"
 
 # The full version, including alpha/beta/rc tags


### PR DESCRIPTION
The copyright date is out of date in the documentation, this fixes it

![image](https://github.com/user-attachments/assets/49cda9f6-7851-4aff-9d7c-aa7c07bebaf7)
