### PR TITLE
Add support for different vector autoreset modes

### DIFF
--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -355,7 +355,7 @@ class CartPoleVectorEnv(VectorEnv):
     metadata = {
         "render_modes": ["rgb_array"],
         "render_fps": 50,
-        "autoreset-mode": AutoresetMode.NEXT_STEP,
+        "autoreset_mode": AutoresetMode.NEXT_STEP,
     }
 
     def __init__(

--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -13,7 +13,7 @@ import gymnasium as gym
 from gymnasium import logger, spaces
 from gymnasium.envs.classic_control import utils
 from gymnasium.error import DependencyNotInstalled
-from gymnasium.vector import VectorEnv
+from gymnasium.vector import AutoresetMode, VectorEnv
 from gymnasium.vector.utils import batch_space
 
 
@@ -355,6 +355,7 @@ class CartPoleVectorEnv(VectorEnv):
     metadata = {
         "render_modes": ["rgb_array"],
         "render_fps": 50,
+        "autoreset-mode": AutoresetMode.NEXT_STEP,
     }
 
     def __init__(

--- a/gymnasium/envs/functional_jax_env.py
+++ b/gymnasium/envs/functional_jax_env.py
@@ -12,6 +12,7 @@ import gymnasium as gym
 from gymnasium.envs.registration import EnvSpec
 from gymnasium.experimental.functional import ActType, FuncEnv, StateType
 from gymnasium.utils import seeding
+from gymnasium.vector import AutoresetMode
 from gymnasium.vector.utils import batch_space
 
 
@@ -115,7 +116,7 @@ class FunctionalJaxVectorEnv(gym.vector.VectorEnv):
         """Initialize the environment from a FuncEnv."""
         super().__init__()
         if metadata is None:
-            metadata = {}
+            metadata = {"AutoresetMode": AutoresetMode.NEXT_STEP}
         self.func_env = func_env
         self.num_envs = num_envs
 

--- a/gymnasium/envs/functional_jax_env.py
+++ b/gymnasium/envs/functional_jax_env.py
@@ -116,7 +116,7 @@ class FunctionalJaxVectorEnv(gym.vector.VectorEnv):
         """Initialize the environment from a FuncEnv."""
         super().__init__()
         if metadata is None:
-            metadata = {"AutoresetMode": AutoresetMode.NEXT_STEP}
+            metadata = {"autoreset_mode": AutoresetMode.NEXT_STEP}
         self.func_env = func_env
         self.num_envs = num_envs
 

--- a/gymnasium/envs/phys2d/cartpole.py
+++ b/gymnasium/envs/phys2d/cartpole.py
@@ -277,7 +277,7 @@ class CartPoleJaxVectorEnv(FunctionalJaxVectorEnv, EzPickle):
         "render_modes": ["rgb_array"],
         "render_fps": 50,
         "jax": True,
-        "AutoresetMode": AutoresetMode.NEXT_STEP,
+        "autoreset_mode": AutoresetMode.NEXT_STEP,
     }
 
     def __init__(

--- a/gymnasium/envs/phys2d/cartpole.py
+++ b/gymnasium/envs/phys2d/cartpole.py
@@ -15,6 +15,7 @@ from gymnasium.envs.functional_jax_env import FunctionalJaxEnv, FunctionalJaxVec
 from gymnasium.error import DependencyNotInstalled
 from gymnasium.experimental.functional import ActType, FuncEnv, StateType
 from gymnasium.utils import EzPickle
+from gymnasium.vector import AutoresetMode
 
 
 RenderStateType = Tuple["pygame.Surface", "pygame.time.Clock"]  # type: ignore  # noqa: F821
@@ -272,7 +273,12 @@ class CartPoleJaxEnv(FunctionalJaxEnv, EzPickle):
 class CartPoleJaxVectorEnv(FunctionalJaxVectorEnv, EzPickle):
     """Jax-based implementation of the vectorized CartPole environment."""
 
-    metadata = {"render_modes": ["rgb_array"], "render_fps": 50, "jax": True}
+    metadata = {
+        "render_modes": ["rgb_array"],
+        "render_fps": 50,
+        "jax": True,
+        "AutoresetMode": AutoresetMode.NEXT_STEP,
+    }
 
     def __init__(
         self,

--- a/gymnasium/envs/phys2d/pendulum.py
+++ b/gymnasium/envs/phys2d/pendulum.py
@@ -230,7 +230,7 @@ class PendulumJaxEnv(FunctionalJaxEnv, EzPickle):
         "render_modes": ["rgb_array"],
         "render_fps": 30,
         "jax": True,
-        "AutoresetMode": AutoresetMode.NEXT_STEP,
+        "autoreset_mode": AutoresetMode.NEXT_STEP,
     }
 
     def __init__(self, render_mode: str | None = None, **kwargs: Any):

--- a/gymnasium/envs/phys2d/pendulum.py
+++ b/gymnasium/envs/phys2d/pendulum.py
@@ -16,6 +16,7 @@ from gymnasium.envs.functional_jax_env import FunctionalJaxEnv, FunctionalJaxVec
 from gymnasium.error import DependencyNotInstalled
 from gymnasium.experimental.functional import ActType, FuncEnv, StateType
 from gymnasium.utils import EzPickle
+from gymnasium.vector import AutoresetMode
 
 
 RenderStateType = Tuple["pygame.Surface", "pygame.time.Clock", Optional[float]]  # type: ignore  # noqa: F821
@@ -225,7 +226,12 @@ class PendulumFunctional(
 class PendulumJaxEnv(FunctionalJaxEnv, EzPickle):
     """Jax-based pendulum environment using the functional version as base."""
 
-    metadata = {"render_modes": ["rgb_array"], "render_fps": 30, "jax": True}
+    metadata = {
+        "render_modes": ["rgb_array"],
+        "render_fps": 30,
+        "jax": True,
+        "AutoresetMode": AutoresetMode.NEXT_STEP,
+    }
 
     def __init__(self, render_mode: str | None = None, **kwargs: Any):
         """Constructor where the kwargs are passed to the base environment to modify the parameters."""

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -978,11 +978,13 @@ def make_vec(
         copied_id_spec.kwargs["wrappers"] = wrappers
     env.unwrapped.spec = copied_id_spec
 
-    if "AutoresetMode" not in env.metadata:
-        warn(f"The VectorEnv ({env}) is missing AutoresetMode metadata.")
-    elif not isinstance(env.metadata["AutoresetMode"], AutoresetMode):
+    if "autoreset_mode" not in env.metadata:
         warn(
-            f"The VectorEnv ({env}) AutoresetMode metadata is not an instance of AutoresetMode, {type(env.metadata['AutoresetMode'])}."
+            f"The VectorEnv ({env}) is missing AutoresetMode metadata, metadata={env.metadata}"
+        )
+    elif not isinstance(env.metadata["autoreset_mode"], AutoresetMode):
+        warn(
+            f"The VectorEnv ({env}) metadata['autoreset_mode'] is not an instance of AutoresetMode, {type(env.metadata['autoreset_mode'])}."
         )
 
     return env

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -19,6 +19,8 @@ from typing import Any, Callable, Iterable, Sequence
 
 import gymnasium as gym
 from gymnasium import Env, Wrapper, error, logger
+from gymnasium.logger import warn
+from gymnasium.vector import AutoresetMode
 
 
 if sys.version_info < (3, 10):
@@ -975,6 +977,13 @@ def make_vec(
     if len(wrappers) > 0:
         copied_id_spec.kwargs["wrappers"] = wrappers
     env.unwrapped.spec = copied_id_spec
+
+    if "AutoresetMode" not in env.metadata:
+        warn(f"The VectorEnv ({env}) is missing AutoresetMode metadata.")
+    elif not isinstance(env.metadata["AutoresetMode"], AutoresetMode):
+        warn(
+            f"The VectorEnv ({env}) AutoresetMode metadata is not an instance of AutoresetMode, {type(env.metadata['AutoresetMode'])}."
+        )
 
     return env
 

--- a/gymnasium/envs/tabular/blackjack.py
+++ b/gymnasium/envs/tabular/blackjack.py
@@ -16,6 +16,7 @@ from gymnasium.envs.functional_jax_env import FunctionalJaxEnv
 from gymnasium.error import DependencyNotInstalled
 from gymnasium.experimental.functional import ActType, FuncEnv, StateType
 from gymnasium.utils import EzPickle, seeding
+from gymnasium.vector import AutoresetMode
 from gymnasium.wrappers import HumanRendering
 
 
@@ -239,6 +240,7 @@ class BlackjackFunctional(
     metadata = {
         "render_modes": ["rgb_array"],
         "render_fps": 4,
+        "AutoresetMode": AutoresetMode.NEXT_STEP,
     }
 
     def transition(

--- a/gymnasium/envs/tabular/blackjack.py
+++ b/gymnasium/envs/tabular/blackjack.py
@@ -240,7 +240,7 @@ class BlackjackFunctional(
     metadata = {
         "render_modes": ["rgb_array"],
         "render_fps": 4,
-        "AutoresetMode": AutoresetMode.NEXT_STEP,
+        "autoreseet-mode": AutoresetMode.NEXT_STEP,
     }
 
     def transition(

--- a/gymnasium/envs/tabular/cliffwalking.py
+++ b/gymnasium/envs/tabular/cliffwalking.py
@@ -137,7 +137,7 @@ class CliffWalkingFunctional(
     metadata = {
         "render_modes": ["rgb_array"],
         "render_fps": 4,
-        "AutoresetMode": AutoresetMode.NEXT_STEP,
+        "autoreset_mode": AutoresetMode.NEXT_STEP,
     }
 
     def transition(

--- a/gymnasium/envs/tabular/cliffwalking.py
+++ b/gymnasium/envs/tabular/cliffwalking.py
@@ -15,6 +15,7 @@ from gymnasium.envs.functional_jax_env import FunctionalJaxEnv
 from gymnasium.error import DependencyNotInstalled
 from gymnasium.experimental.functional import ActType, FuncEnv, StateType
 from gymnasium.utils import EzPickle
+from gymnasium.vector import AutoresetMode
 from gymnasium.wrappers import HumanRendering
 
 
@@ -136,6 +137,7 @@ class CliffWalkingFunctional(
     metadata = {
         "render_modes": ["rgb_array"],
         "render_fps": 4,
+        "AutoresetMode": AutoresetMode.NEXT_STEP,
     }
 
     def transition(

--- a/gymnasium/vector/__init__.py
+++ b/gymnasium/vector/__init__.py
@@ -4,6 +4,7 @@ from gymnasium.vector import utils
 from gymnasium.vector.async_vector_env import AsyncVectorEnv
 from gymnasium.vector.sync_vector_env import SyncVectorEnv
 from gymnasium.vector.vector_env import (
+    AutoresetMode,
     VectorActionWrapper,
     VectorEnv,
     VectorObservationWrapper,
@@ -21,4 +22,5 @@ __all__ = [
     "SyncVectorEnv",
     "AsyncVectorEnv",
     "utils",
+    "AutoresetMode",
 ]

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -299,20 +299,20 @@ class AsyncVectorEnv(VectorEnv):
                 str(self._state.value),
             )
 
-        if options is not None and "mask" in options:
-            reset_mask = options.pop("mask")
+        if options is not None and "reset_mask" in options:
+            reset_mask = options.pop("reset_mask")
             assert isinstance(
                 reset_mask, np.ndarray
-            ), f"`options['mask': mask]` must be a numpy array, got {type(reset_mask)}"
+            ), f"`options['reset_mask': mask]` must be a numpy array, got {type(reset_mask)}"
             assert reset_mask.shape == (
                 self.num_envs,
-            ), f"`options['mask': mask]` must have shape `({self.num_envs},)`, got {reset_mask.shape}"
+            ), f"`options['reset_mask': mask]` must have shape `({self.num_envs},)`, got {reset_mask.shape}"
             assert (
                 reset_mask.dtype == np.bool_
-            ), f"`options['mask': mask]` must have `dtype=np.bool_`, got {reset_mask.dtype}"
+            ), f"`options['reset_mask': mask]` must have `dtype=np.bool_`, got {reset_mask.dtype}"
             assert np.any(
                 reset_mask
-            ), f"`options['mask': mask]` must contain a boolean array, got reset_mask={reset_mask}"
+            ), f"`options['reset_mask': mask]` must contain a boolean array, got reset_mask={reset_mask}"
 
             for pipe, env_seed, env_reset in zip(self.parent_pipes, seed, reset_mask):
                 if env_reset:

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -230,8 +230,6 @@ class SyncVectorEnv(VectorEnv):
                 infos = self._add_info(infos, env_info, i)
 
         # Concatenate the observations
-        print(f"{self._env_obs=}")
-        print(f"{self._observations}")
         self._observations = concatenate(
             self.single_observation_space, self._env_obs, self._observations
         )

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -230,6 +230,8 @@ class SyncVectorEnv(VectorEnv):
                 infos = self._add_info(infos, env_info, i)
 
         # Concatenate the observations
+        print(f"{self._env_obs=}")
+        print(f"{self._observations}")
         self._observations = concatenate(
             self.single_observation_space, self._env_obs, self._observations
         )

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -187,20 +187,20 @@ class SyncVectorEnv(VectorEnv):
             len(seed) == self.num_envs
         ), f"If seeds are passed as a list the length must match num_envs={self.num_envs} but got length={len(seed)}."
 
-        if options is not None and "mask" in options:
-            reset_mask = options.pop("mask")
+        if options is not None and "reset_mask" in options:
+            reset_mask = options.pop("reset_mask")
             assert isinstance(
                 reset_mask, np.ndarray
-            ), f"`options['mask': mask]` must be a numpy array, got {type(reset_mask)}"
+            ), f"`options['reset_mask': mask]` must be a numpy array, got {type(reset_mask)}"
             assert reset_mask.shape == (
                 self.num_envs,
-            ), f"`options['mask': mask]` must have shape `({self.num_envs},)`, got {reset_mask.shape}"
+            ), f"`options['reset_mask': mask]` must have shape `({self.num_envs},)`, got {reset_mask.shape}"
             assert (
                 reset_mask.dtype == np.bool_
-            ), f"`options['mask': mask]` must have `dtype=np.bool_`, got {reset_mask.dtype}"
+            ), f"`options['reset_mask': mask]` must have `dtype=np.bool_`, got {reset_mask.dtype}"
             assert np.any(
                 reset_mask
-            ), f"`options['mask': mask]` must contain a boolean array, got reset_mask={reset_mask}"
+            ), f"`options['reset_mask': mask]` must contain a boolean array, got reset_mask={reset_mask}"
 
             self._terminations[reset_mask] = False
             self._truncations[reset_mask] = False

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -525,9 +525,16 @@ class VectorObservationWrapper(VectorWrapper):
     """
 
     def __init__(self, env: VectorEnv):
+        """Vector observation wrapper that batch transforms observations.
+
+        Args:
+            env: Vector environment.
+        """
         super().__init__(env)
         if "autoreset_mode" not in env.metadata:
-            warn("todo")
+            warn(
+                f"Vector environment ({env}) is missing `autoreset_mode` metadata key."
+            )
         else:
             assert (
                 env.metadata["autoreset_mode"] == AutoresetMode.NEXT_STEP

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -9,6 +9,7 @@ import numpy as np
 
 import gymnasium as gym
 from gymnasium.core import ActType, ObsType, RenderFrame
+from gymnasium.logger import warn
 from gymnasium.utils import seeding
 
 
@@ -516,6 +517,13 @@ class VectorObservationWrapper(VectorWrapper):
 
     Equivalent to :class:`gymnasium.ObservationWrapper` for vectorized environments.
     """
+
+    def __init__(self, env: VectorEnv):
+        super().__init__(env)
+        if "autoreset_mode" not in env.metadata:
+            warn('todo')
+        else:
+            assert env.metadata["autoreset_mode"] == AutoresetMode.NEXT_STEP or env.metadata["autoreset_mode"] == AutoresetMode.DISABLED
 
     def reset(
         self,

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import numpy as np
@@ -24,7 +25,16 @@ __all__ = [
     "VectorActionWrapper",
     "VectorRewardWrapper",
     "ArrayType",
+    "AutoresetMode",
 ]
+
+
+class AutoresetMode(Enum):
+    """Enum representing the different autoreset modes, next step, same step and disabled."""
+
+    NEXT_STEP: str = "NextStep"
+    SAME_STEP: str = "SameStep"
+    DISABLED: str = "Disabled"
 
 
 class VectorEnv(Generic[ObsType, ActType, ArrayType]):

--- a/gymnasium/wrappers/vector/common.py
+++ b/gymnasium/wrappers/vector/common.py
@@ -9,7 +9,13 @@ import numpy as np
 
 from gymnasium.core import ActType, ObsType
 from gymnasium.logger import warn
-from gymnasium.vector.vector_env import ArrayType, VectorEnv, VectorWrapper, AutoresetMode
+from gymnasium.vector.vector_env import (
+    ArrayType,
+    AutoresetMode,
+    VectorEnv,
+    VectorWrapper,
+)
+
 
 __all__ = ["RecordEpisodeStatistics"]
 
@@ -79,7 +85,7 @@ class RecordEpisodeStatistics(VectorWrapper):
         super().__init__(env)
         self._stats_key = stats_key
         if "autoreset_mode" not in self.env.metadata:
-            warn('todo')
+            warn("todo")
             self._autoreset_mode = AutoresetMode.NEXT_STEP
         else:
             assert isinstance(self.env.metadata["autoreset_mode"], AutoresetMode)
@@ -148,9 +154,11 @@ class RecordEpisodeStatistics(VectorWrapper):
         ), f"`vector.RecordEpisodeStatistics` requires `info` type to be `dict`, its actual type is {type(infos)}. This may be due to usage of other wrappers in the wrong order."
 
         self.episode_returns[self.prev_dones] = 0
-        self.episode_returns[np.logical_not(self.prev_dones)] += rewards[np.logical_not(self.prev_dones)]
+        self.episode_returns[np.logical_not(self.prev_dones)] += rewards[
+            np.logical_not(self.prev_dones)
+        ]
 
-        self.episode_lengths[self.prev_dones] = -1 if self._autoreset_mode == AutoresetMode.NEXT_STEP else 0
+        self.episode_lengths[self.prev_dones] = 0
         self.episode_lengths[~self.prev_dones] += 1
 
         self.episode_start_times[self.prev_dones] = time.perf_counter()

--- a/gymnasium/wrappers/vector/common.py
+++ b/gymnasium/wrappers/vector/common.py
@@ -8,8 +8,8 @@ from collections import deque
 import numpy as np
 
 from gymnasium.core import ActType, ObsType
-from gymnasium.vector.vector_env import ArrayType, VectorEnv, VectorWrapper
-
+from gymnasium.logger import warn
+from gymnasium.vector.vector_env import ArrayType, VectorEnv, VectorWrapper, AutoresetMode
 
 __all__ = ["RecordEpisodeStatistics"]
 
@@ -78,13 +78,19 @@ class RecordEpisodeStatistics(VectorWrapper):
         """
         super().__init__(env)
         self._stats_key = stats_key
+        if "autoreset_mode" not in self.env.metadata:
+            warn('todo')
+            self._autoreset_mode = AutoresetMode.NEXT_STEP
+        else:
+            assert isinstance(self.env.metadata["autoreset_mode"], AutoresetMode)
+            self._autoreset_mode = self.env.metadata["autoreset_mode"]
 
         self.episode_count = 0
 
-        self.episode_start_times: np.ndarray = np.zeros(())
-        self.episode_returns: np.ndarray = np.zeros(())
-        self.episode_lengths: np.ndarray = np.zeros((), dtype=int)
-        self.prev_dones: np.ndarray = np.zeros((), dtype=bool)
+        self.episode_start_times: np.ndarray = np.zeros((self.num_envs,))
+        self.episode_returns: np.ndarray = np.zeros((self.num_envs,))
+        self.episode_lengths: np.ndarray = np.zeros((self.num_envs,), dtype=int)
+        self.prev_dones: np.ndarray = np.zeros((self.num_envs,), dtype=bool)
 
         self.time_queue = deque(maxlen=buffer_length)
         self.return_queue = deque(maxlen=buffer_length)
@@ -98,10 +104,30 @@ class RecordEpisodeStatistics(VectorWrapper):
         """Resets the environment using kwargs and resets the episode returns and lengths."""
         obs, info = super().reset(seed=seed, options=options)
 
-        self.episode_start_times = np.full(self.num_envs, time.perf_counter())
-        self.episode_returns = np.zeros(self.num_envs)
-        self.episode_lengths = np.zeros(self.num_envs, dtype=int)
-        self.prev_dones = np.zeros(self.num_envs, dtype=bool)
+        if options is not None and "reset_mask" in options:
+            reset_mask = options.pop("reset_mask")
+            assert isinstance(
+                reset_mask, np.ndarray
+            ), f"`options['reset_mask': mask]` must be a numpy array, got {type(reset_mask)}"
+            assert reset_mask.shape == (
+                self.num_envs,
+            ), f"`options['reset_mask': mask]` must have shape `({self.num_envs},)`, got {reset_mask.shape}"
+            assert (
+                reset_mask.dtype == np.bool_
+            ), f"`options['reset_mask': mask]` must have `dtype=np.bool_`, got {reset_mask.dtype}"
+            assert np.any(
+                reset_mask
+            ), f"`options['reset_mask': mask]` must contain a boolean array, got reset_mask={reset_mask}"
+
+            self.episode_start_times[reset_mask] = time.perf_counter()
+            self.episode_returns[reset_mask] = 0
+            self.episode_lengths[reset_mask] = 0
+            self.prev_dones[reset_mask] = False
+        else:
+            self.episode_start_times = np.full(self.num_envs, time.perf_counter())
+            self.episode_returns = np.zeros(self.num_envs)
+            self.episode_lengths = np.zeros(self.num_envs, dtype=int)
+            self.prev_dones = np.zeros(self.num_envs, dtype=bool)
 
         return obs, info
 
@@ -122,10 +148,12 @@ class RecordEpisodeStatistics(VectorWrapper):
         ), f"`vector.RecordEpisodeStatistics` requires `info` type to be `dict`, its actual type is {type(infos)}. This may be due to usage of other wrappers in the wrong order."
 
         self.episode_returns[self.prev_dones] = 0
-        self.episode_lengths[self.prev_dones] = 0
-        self.episode_start_times[self.prev_dones] = time.perf_counter()
-        self.episode_returns[~self.prev_dones] += rewards[~self.prev_dones]
+        self.episode_returns[np.logical_not(self.prev_dones)] += rewards[np.logical_not(self.prev_dones)]
+
+        self.episode_lengths[self.prev_dones] = -1 if self._autoreset_mode == AutoresetMode.NEXT_STEP else 0
         self.episode_lengths[~self.prev_dones] += 1
+
+        self.episode_start_times[self.prev_dones] = time.perf_counter()
 
         self.prev_dones = dones = np.logical_or(terminations, truncations)
         num_dones = np.sum(dones)
@@ -133,7 +161,7 @@ class RecordEpisodeStatistics(VectorWrapper):
         if num_dones:
             if self._stats_key in infos or f"_{self._stats_key}" in infos:
                 raise ValueError(
-                    f"Attempted to add episode stats when they already exist, info keys: {list(infos.keys())}"
+                    f"Attempted to add episode stats with key '{self._stats_key}' but this key already exists in info: {list(infos.keys())}"
                 )
             else:
                 episode_time_length = np.round(

--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -12,7 +12,11 @@ import numpy as np
 import gymnasium as gym
 from gymnasium.core import ObsType
 from gymnasium.logger import warn
-from gymnasium.vector.vector_env import VectorEnv, VectorObservationWrapper, AutoresetMode
+from gymnasium.vector.vector_env import (
+    AutoresetMode,
+    VectorEnv,
+    VectorObservationWrapper,
+)
 from gymnasium.wrappers.utils import RunningMeanStd
 
 
@@ -69,7 +73,9 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         VectorObservationWrapper.__init__(self, env)
 
         if "autoreset_mode" not in self.env.metadata:
-            warn(f'{self} is missing `autoreset_mode` data. Assuming that the vector environment it follows the `NextStep` autoreset api or autoreset is disabled. Read todo for more details.')
+            warn(
+                f"{self} is missing `autoreset_mode` data. Assuming that the vector environment it follows the `NextStep` autoreset api or autoreset is disabled. Read todo for more details."
+            )
         else:
             assert self.env.metadata["autoreset_mode"] in {AutoresetMode.NEXT_STEP}
 
@@ -96,7 +102,7 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         seed: int | list[int] | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[ObsType, dict[str, Any]]:
-        assert "reset_mask" not in options or np.all(options["reset_mask"])
+        assert options is None or "reset_mask" not in options or np.all(options["reset_mask"])
         return super().reset(seed=seed, options=options)
 
     def observations(self, observations: ObsType) -> ObsType:

--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -5,11 +5,14 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 
 import gymnasium as gym
 from gymnasium.core import ObsType
-from gymnasium.vector.vector_env import VectorEnv, VectorObservationWrapper
+from gymnasium.logger import warn
+from gymnasium.vector.vector_env import VectorEnv, VectorObservationWrapper, AutoresetMode
 from gymnasium.wrappers.utils import RunningMeanStd
 
 
@@ -65,6 +68,11 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         gym.utils.RecordConstructorArgs.__init__(self, epsilon=epsilon)
         VectorObservationWrapper.__init__(self, env)
 
+        if "autoreset_mode" not in self.env.metadata:
+            warn(f'{self} is missing `autoreset_mode` data. Assuming that the vector environment it follows the `NextStep` autoreset api or autoreset is disabled. Read todo for more details.')
+        else:
+            assert self.env.metadata["autoreset_mode"] in {AutoresetMode.NEXT_STEP}
+
         self.obs_rms = RunningMeanStd(
             shape=self.single_observation_space.shape,
             dtype=self.single_observation_space.dtype,
@@ -81,6 +89,15 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
     def update_running_mean(self, setting: bool):
         """Sets the property to freeze/continue the running mean calculation of the observation statistics."""
         self._update_running_mean = setting
+
+    def reset(
+        self,
+        *,
+        seed: int | list[int] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[ObsType, dict[str, Any]]:
+        assert "reset_mask" not in options or np.all(options["reset_mask"])
+        return super().reset(seed=seed, options=options)
 
     def observations(self, observations: ObsType) -> ObsType:
         """Defines the vector observation normalization function.

--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -102,6 +102,7 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         seed: int | list[int] | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[ObsType, dict[str, Any]]:
+        """Reset function for `NormalizeObservationWrapper` which is disabled for partial resets."""
         assert (
             options is None
             or "reset_mask" not in options

--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -102,7 +102,11 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         seed: int | list[int] | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[ObsType, dict[str, Any]]:
-        assert options is None or "reset_mask" not in options or np.all(options["reset_mask"])
+        assert (
+            options is None
+            or "reset_mask" not in options
+            or np.all(options["reset_mask"])
+        )
         return super().reset(seed=seed, options=options)
 
     def observations(self, observations: ObsType) -> ObsType:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ all = [
     "moviepy >=1.0.0",
 ]
 testing = [
-    "pytest ==7.1.3",
+    "pytest >=7.1.3",
     "scipy >=1.7.3",
     "dill >=0.3.7",
 ]

--- a/tests/testing_env.py
+++ b/tests/testing_env.py
@@ -45,7 +45,6 @@ def basic_render_func(self):
     pass
 
 
-# todo: change all testing environment to this generic class
 class GenericTestEnv(gym.Env):
     """A generic testing environment for use in testing with modified environments are required."""
 

--- a/tests/vector/test_autoreset_mode.py
+++ b/tests/vector/test_autoreset_mode.py
@@ -1,0 +1,294 @@
+from functools import partial
+
+import numpy as np
+import pytest
+
+import gymnasium as gym
+from gymnasium import VectorizeMode
+from gymnasium.spaces import Discrete
+from gymnasium.utils.env_checker import data_equivalence
+from gymnasium.vector import AsyncVectorEnv, SyncVectorEnv
+from gymnasium.vector.vector_env import AutoresetMode
+from tests.testing_env import GenericTestEnv
+
+
+def count_reset(
+    self: GenericTestEnv, seed: int | None = None, options: dict | None = None
+):
+    super(GenericTestEnv, self).reset(seed=seed)
+
+    self.count = seed if seed is not None else 0
+    return self.count, {}
+
+
+def count_step(self: GenericTestEnv, action):
+    self.count += 1
+
+    return self.count, action, self.count == self.max_count, False, {}
+
+
+@pytest.mark.parametrize(
+    "vectoriser",
+    [
+        SyncVectorEnv,
+        AsyncVectorEnv,
+        partial(AsyncVectorEnv, shared_memory=False),
+    ],
+    ids=["Sync", "Async(shared_memory=True)", "Async(shared_memory=False)"],
+)
+def test_autoreset_next_step(vectoriser):
+    envs = vectoriser(
+        [
+            lambda: GenericTestEnv(
+                action_space=Discrete(5),
+                observation_space=Discrete(5),
+                reset_func=count_reset,
+                step_func=count_step,
+            )
+            for _ in range(3)
+        ],
+        autoreset_mode=AutoresetMode.NEXT_STEP,
+    )
+    print(f"{envs.metadata=}")
+    assert envs.metadata["autoreset_mode"] == AutoresetMode.NEXT_STEP
+    envs.set_attr("max_count", [2, 3, 3])
+
+    obs, info = envs.reset()
+    assert np.all(obs == [0, 0, 0])
+    assert info == {}
+
+    obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
+    assert np.all(obs == [1, 1, 1])
+    assert np.all(rewards == [1, 2, 3])
+    assert np.all(terminations == [False, False, False])
+    assert np.all(truncations == [False, False, False])
+    assert info == {}
+
+    obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
+    assert np.all(obs == [2, 2, 2])
+    assert np.all(rewards == [1, 2, 3])
+    assert np.all(terminations == [True, False, False])
+    assert np.all(truncations == [False, False, False])
+    assert info == {}
+
+    obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
+    assert np.all(obs == [0, 3, 3])
+    assert np.all(rewards == [0, 2, 3])
+    assert np.all(terminations == [False, True, True])
+    assert np.all(truncations == [False, False, False])
+    assert info == {}
+
+    obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
+    assert np.all(obs == [1, 0, 0])
+    assert np.all(rewards == [1, 0, 0])
+    assert np.all(terminations == [False, False, False])
+    assert np.all(truncations == [False, False, False])
+    assert info == {}
+
+    envs.close()
+
+
+@pytest.mark.parametrize(
+    "vectoriser",
+    [
+        SyncVectorEnv,
+        AsyncVectorEnv,
+        partial(AsyncVectorEnv, shared_memory=False),
+    ],
+    ids=["Sync", "Async(shared_memory=True)", "Async(shared_memory=False)"],
+)
+def test_autoreset_within_step(vectoriser):
+    envs = vectoriser(
+        [
+            lambda: GenericTestEnv(
+                action_space=Discrete(5),
+                observation_space=Discrete(5),
+                reset_func=count_reset,
+                step_func=count_step,
+            )
+            for _ in range(3)
+        ],
+        autoreset_mode=AutoresetMode.SAME_STEP,
+    )
+    assert envs.metadata["autoreset_mode"] == AutoresetMode.SAME_STEP
+    envs.set_attr("max_count", [2, 3, 3])
+
+    obs, info = envs.reset()
+    assert np.all(obs == [0, 0, 0])
+    assert info == {}
+
+    obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
+    assert np.all(obs == [1, 1, 1])
+    assert np.all(rewards == [1, 2, 3])
+    assert np.all(terminations == [False, False, False])
+    assert np.all(truncations == [False, False, False])
+    assert info == {}
+
+    obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
+    assert np.all(obs == [0, 2, 2])
+    assert np.all(rewards == [1, 2, 3])
+    assert np.all(terminations == [True, False, False])
+    assert np.all(truncations == [False, False, False])
+    assert data_equivalence(
+        info,
+        {
+            "final_obs": np.array([2, 0, 0]),
+            "final_info": {},
+            "_final_obs": np.array([True, False, False]),
+            "_final_info": np.array([True, False, False]),
+        },
+    )
+
+    obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
+    assert np.all(obs == [1, 0, 0])
+    assert np.all(rewards == [1, 2, 3])
+    assert np.all(terminations == [False, True, True])
+    assert np.all(truncations == [False, False, False])
+    assert data_equivalence(
+        info,
+        {
+            "final_obs": np.array([0, 3, 3]),
+            "final_info": {},
+            "_final_obs": np.array([False, True, True]),
+            "_final_info": np.array([False, True, True]),
+        },
+    )
+
+    obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
+    assert np.all(obs == [0, 1, 1])
+    assert np.all(rewards == [1, 2, 3])
+    assert np.all(terminations == [True, False, False])
+    assert np.all(truncations == [False, False, False])
+    assert data_equivalence(
+        info,
+        {
+            "final_obs": np.array([2, 0, 0]),
+            "final_info": {},
+            "_final_obs": np.array([True, False, False]),
+            "_final_info": np.array([True, False, False]),
+        },
+    )
+
+    envs.close()
+
+
+@pytest.mark.parametrize(
+    "vectoriser",
+    [
+        SyncVectorEnv,
+        AsyncVectorEnv,
+        partial(AsyncVectorEnv, shared_memory=False),
+    ],
+    ids=["Sync", "Async(shared_memory=True)", "Async(shared_memory=False)"],
+)
+def test_autoreset_disabled(vectoriser):
+    envs = vectoriser(
+        [
+            lambda: GenericTestEnv(
+                action_space=Discrete(5),
+                observation_space=Discrete(5),
+                reset_func=count_reset,
+                step_func=count_step,
+            )
+            for _ in range(3)
+        ],
+        autoreset_mode=AutoresetMode.DISABLED,
+    )
+    assert envs.metadata["autoreset_mode"] == AutoresetMode.DISABLED
+    envs.set_attr("max_count", [2, 3, 3])
+
+    obs, info = envs.reset()
+    assert np.all(obs == [0, 0, 0])
+    assert info == {}
+
+    obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
+    assert np.all(obs == [1, 1, 1])
+    assert np.all(rewards == [1, 2, 3])
+    assert np.all(terminations == [False, False, False])
+    assert np.all(truncations == [False, False, False])
+    assert info == {}
+
+    obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
+    assert np.all(obs == [2, 2, 2])
+    assert np.all(rewards == [1, 2, 3])
+    assert np.all(terminations == [True, False, False])
+    assert np.all(truncations == [False, False, False])
+    assert info == {}
+
+    obs, info = envs.reset(options={"mask": terminations})
+    assert np.all(obs == [0, 2, 2])
+    assert info == {}
+
+    obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
+    assert np.all(obs == [1, 3, 3])
+    assert np.all(rewards == [1, 2, 3])
+    assert np.all(terminations == [False, True, True])
+    assert np.all(truncations == [False, False, False])
+    assert info == {}
+
+    obs, info = envs.reset(options={"mask": terminations})
+    assert np.all(obs == [1, 0, 0])
+    assert info == {}
+
+    obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
+    assert np.all(obs == [2, 1, 1])
+    assert np.all(rewards == [1, 2, 3])
+    assert np.all(terminations == [True, False, False])
+    assert np.all(truncations == [False, False, False])
+    assert info == {}
+
+    envs.close()
+
+
+@pytest.mark.parametrize(
+    "vectoriser",
+    [
+        SyncVectorEnv,
+        AsyncVectorEnv,
+        partial(AsyncVectorEnv, shared_memory=False),
+    ],
+    ids=["Sync", "Async(shared_memory=True)", "Async(shared_memory=False)"],
+)
+@pytest.mark.parametrize(
+    "autoreset_mode",
+    [AutoresetMode.NEXT_STEP, AutoresetMode.DISABLED, AutoresetMode.SAME_STEP],
+)
+def test_autoreset_metadata(vectoriser, autoreset_mode):
+    envs = vectoriser(
+        [lambda: GenericTestEnv(), lambda: GenericTestEnv()],
+        autoreset_mode=autoreset_mode,
+    )
+    assert envs.metadata["autoreset_mode"] == autoreset_mode
+    envs.close()
+
+    envs = vectoriser(
+        [lambda: GenericTestEnv(), lambda: GenericTestEnv()],
+        autoreset_mode=autoreset_mode.value,
+    )
+    assert envs.metadata["autoreset_mode"] == autoreset_mode
+    envs.close()
+
+
+@pytest.mark.parametrize(
+    "vectorization_mode", [VectorizeMode.SYNC, VectorizeMode.ASYNC]
+)
+@pytest.mark.parametrize(
+    "autoreset_mode",
+    [AutoresetMode.NEXT_STEP, AutoresetMode.DISABLED, AutoresetMode.SAME_STEP],
+)
+def test_make_vec_autoreset(vectorization_mode, autoreset_mode):
+    envs = gym.make_vec(
+        "CartPole-v1",
+        vectorization_mode=vectorization_mode,
+        vector_kwargs={"autoreset_mode": autoreset_mode},
+    )
+    envs.metadata["autoreset_mode"] = autoreset_mode
+    envs.close()
+
+    envs = gym.make_vec(
+        "CartPole-v1",
+        vectorization_mode=vectorization_mode,
+        vector_kwargs={"autoreset_mode": autoreset_mode.value},
+    )
+    envs.metadata["autoreset_mode"] = autoreset_mode
+    envs.close()

--- a/tests/vector/test_autoreset_mode.py
+++ b/tests/vector/test_autoreset_mode.py
@@ -52,7 +52,6 @@ def test_autoreset_next_step(vectoriser):
         ],
         autoreset_mode=AutoresetMode.NEXT_STEP,
     )
-    print(f"{envs.metadata=}")
     assert envs.metadata["autoreset_mode"] == AutoresetMode.NEXT_STEP
     envs.set_attr("max_count", [2, 3, 3])
 
@@ -135,7 +134,7 @@ def test_autoreset_within_step(vectoriser):
     assert data_equivalence(
         info,
         {
-            "final_obs": np.array([2, 0, 0]),
+            "final_obs": np.array([2, None, None], dtype=object),
             "final_info": {},
             "_final_obs": np.array([True, False, False]),
             "_final_info": np.array([True, False, False]),
@@ -150,7 +149,7 @@ def test_autoreset_within_step(vectoriser):
     assert data_equivalence(
         info,
         {
-            "final_obs": np.array([0, 3, 3]),
+            "final_obs": np.array([None, 3, 3], dtype=object),
             "final_info": {},
             "_final_obs": np.array([False, True, True]),
             "_final_info": np.array([False, True, True]),
@@ -165,7 +164,7 @@ def test_autoreset_within_step(vectoriser):
     assert data_equivalence(
         info,
         {
-            "final_obs": np.array([2, 0, 0]),
+            "final_obs": np.array([2, None, None], dtype=object),
             "final_info": {},
             "_final_obs": np.array([True, False, False]),
             "_final_info": np.array([True, False, False]),

--- a/tests/vector/test_autoreset_mode.py
+++ b/tests/vector/test_autoreset_mode.py
@@ -215,7 +215,7 @@ def test_autoreset_disabled(vectoriser):
     assert np.all(truncations == [False, False, False])
     assert info == {}
 
-    obs, info = envs.reset(options={"mask": terminations})
+    obs, info = envs.reset(options={"reset_mask": terminations})
     assert np.all(obs == [0, 2, 2])
     assert info == {}
 
@@ -226,7 +226,7 @@ def test_autoreset_disabled(vectoriser):
     assert np.all(truncations == [False, False, False])
     assert info == {}
 
-    obs, info = envs.reset(options={"mask": terminations})
+    obs, info = envs.reset(options={"reset_mask": terminations})
     assert np.all(obs == [1, 0, 0])
     assert info == {}
 

--- a/tests/vector/test_vector_env.py
+++ b/tests/vector/test_vector_env.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from functools import partial
 
 import numpy as np
@@ -267,20 +268,52 @@ def test_partial_reset_failure(vectoriser):
     )
 
     # Test first reset using a mask
-    with pytest.raises(AssertionError):
-        envs.reset(options={"reset_mask": np.array([True, True, False])})
+    # with pytest.raises(AssertionError):
+    #     envs.reset(options={"reset_mask": np.array([True, True, False])})
 
     # Reset with all trues
     envs.reset(options={"reset_mask": np.array([True, True, True])})
 
     # Reset with mask of an incorrect shape
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "`options['reset_mask': mask]` must have shape `(3,)`, got (1,)"
+        ),
+    ):
         envs.reset(options={"reset_mask": np.array([True])})
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "options['reset_mask': mask]` must have shape `(3,)`, got (4,)"
+        ),
+    ):
         envs.reset(options={"reset_mask": np.array([True, True, False, False])})
-    with pytest.raises(AssertionError):
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "`options['reset_mask': mask]` must have shape `(3,)`, got (1, 3)"
+        ),
+    ):
         envs.reset(options={"reset_mask": np.array([[True, True, True]])})
-    with pytest.raises(AssertionError):
-        envs.reset(options={"reset_mask": np.array([[1, 1, 0]])})
-    with pytest.raises(AssertionError):
-        envs.reset(options={"reset_mask": np.array([[1.0, 1.0, 0.0]])})
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "`options['reset_mask': mask]` must contain a boolean array, got reset_mask=[False False False]"
+        ),
+    ):
+        envs.reset(options={"reset_mask": np.array([False, False, False])})
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "`options['reset_mask': mask]` must have `dtype=np.bool_`, got int64"
+        ),
+    ):
+        envs.reset(options={"reset_mask": np.array([1, 1, 0])})
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "`options['reset_mask': mask]` must have `dtype=np.bool_`, got float64"
+        ),
+    ):
+        envs.reset(options={"reset_mask": np.array([1.0, 1.0, 0.0])})

