### PR TITLE
Add width and height check for MujocoRenderer

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -702,6 +702,10 @@ class MujocoRenderer:
         Returns:
             If render_mode is "rgb_array" or "depth_array" it returns a numpy array in the specified format. "human" render mode does not return anything.
         """
+        if render_mode != "human":
+            assert (
+                self.width is not None and self.height is not None
+            ), f"The width: {self.width} and height: {self.height} cannot be `None` when the render_mode is not `human`."
 
         viewer = self._get_viewer(render_mode=render_mode)
 
@@ -715,11 +719,6 @@ class MujocoRenderer:
         - `WindowViewer` class for "human" render mode
         - `OffScreenViewer` class for "rgb_array" or "depth_array" render mode
         """
-        if render_mode != "human":
-            assert (
-                self.width is not None and self.height is not None
-            ), f"The width: {self.width} and height: {self.height} cannot be `None` when the render_mode is not `human`."
-
         self.viewer = self._viewers.get(render_mode)
         if self.viewer is None:
             if render_mode == "human":

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -715,6 +715,11 @@ class MujocoRenderer:
         - `WindowViewer` class for "human" render mode
         - `OffScreenViewer` class for "rgb_array" or "depth_array" render mode
         """
+        if render_mode != "human":
+            assert (
+                self.width is not None and self.height is not None
+            ), "The width and height cannot be `None` when the render_mode is not Human."
+
         self.viewer = self._viewers.get(render_mode)
         if self.viewer is None:
             if render_mode == "human":

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -718,7 +718,7 @@ class MujocoRenderer:
         if render_mode != "human":
             assert (
                 self.width is not None and self.height is not None
-            ), "The width and height cannot be `None` when the render_mode is not Human."
+            ), f"The width: {self.width} and height: {self.height} cannot be `None` when the render_mode is not `human`."
 
         self.viewer = self._viewers.get(render_mode)
         if self.viewer is None:


### PR DESCRIPTION
# Description

The width and height of OffScreenViewer cannot be None otherwise, it will cause the error. Adding a type check before creating the opengl_context could provide more information for debugging.

Fixes #1225

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes