### PR TITLE
StickyAction wrapper can repeat the old action for more than 1 step

### DIFF
--- a/gymnasium/wrappers/stateful_action.py
+++ b/gymnasium/wrappers/stateful_action.py
@@ -18,7 +18,8 @@ class StickyAction(
     """Adds a probability that the action is repeated for the same ``step`` function.
 
     This wrapper follows the implementation proposed by `Machado et al., 2018 <https://arxiv.org/pdf/1709.06009.pdf>`_
-    in Section 5.2 on page 12.
+    in Section 5.2 on page 12, and adds the possibility to repeat the action for
+    more than one step.
 
     No vector version of the wrapper exists.
 
@@ -42,17 +43,25 @@ class StickyAction(
     """
 
     def __init__(
-        self, env: gym.Env[ObsType, ActType], repeat_action_probability: float
+        self, env: gym.Env[ObsType, ActType],
+        repeat_action_probability: float,
+        repeat_action_duration: int = 1,
     ):
         """Initialize StickyAction wrapper.
 
         Args:
-            env (Env): the wrapped environment
-            repeat_action_probability (int | float): a probability of repeating the old action.
+            env (Env): the wrapped environment,
+            repeat_action_probability (int | float): a probability of repeating the old action,
+            repeat_action_duration (int): the number of steps the action is repeated.
         """
         if not 0 <= repeat_action_probability < 1:
             raise InvalidProbability(
                 f"repeat_action_probability should be in the interval [0,1). Received {repeat_action_probability}"
+            )
+
+        if repeat_action_duration < 1:
+            raise ValueError(
+                f"repeat_action_duration should be larger or equal than 1. Received {repeat_action_duration}"
             )
 
         gym.utils.RecordConstructorArgs.__init__(
@@ -61,23 +70,35 @@ class StickyAction(
         gym.ActionWrapper.__init__(self, env)
 
         self.repeat_action_probability = repeat_action_probability
+        self.repeat_action_duration = repeat_action_duration
         self.last_action: ActType | None = None
+        self.last_action_repeats = 0
+        self.is_repeating = False
 
     def reset(
         self, *, seed: int | None = None, options: dict[str, Any] | None = None
     ) -> tuple[ObsType, dict[str, Any]]:
         """Reset the environment."""
         self.last_action = None
+        self.last_action_repeats = 0
+        self.is_repeating = False
 
         return super().reset(seed=seed, options=options)
 
     def action(self, action: ActType) -> ActType:
         """Execute the action."""
         if (
-            self.last_action is not None
+            self.is_repeating
+            or self.last_action is not None
             and self.np_random.uniform() < self.repeat_action_probability
         ):
             action = self.last_action
+            self.is_repeating = True
+            self.last_action_repeats += 1
+
+        if self.last_action_repeats == self.repeat_action_duration:
+            self.is_repeating = False
+            self.last_action_repeats = 0
 
         self.last_action = action
         return action

--- a/gymnasium/wrappers/stateful_action.py
+++ b/gymnasium/wrappers/stateful_action.py
@@ -43,7 +43,8 @@ class StickyAction(
     """
 
     def __init__(
-        self, env: gym.Env[ObsType, ActType],
+        self,
+        env: gym.Env[ObsType, ActType],
         repeat_action_probability: float,
         repeat_action_duration: int = 1,
     ):

--- a/tests/wrappers/test_sticky_action.py
+++ b/tests/wrappers/test_sticky_action.py
@@ -16,16 +16,29 @@ def test_sticky_action():
         repeat_action_probability=0.5,
     )
 
-    previous_action = None
-    for _ in range(NUM_STEPS):
-        input_action = env.action_space.sample()
-        executed_action, _, _, _, _ = env.step(input_action)
+previous_action = None
+for _ in range(NUM_STEPS):
+    input_action = env.action_space.sample()
+    executed_action, _, _, _, _ = env.step(input_action)
 
-        assert np.all(executed_action == input_action) or np.all(
-            executed_action == previous_action
-        )
-        previous_action = executed_action
+    assert np.all(executed_action == input_action) or np.all(
+        executed_action == previous_action
+    )
+    previous_action = executed_action
 
+env = StickyAction(
+    GenericTestEnv(step_func=record_action_as_obs_step),
+    repeat_action_probability=0.5, repeat_action_duration=4,
+)
+
+previous_action = None
+for _ in range(NUM_STEPS):
+    input_action = env.action_space.sample()
+    executed_action, _, _, _, _ = env.step(input_action)
+    assert np.all(executed_action == input_action) or np.all(
+        executed_action == previous_action
+    )
+    previous_action = executed_action
 
 @pytest.mark.parametrize("repeat_action_probability", [-1, 1, 1.5])
 def test_sticky_action_raise(repeat_action_probability):
@@ -33,4 +46,12 @@ def test_sticky_action_raise(repeat_action_probability):
     with pytest.raises(InvalidProbability):
         StickyAction(
             GenericTestEnv(), repeat_action_probability=repeat_action_probability
+        )
+
+@pytest.mark.parametrize("repeat_action_duration", [-4, 0])
+def test_sticky_action_raise(repeat_action_duration):
+    """Tests the stick action wrapper with durations that should raise an error."""
+    with pytest.raises(ValueError):
+        StickyAction(
+            GenericTestEnv(), 0.5, repeat_action_duration=repeat_action_duration
         )

--- a/tests/wrappers/test_sticky_action.py
+++ b/tests/wrappers/test_sticky_action.py
@@ -16,40 +16,43 @@ def test_sticky_action():
         repeat_action_probability=0.5,
     )
 
-previous_action = None
-for _ in range(NUM_STEPS):
-    input_action = env.action_space.sample()
-    executed_action, _, _, _, _ = env.step(input_action)
+    previous_action = None
+    for _ in range(NUM_STEPS):
+        input_action = env.action_space.sample()
+        executed_action, _, _, _, _ = env.step(input_action)
 
-    assert np.all(executed_action == input_action) or np.all(
-        executed_action == previous_action
+        assert np.all(executed_action == input_action) or np.all(
+            executed_action == previous_action
+        )
+        previous_action = executed_action
+
+    env = StickyAction(
+        GenericTestEnv(step_func=record_action_as_obs_step),
+        repeat_action_probability=0.5,
+        repeat_action_duration=4,
     )
-    previous_action = executed_action
 
-env = StickyAction(
-    GenericTestEnv(step_func=record_action_as_obs_step),
-    repeat_action_probability=0.5, repeat_action_duration=4,
-)
+    previous_action = None
+    for _ in range(NUM_STEPS):
+        input_action = env.action_space.sample()
+        executed_action, _, _, _, _ = env.step(input_action)
+        assert np.all(executed_action == input_action) or np.all(
+            executed_action == previous_action
+        )
+        previous_action = executed_action
 
-previous_action = None
-for _ in range(NUM_STEPS):
-    input_action = env.action_space.sample()
-    executed_action, _, _, _, _ = env.step(input_action)
-    assert np.all(executed_action == input_action) or np.all(
-        executed_action == previous_action
-    )
-    previous_action = executed_action
 
 @pytest.mark.parametrize("repeat_action_probability", [-1, 1, 1.5])
-def test_sticky_action_raise(repeat_action_probability):
+def test_sticky_action_raise_probability(repeat_action_probability):
     """Tests the stick action wrapper with probabilities that should raise an error."""
     with pytest.raises(InvalidProbability):
         StickyAction(
             GenericTestEnv(), repeat_action_probability=repeat_action_probability
         )
 
+
 @pytest.mark.parametrize("repeat_action_duration", [-4, 0])
-def test_sticky_action_raise(repeat_action_duration):
+def test_sticky_action_raise_duration(repeat_action_duration):
     """Tests the stick action wrapper with durations that should raise an error."""
     with pytest.raises(ValueError):
         StickyAction(


### PR DESCRIPTION
The StickyAction wrapper now takes an optional argument to allow the old action to be repeated for more than 1 steps (default is 1). The original behavior is unchanged. 

# Description

No fix, this is an extra feature. It increases the difficulty of sticky actions and the "non-Markovianity" of the environment (the more steps the action is repeated, the more in the past the agent should look to predict the next state). It can be useful for RL of non-Markov decision processes.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