--- a/tests/vector/test_vector_env.py
+++ b/tests/vector/test_vector_env.py
@@ -235,18 +235,18 @@ def test_partial_reset(vectoriser):
         [lambda: gym.make("CartPole-v1") for _ in range(3)],
         autoreset_mode=AutoresetMode.DISABLED,
     )
-    initial_obs, initial_info = envs.reset(seed=[0, 1, 2])
+    reset_obs, _ = envs.reset(seed=[0, 1, 2])
 
     envs.action_space.seed(123)
     envs.step(envs.action_space.sample())
     envs.step(envs.action_space.sample())
     step_obs, *_ = envs.step(envs.action_space.sample())
 
-    mask_obs, mask_info = envs.reset(
-        seed=[0, 1, 0], options={"mask": np.array([True, True, False])}
+    reset_mask_obs, _ = envs.reset(
+        seed=[0, 1, 0], options={"reset_mask": np.array([True, True, False])}
     )
-    assert np.all(mask_obs[:2] == initial_obs[:2])
-    assert np.all(mask_obs[2] == step_obs[2])
+    assert np.all(reset_mask_obs[:2] == reset_obs[:2])
+    assert np.all(reset_mask_obs[2] == step_obs[2])
 
     envs.close()
 

--- a/tests/vector/test_vector_env.py
+++ b/tests/vector/test_vector_env.py
@@ -19,13 +19,18 @@ from tests.vector.testing_utils import make_env
 
 
 @pytest.mark.parametrize("shared_memory", [True, False])
-def test_vector_env_equal(shared_memory):
+@pytest.mark.parametrize(
+    "autoreset_mode", [AutoresetMode.NEXT_STEP, AutoresetMode.SAME_STEP]
+)
+def test_vector_env_equal(shared_memory, autoreset_mode):
     """Test that vector environment are equal for both async and sync variants."""
     env_fns = [make_env("CartPole-v1", i) for i in range(4)]
     num_steps = 100
 
-    async_env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)
-    sync_env = SyncVectorEnv(env_fns)
+    async_env = AsyncVectorEnv(
+        env_fns, shared_memory=shared_memory, autoreset_mode=autoreset_mode
+    )
+    sync_env = SyncVectorEnv(env_fns, autoreset_mode=autoreset_mode)
 
     assert async_env.num_envs == sync_env.num_envs
     assert async_env.observation_space == sync_env.observation_space

