### PR TITLE
Add Itomori custom env to third_party_environments.md

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -224,7 +224,7 @@ goal-RL ([Gymnasium-Robotics](https://robotics.farama.org/)).
   ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.29.1-blue)
   ![GitHub stars](https://img.shields.io/github/stars/gustavo-moura/itomori)
 
-  Itomori is a Gymnasium environment for risk-aware UAV flight. Designed as part of a research project, Itomori provides tools to solve Chance-Constrained Markov Decision Processes (CCMDP). The env allows to simulate, visualize, and evaluate UAV navigation in complex and risky environments, incorporating variables like GPS uncertainty, collision risk, and adaptive flight planning. Itomori is intended to support UAV path-planning research by offering adjustable parameters, detailed visualizations, and insights into agent behavior in uncertain environments.
+  Itomori is an environment for risk-aware UAV flight, it provides tools to solve Chance-Constrained Markov Decision Processes (CCMDP). The env allows to simulate, visualize, and evaluate UAV navigation in complex and risky environments, incorporating variables like GPS uncertainty, collision risk, and adaptive flight planning. Itomori is intended to support UAV path-planning research by offering adjustable parameters, detailed visualizations, and insights into agent behavior in uncertain environments.
 
 - [OmniIsaacGymEnvs: Gym environments for NVIDIA Omniverse Isaac ](https://github.com/NVIDIA-Omniverse/OmniIsaacGymEnvs/)
 

--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -219,6 +219,13 @@ goal-RL ([Gymnasium-Robotics](https://robotics.farama.org/)).
 
   A simple environment using [PyBullet](https://github.com/bulletphysics/bullet3) to simulate the dynamics of a [Bitcraze Crazyflie 2.x](https://www.bitcraze.io/documentation/hardware/crazyflie_2_1/crazyflie_2_1-datasheet.pdf) nanoquadrotor.
 
+- [Itomori: UAV Risk-aware Flight Environment](https://github.com/gustavo-moura/itomori)
+
+  ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.29.1-blue)
+  ![GitHub stars](https://img.shields.io/github/stars/gustavo-moura/itomori)
+
+  Itomori is a Gymnasium environment for risk-aware UAV flight. Designed as part of a research project, Itomori provides tools to solve Chance-Constrained Markov Decision Processes (CCMDP). The env allows to simulate, visualize, and evaluate UAV navigation in complex and risky environments, incorporating variables like GPS uncertainty, collision risk, and adaptive flight planning. Itomori is intended to support UAV path-planning research by offering adjustable parameters, detailed visualizations, and insights into agent behavior in uncertain environments.
+
 - [OmniIsaacGymEnvs: Gym environments for NVIDIA Omniverse Isaac ](https://github.com/NVIDIA-Omniverse/OmniIsaacGymEnvs/)
 
   Reinforcement Learning Environments for [Omniverse Isaac simulator](https://docs.omniverse.nvidia.com/app_isaacsim/app_isaacsim/overview.html).


### PR DESCRIPTION
# Description

Contribute third_party_environments.md, add links to Itomori, a custom gymnasium environment used to explore UAV agents in a risky environment, used to do research on chance constrained MDPs.
No additional dependencies needed.

## Type of change

Please delete options that are not relevant.

- [X] Documentation only change (no code changed)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

(Not applicable(?) - it's just changes to the md file.)
If there's anything I need to run, please let me know.