### PR TITLE
Add uv to install pip deps in workflows

### DIFF
--- a/bin/all-py.Dockerfile
+++ b/bin/all-py.Dockerfile
@@ -19,19 +19,21 @@ RUN apt-get -y update \
 
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/root/.mujoco/mujoco210/bin"
 
+RUN pip install uv
+
 # Build mujoco-py from source. Pypi installs wheel packages and Cython won't recompile old file versions in the Github Actions CI.
 # Thus generating the following error https://github.com/cython/cython/pull/4428
 RUN git clone https://github.com/openai/mujoco-py.git\
     && cd mujoco-py \
-    && pip install -e .
+    && uv pip install --system -e .
 
 COPY . /usr/local/gymnasium/
 WORKDIR /usr/local/gymnasium/
 
 # Specify the numpy version to cover both 1.x and 2.x
-RUN pip install --upgrade "numpy$NUMPY_VERSION"
+RUN uv pip install --system --upgrade "numpy$NUMPY_VERSION"
 
 # Test with PyTorch CPU build, since CUDA is not available in CI anyway
-RUN pip install .[all,testing] --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu
+RUN uv pip install --system .[all,testing] --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu
 
 ENTRYPOINT ["/usr/local/gymnasium/bin/docker_entrypoint"]

--- a/bin/necessary-py.Dockerfile
+++ b/bin/necessary-py.Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get -y update \
 COPY . /usr/local/gymnasium/
 WORKDIR /usr/local/gymnasium/
 
-RUN pip install --upgrade "numpy>=1.21,<2.0"
-RUN pip install .[testing] --no-cache-dir
+RUN pip install uv
+RUN uv pip install --system --upgrade "numpy>=1.21,<2.0"
+RUN uv pip install --system .[testing] --no-cache-dir
 
 ENTRYPOINT ["/usr/local/gymnasium/bin/docker_entrypoint"]


### PR DESCRIPTION
Building the docker container now takes ~1min40, was 2min40 before. 