### PR TITLE
Fix parameter name in tutorial code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 # Virtualenv
 /env
 /venv
+/.venv
 
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info

--- a/docs/introduction/train_agent.md
+++ b/docs/introduction/train_agent.md
@@ -116,7 +116,7 @@ epsilon_decay = start_epsilon / (n_episodes / 2)  # reduce the exploration over 
 final_epsilon = 0.1
 
 env = gym.make("Blackjack-v1", sab=False)
-env = gym.wrappers.RecordEpisodeStatistics(env, deque_size=n_episodes)
+env = gym.wrappers.RecordEpisodeStatistics(env, buffer_length=n_episodes)
 
 agent = BlackjackAgent(
     env=env,

--- a/docs/tutorials/training_agents/blackjack_tutorial.py
+++ b/docs/tutorials/training_agents/blackjack_tutorial.py
@@ -275,7 +275,7 @@ agent = BlackjackAgent(
 #
 
 
-env = gym.wrappers.RecordEpisodeStatistics(env, deque_size=n_episodes)
+env = gym.wrappers.RecordEpisodeStatistics(env, buffer_length=n_episodes)
 for episode in tqdm(range(n_episodes)):
     obs, info = env.reset()
     done = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]  # kept for backward compatibility
 jax = ["jax >=0.4.0", "jaxlib >=0.4.0", "flax >=0.5.0"]
 torch = ["torch >=1.0.0"]
-other = ["moviepy >=1.0.0", "matplotlib >=3.0", "opencv-python >=3.0"]
+other = ["moviepy >=1.0.0", "matplotlib >=3.0", "opencv-python >=3.0", "seaborn >= 0.13"]
 all = [
     # All dependencies above except accept-rom-license
     # NOTE: No need to manually remove the duplicates, setuptools automatically does that.


### PR DESCRIPTION
# Description

There is something off in the blackjack tutorial code. The current version uses a `deque_size` parameter which doesn't  exist. I renamed it `buffer_length`, hoping this is the right parameter to use.

In order to test my code, I had to add a missing dependency (seaborn) to `pyproject.toml`.

I also gitignored the `/.venv` subfolder, which I think is quite frequently used for storing virtual envs.

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)
