### PR TITLE
Introducing Gymnasium Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![arXiv](https://img.shields.io/badge/arXiv-2407.17032-b31b1b.svg)](https://arxiv.org/abs/2407.17032)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![](https://img.shields.io/badge/Gurubase-Ask%20Gymnasium%20Guru-006BFF)](https://gurubase.io/g/gymnasium)
 
 <p align="center">
     <img src="https://raw.githubusercontent.com/Farama-Foundation/Gymnasium/main/gymnasium-text.png" width="500px"/>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Gymnasium Guru](https://gurubase.io/g/gymnasium) to Gurubase. Gymnasium Guru uses the data from this repo and data from the [docs](https://gymnasium.farama.org/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Gymnasium Guru" badge, which highlights that Gymnasium now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Gymnasium Guru in Gurubase, just let me know that's totally fine.