### PR TITLE
Use multiprocessing.get_all_start_methods() in test_async_with_dynamically_registered_env

### DIFF
--- a/tests/envs/registration/test_make_vec.py
+++ b/tests/envs/registration/test_make_vec.py
@@ -1,6 +1,6 @@
 """Testing of the `gym.make_vec` function."""
 
-import multiprocess
+import multiprocessing
 import re
 
 import pytest

--- a/tests/envs/registration/test_make_vec.py
+++ b/tests/envs/registration/test_make_vec.py
@@ -1,5 +1,6 @@
 """Testing of the `gym.make_vec` function."""
 
+import multiprocess
 import re
 
 import pytest
@@ -236,7 +237,7 @@ def test_make_vec_with_spec(env_id: str, kwargs: dict):
     recreated_envs.close()
 
 
-@pytest.mark.parametrize("ctx", [None, "spawn", "fork", "forkserver"])
+@pytest.mark.parametrize("ctx", [None] + multiprocessing.get_all_start_methods())
 def test_async_with_dynamically_registered_env(ctx):
     gym.register("TestEnv-v0", CartPoleEnv)
 


### PR DESCRIPTION
# Description

On Windows, I was obtaining these test failures:

~~~
2024-10-20T14:32:51.8042643Z FAILED tests/envs/registration/test_make_vec.py::test_async_with_dynamically_registered_env[fork] - ValueError: cannot find context for 'fork'
2024-10-20T14:32:51.8043645Z FAILED tests/envs/registration/test_make_vec.py::test_async_with_dynamically_registered_env[forkserver] - ValueError: cannot find context for 'forkserver'
~~~

This is happening as `fork` and `forkserver` are not supported on Windows, and other platforms may have similar limitations. To avoid such test failures, I modified the `test_async_with_dynamically_registered_env` parametrization to use [`multiprocessing.get_all_start_methods()`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.get_all_start_methods) instead of hardcoding `["spawn", "fork", "forkserver"]` on all platforms.


## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
