### PR TITLE
Update basic_usage.md

### DIFF
--- a/docs/introduction/basic_usage.md
+++ b/docs/introduction/basic_usage.md
@@ -49,7 +49,7 @@ In reinforcement learning, the classic "agent-environment loop" pictured below i
 :class: only-dark
 ```
 
-For Gymnasium, the "agent-environment-loop" is implemented below for a single episode (until the environment ends). See the next section for a line-by-line explanation. Note that running this code requires installing swig (`pip install swig` or [download](https://www.swig.org/download.html)) along with `pip install gymnasium[box2d]`.
+For Gymnasium, the "agent-environment-loop" is implemented below for a single episode (until the environment ends). See the next section for a line-by-line explanation. Note that running this code requires installing swig (`pip install swig` or [download](https://www.swig.org/download.html)) along with `pip install "gymnasium[box2d]"`.
 
 ```python
 import gymnasium as gym


### PR DESCRIPTION
# Description

I was following the basic usage example from the documentation and ran into:

```
$ pip install gymnasium[box2d]                    
zsh: no matches found: gymnasium[box2d]
```

It turns out one needs to wrap that argument into a single string.
The gymnasium error message for DependencyNotInstalled does this:

```
gymnasium.error.DependencyNotInstalled: pygame is not installed, run `pip install "gymnasium[box2d]"`
```

So this is a minor documentation fix.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x ] Documentation only change (no code changed)

### Screenshots


# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