--- a/tests/vector/test_vector_env.py
+++ b/tests/vector/test_vector_env.py
@@ -263,19 +263,19 @@ def test_partial_reset_failure(vectoriser):
 
     # Test first reset using a mask
     with pytest.raises(AssertionError):
-        envs.reset(options={"mask": np.array([True, True, False])})
+        envs.reset(options={"reset_mask": np.array([True, True, False])})
 
     # Reset with all trues
-    envs.reset(options={"mask": np.array([True, True, True])})
+    envs.reset(options={"reset_mask": np.array([True, True, True])})
 
     # Reset with mask of an incorrect shape
     with pytest.raises(AssertionError):
-        envs.reset(options={"mask": np.array([True])})
+        envs.reset(options={"reset_mask": np.array([True])})
     with pytest.raises(AssertionError):
-        envs.reset(options={"mask": np.array([True, True, False, False])})
+        envs.reset(options={"reset_mask": np.array([True, True, False, False])})
     with pytest.raises(AssertionError):
-        envs.reset(options={"mask": np.array([[True, True, True]])})
+        envs.reset(options={"reset_mask": np.array([[True, True, True]])})
     with pytest.raises(AssertionError):
-        envs.reset(options={"mask": np.array([[1, 1, 0]])})
+        envs.reset(options={"reset_mask": np.array([[1, 1, 0]])})
     with pytest.raises(AssertionError):
