### PR TITLE
re-enable `pyright.reportPrivateImportUsage` and `pyright.reportUnboundVariable`

### DIFF
--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -374,7 +374,7 @@ class LunarLander(gym.Env, EzPickle):
         # Create Lander body
         initial_y = VIEWPORT_H / SCALE
         initial_x = VIEWPORT_W / SCALE / 2
-        self.lander: Box2D.b2Body = self.world.CreateDynamicBody(
+        self.lander = self.world.CreateDynamicBody(
             position=(initial_x, initial_y),
             angle=0.0,
             fixtures=fixtureDef(

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -374,7 +374,7 @@ class LunarLander(gym.Env, EzPickle):
         # Create Lander body
         initial_y = VIEWPORT_H / SCALE
         initial_x = VIEWPORT_W / SCALE / 2
-        self.lander = self.world.CreateDynamicBody(
+        self.lander: Box2D.b2Body = self.world.CreateDynamicBody(
             position=(initial_x, initial_y),
             angle=0.0,
             fixtures=fixtureDef(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,6 @@ reportCallIssue = "none"  # TODO fix one by one
 reportOperatorIssue = "none"  # TODO fix one by one
 reportInvalidTypeForm = "none"  # TODO fix one by one
 reportOptionalMemberAccess = "none"  # TODO fix one by one
-reportRedeclaration = "none"  # TODO fix one by one
 reportAssignmentType = "none"  # TODO fix one by one
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,9 +142,6 @@ reportAttributeAccessIssue = "none"  # pyright provides false positives
 reportArgumentType = "none"  # pyright provides false positives
 
 reportPrivateUsage = "warning"
-# reportUnboundVariable = "warning"
-
-# reportPrivateImportUsage = "none"  # -> commented out raises 144 errors
 
 reportIndexIssue = "none"  # TODO fix one by one
 reportReturnType = "none"  # TODO fix one by one

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,19 +137,14 @@ reportMissingTypeStubs = false
 # For warning and error, will raise an error when
 reportInvalidTypeVarUse = "none"
 
-# reportUnknownMemberType = "warning"  # -> raises 6035 warnings
-# reportUnknownParameterType = "warning"  # -> raises 1327 warnings
-# reportUnknownVariableType = "warning"  # -> raises 2585 warnings
-# reportUnknownArgumentType = "warning"  # -> raises 2104 warnings
 reportGeneralTypeIssues = "none"  # -> commented out raises 489 errors
-# reportUntypedFunctionDecorator = "none"  # -> pytest.mark.parameterize issues
-reportAttributeAccessIssue = "none"
-reportArgumentType = "none"
+reportAttributeAccessIssue = "none"  # pyright provides false positives
+reportArgumentType = "none"  # pyright provides false positives
 
 reportPrivateUsage = "warning"
-reportUnboundVariable = "warning"
+# reportUnboundVariable = "warning"
 
-reportPrivateImportUsage = "none"  # -> commented out raises 144 errors
+# reportPrivateImportUsage = "none"  # -> commented out raises 144 errors
 
 reportIndexIssue = "none"  # TODO fix one by one
 reportReturnType = "none"  # TODO fix one by one


### PR DESCRIPTION
`reportPrivateImportUsage` was due to MuJoCo, but this has been fixed in (a while ago) v5

`reportUnboundVariable` I have no idea when this was an issue

also cleans up options in `pyproject.toml`