### PR TITLE
Raise minimum required version of mujoco to 2.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
 mujoco-py = ["mujoco-py >=2.1,<2.2", "cython<3"]
 mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]  # kept for backward compatibility
-mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1"]
+mujoco = ["mujoco >=2.3.6", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]  # kept for backward compatibility
 jax = ["jax >=0.4.0", "jaxlib >=0.4.0", "flax >=0.5.0"]
@@ -62,7 +62,7 @@ all = [
     "mujoco-py >=2.1,<2.2",
     "cython <3",
     # mujoco
-    "mujoco >=2.1.5",
+    "mujoco >=2.3.6",
     "imageio >=2.14.1",
     # toy-text
     "pygame >=2.1.3",


### PR DESCRIPTION
# Description

`mjtState` used in https://github.com/Farama-Foundation/Gymnasium/pull/928 was added in mujoco 2.3.6, see https://github.com/google-deepmind/mujoco/commit/f67e3595329718c80b84a024febbed143d1b4636 . I am not sure if it make anyhow sense to permit a lower version of mujoco for users that do not use `mujoco.utils.get_state`, but anyhow I think a PR with the concrete proposed change is more convenient to discuss then an issue.

Furthermore, I am not familiar with how `mujoco_py` works and if this additional constraint could be a problem.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