-        envs.reset(options={"mask": np.array([[1.0, 1.0, 0.0]])})
+        envs.reset(options={"reset_mask": np.array([[1.0, 1.0, 0.0]])})

--- a/tests/vector/test_vector_env_info.py
+++ b/tests/vector/test_vector_env_info.py
@@ -140,7 +140,7 @@ class ReturnInfoEnv(gym.Env):
 
 
 @pytest.mark.parametrize("vectorizer", [AsyncVectorEnv, SyncVectorEnv])
-def test_vectorizers(vectorizer):
+def test_vector_return_info(vectorizer):
     vec_env = vectorizer(
         [
             lambda: ReturnInfoEnv([{"a": 1}, {"c": np.array([1, 2])}]),

--- a/tests/wrappers/vector/test_vector_wrappers.py
+++ b/tests/wrappers/vector/test_vector_wrappers.py
@@ -19,6 +19,7 @@ from gymnasium import wrappers
 from gymnasium.spaces import Box, Dict, Discrete
 from gymnasium.utils.env_checker import data_equivalence
 from gymnasium.vector import VectorEnv
+from gymnasium.vector.vector_env import AutoresetMode
 from tests.testing_env import GenericTestEnv
 
 
@@ -36,6 +37,7 @@ def custom_environments():
     del gym.registry["DictObsEnv-v0"]
 
 
+@pytest.mark.parametrize("autoreset_mode", [AutoresetMode.NEXT_STEP, AutoresetMode.SAME_STEP])
 @pytest.mark.parametrize("num_envs", (1, 3))
 @pytest.mark.parametrize(
     "env_id, wrapper_name, kwargs",

--- a/tests/wrappers/vector/test_vector_wrappers.py
+++ b/tests/wrappers/vector/test_vector_wrappers.py
@@ -73,11 +73,11 @@ def custom_environments():
 )
 def test_vector_wrapper_equivalence(
     autoreset_mode: AutoresetMode,
+    num_envs: int,
     env_id: str,
     wrapper_name: str,
     kwargs: dict[str, Any],
-    num_envs: int,
-    custom_environments,
+    custom_environments,  # pytest fixture
     vectorization_mode: str = "sync",
     num_steps: int = 50,
 ):

--- a/tests/wrappers/vector/test_vector_wrappers.py
+++ b/tests/wrappers/vector/test_vector_wrappers.py
@@ -37,7 +37,9 @@ def custom_environments():
     del gym.registry["DictObsEnv-v0"]
 
 
-@pytest.mark.parametrize("autoreset_mode", [AutoresetMode.NEXT_STEP, AutoresetMode.SAME_STEP])
+@pytest.mark.parametrize(
+    "autoreset_mode", [AutoresetMode.NEXT_STEP, AutoresetMode.SAME_STEP]
+)
 @pytest.mark.parametrize("num_envs", (1, 3))
 @pytest.mark.parametrize(
     "env_id, wrapper_name, kwargs",
@@ -70,6 +72,7 @@ def custom_environments():
     ),
 )
 def test_vector_wrapper_equivalence(
+    autoreset_mode: AutoresetMode,
     env_id: str,
     wrapper_name: str,
     kwargs: dict[str, Any],


### PR DESCRIPTION
# Description

With the change in Gymnasium v1.0, some users have requested support for the other vector autoreset APIs / modes:
1. Next step - This is the default API. When a sub-environment terminates or truncates, its reset function is called in the next step. 
2. Same step - This is <1.0 API, on a sub-environment terminating or truncating; within this step, the sub-environment will call reset. The resulting terminating / truncating observation is stored in `info["final_obs"]` with the reset observation passed back to the step's `obs`. 
3. Partial reset / disabled autoreset - Some users wish to disable autoreset and partially reset the environment themselves. Though unadvised, partial resets can be used with the prior two APIs. This API will not autoreset on a termination or truncation signal. However, it raises an error if a step function is called on a sub-environment that has terminated or truncated without being partially reset. 

We have added support to the built-in `SyncVectorEnv` and `AsyncVectorEnv` using the `autoreset_mode` argument, which takes a str or Enum of `AutoresetMode` with the `metadata["autoreset_mode"]` specifying the implemented API. 

For custom vector environments, we highly recommend adding this metadata tag to help users and wrappers know the implemented API, as these environments can have any of the autoreset modes implemented.

Importantly, different built-in wrappers have different levels of compatibility; see the table below.

| Wrapper name                   | Next step autoreset | Same Step autorest | Partial reset | 
|--------------------------------|-------------------------|---------------------------|---------------|
| VectorObservationWrapper       | Yes                     | No                        | Yes           | 
| TransformObservation           | Yes                     | No                        | Yes           | 
| NormalizeObservation           | Yes                     | No                        | No            |
| VectorizeTransformObservation* | Yes                     | Yes                       | Yes           |
| RecordEpisodeStatistics        | Yes                     | Yes                       | Yes           |

\* all inherited wrappers from `VectorizeTransformObservation` are compatible (`FilterObservation`, `FlattenObservation`, `GrayscaleObservation`, `ResizeObservation`, `ReshapeObservation`, `DtypeObservation`).

All other reward and action wrappers should be fully compatible.

Why are some wrappers limited?
* For same-step autoreset, the final observation must also be transformed, such as for stateful wrappers like `NormalizeObservation` or wrappers that apply a batch-based transform such as `TransformObservation`. This is not possible to implement efficiently. Future PR could investigate adding this. 
* For partial resets (i.e., autoreset disabled), like the within-step autoreset, for stateful wrappers like `NormalizeObservation`, you would not wish to update the normalizer again for the non-final states. For simple Box space environments, it would be possible to add compatibility through filtering the observations, but for more complex spaces, like `Dict`, this is not efficiently possible. 
