### PR TITLE
Add rendering wrapper with noise

### DIFF
--- a/gymnasium/wrappers/__init__.py
+++ b/gymnasium/wrappers/__init__.py
@@ -58,7 +58,13 @@ from gymnasium.wrappers.common import (
     RecordEpisodeStatistics,
     TimeLimit,
 )
-from gymnasium.wrappers.rendering import HumanRendering, RecordVideo, RenderCollection
+from gymnasium.wrappers.rendering import (
+    AddWhiteNoise,
+    HumanRendering,
+    ObstructView,
+    RecordVideo,
+    RenderCollection,
+)
 from gymnasium.wrappers.stateful_action import StickyAction
 from gymnasium.wrappers.stateful_observation import (
     DelayObservation,
@@ -122,6 +128,8 @@ __all__ = [
     "OrderEnforcing",
     "RecordEpisodeStatistics",
     # --- Rendering ---
+    "AddWhiteNoise",
+    "ObstructView",
     "RenderCollection",
     "RecordVideo",
     "HumanRendering",

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -17,7 +17,7 @@ import numpy as np
 import gymnasium as gym
 from gymnasium import error, logger
 from gymnasium.core import ActType, ObsType, RenderFrame
-from gymnasium.error import DependencyNotInstalled
+from gymnasium.error import DependencyNotInstalled, InvalidProbability
 
 
 __all__ = [

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -629,7 +629,9 @@ class AddWhiteNoise(
                 size=render_out.shape,
                 dtype=np.uint8,
             )
+
         mask = self.np_random.random(
             render_out.shape[0:2]
         ) < self.observation_noise_probability
+
         return np.where(mask[..., None], rnd_color, render_out)

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -571,8 +571,8 @@ class HumanRendering(
 class AddWhiteNoise(
     gym.Wrapper[ObsType, ActType, ObsType, ActType], gym.utils.RecordConstructorArgs
 ):
-    """
-    Randomly replaces pixels with white noise.
+    """Randomly replaces pixels with white noise.
+
     If used with ``render_mode="rgb_array"`` and ``AddRenderObservation``, it will
     make observations noisy.
     The environment may also become partially-observable, turning the MDP into a POMDP.
@@ -614,17 +614,20 @@ class AddWhiteNoise(
         self.grayscale_noise = grayscale_noise
 
     def render(self) -> RenderFrame:
-        """Compute the render frames as specified by render_mode attribute during
-        initialization of the environment, then add white noise."""
+        """Compute the render frames as specified by render_mode attribute during initialization of the environment, then add white noise."""
         render_out = super().render()
 
         if self.grayscale_noise:
-            rnd_color = self.np_random.integers(
-                (0, 0, 0),
-                255 * np.array([0.2989, 0.5870, 0.1140]),
-                size=render_out.shape,
-                dtype=np.uint8,
-            ).sum(-1, keepdims=True).repeat(3, -1)
+            rnd_color = (
+                self.np_random.integers(
+                    (0, 0, 0),
+                    255 * np.array([0.2989, 0.5870, 0.1140]),
+                    size=render_out.shape,
+                    dtype=np.uint8,
+                )
+                .sum(-1, keepdims=True)
+                .repeat(3, -1)
+            )
         else:
             rnd_color = self.np_random.integers(
                 0,
@@ -633,9 +636,10 @@ class AddWhiteNoise(
                 dtype=np.uint8,
             )
 
-        mask = self.np_random.random(
-            render_out.shape[0:2]
-        ) < self.observation_noise_probability
+        mask = (
+            self.np_random.random(render_out.shape[0:2])
+            < self.observation_noise_probability
+        )
 
         return np.where(mask[..., None], rnd_color, render_out)
 
@@ -643,8 +647,8 @@ class AddWhiteNoise(
 class ObstructView(
     gym.Wrapper[ObsType, ActType, ObsType, ActType], gym.utils.RecordConstructorArgs
 ):
-    """
-    Randomly obstructs rendering with white noise patches.
+    """Randomly obstructs rendering with white noise patches.
+
     If used with ``render_mode="rgb_array"`` and ``AddRenderObservation``, it will
     make observations noisy.
     The number of patches depends on how many pixels we want to obstruct.
@@ -692,13 +696,12 @@ class ObstructView(
         )
         gym.Wrapper.__init__(self, env)
 
-        self.obstruction_centers_ratio = obstructed_pixels_ratio / obstruction_width ** 2
+        self.obstruction_centers_ratio = obstructed_pixels_ratio / obstruction_width**2
         self.obstruction_width = obstruction_width
         self.grayscale_noise = grayscale_noise
 
     def render(self) -> RenderFrame:
-        """Compute the render frames as specified by render_mode attribute during
-        initialization of the environment, then add white noise patches."""
+        """Compute the render frames as specified by render_mode attribute during initialization of the environment, then add white noise patches."""
         render_out = super().render()
 
         render_shape = render_out.shape
@@ -716,12 +719,16 @@ class ObstructView(
             ] = True
 
         if self.grayscale_noise:
-            rnd_color = self.np_random.integers(
-                (0, 0, 0),
-                255 * np.array([0.2989, 0.5870, 0.1140]),
-                size=render_out.shape,
-                dtype=np.uint8,
-            ).sum(-1, keepdims=True).repeat(3, -1)
+            rnd_color = (
+                self.np_random.integers(
+                    (0, 0, 0),
+                    255 * np.array([0.2989, 0.5870, 0.1140]),
+                    size=render_out.shape,
+                    dtype=np.uint8,
+                )
+                .sum(-1, keepdims=True)
+                .repeat(3, -1)
+            )
         else:
             rnd_color = self.np_random.integers(
                 0,

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -579,7 +579,7 @@ class AddWhiteNoise(
 
     Example - Every pixel will be replaced by white noise with probability 0.5:
         >>> env = gym.make("LunarLander-v3", render_mode="rgb_array")
-        >>> env = AddWhiteNoise(env, observation_noise_probability=0.5)
+        >>> env = AddWhiteNoise(env, probability_of_noise_per_pixel=0.5)
         >>> env = HumanRendering(env)
         >>> obs, _ = env.reset(seed=123)
         >>> obs, *_ = env.step(env.action_space.sample())
@@ -588,37 +588,37 @@ class AddWhiteNoise(
     def __init__(
         self,
         env: gym.Env[ObsType, ActType],
-        observation_noise_probability: float,
-        grayscale_noise: bool = False,
+        probability_of_noise_per_pixel: float,
+        is_noise_grayscale: bool = False,
     ):
         """Wrapper replaces random pixels with white noise.
 
         Args:
             env: The environment that is being wrapped
-            observation_noise_probability: the probability that a pixel is white noise
-            grayscale_noise: if True, RGB noise is converted to grayscale
+            probability_of_noise_per_pixel: the probability that a pixel is white noise
+            is_noise_grayscale: if True, RGB noise is converted to grayscale
         """
-        if not 0 <= observation_noise_probability < 1:
+        if not 0 <= probability_of_noise_per_pixel < 1:
             raise InvalidProbability(
-                f"observation_noise_probability should be in the interval [0,1). Received {observation_noise_probability}"
+                f"probability_of_noise_per_pixel should be in the interval [0,1). Received {probability_of_noise_per_pixel}"
             )
 
         gym.utils.RecordConstructorArgs.__init__(
             self,
-            observation_noise_probability=observation_noise_probability,
-            grayscale_noise=grayscale_noise,
+            probability_of_noise_per_pixel=probability_of_noise_per_pixel,
+            is_noise_grayscale=is_noise_grayscale,
         )
         gym.Wrapper.__init__(self, env)
 
-        self.observation_noise_probability = observation_noise_probability
-        self.grayscale_noise = grayscale_noise
+        self.probability_of_noise_per_pixel = probability_of_noise_per_pixel
+        self.is_noise_grayscale = is_noise_grayscale
 
     def render(self) -> RenderFrame:
         """Compute the render frames as specified by render_mode attribute during initialization of the environment, then add white noise."""
         render_out = super().render()
 
-        if self.grayscale_noise:
-            rnd_color = (
+        if self.is_noise_grayscale:
+            noise = (
                 self.np_random.integers(
                     (0, 0, 0),
                     255 * np.array([0.2989, 0.5870, 0.1140]),
@@ -629,7 +629,7 @@ class AddWhiteNoise(
                 .repeat(3, -1)
             )
         else:
-            rnd_color = self.np_random.integers(
+            noise = self.np_random.integers(
                 0,
                 255,
                 size=render_out.shape,
@@ -638,10 +638,10 @@ class AddWhiteNoise(
 
         mask = (
             self.np_random.random(render_out.shape[0:2])
-            < self.observation_noise_probability
+            < self.probability_of_noise_per_pixel
         )
 
-        return np.where(mask[..., None], rnd_color, render_out)
+        return np.where(mask[..., None], noise, render_out)
 
 
 class ObstructView(
@@ -668,7 +668,7 @@ class ObstructView(
         env: gym.Env[ObsType, ActType],
         obstructed_pixels_ratio: float,
         obstruction_width: int,
-        grayscale_noise: bool = False,
+        is_noise_grayscale: bool = False,
     ):
         """Wrapper obstructs pixels with white noise patches.
 
@@ -676,7 +676,7 @@ class ObstructView(
             env: The environment that is being wrapped
             obstructed_pixels_ratio: the percentage of pixels obstructed with white noise
             obstruction_width: the width of the obstruction patches
-            grayscale_noise: if True, RGB noise is converted to grayscale
+            is_noise_grayscale: if True, RGB noise is converted to grayscale
         """
         if not 0 <= obstructed_pixels_ratio < 1:
             raise ValueError(
@@ -692,13 +692,13 @@ class ObstructView(
             self,
             obstructed_pixels_ratio=obstructed_pixels_ratio,
             obstruction_width=obstruction_width,
-            grayscale_noise=grayscale_noise,
+            is_noise_grayscale=is_noise_grayscale,
         )
         gym.Wrapper.__init__(self, env)
 
         self.obstruction_centers_ratio = obstructed_pixels_ratio / obstruction_width**2
         self.obstruction_width = obstruction_width
-        self.grayscale_noise = grayscale_noise
+        self.is_noise_grayscale = is_noise_grayscale
 
     def render(self) -> RenderFrame:
         """Compute the render frames as specified by render_mode attribute during initialization of the environment, then add white noise patches."""
@@ -718,8 +718,8 @@ class ObstructView(
                 max(y - low, 0) : min(y + high, render_shape[1]),
             ] = True
 
-        if self.grayscale_noise:
-            rnd_color = (
+        if self.is_noise_grayscale:
+            noise = (
                 self.np_random.integers(
                     (0, 0, 0),
                     255 * np.array([0.2989, 0.5870, 0.1140]),
@@ -730,11 +730,11 @@ class ObstructView(
                 .repeat(3, -1)
             )
         else:
-            rnd_color = self.np_random.integers(
+            noise = self.np_random.integers(
                 0,
                 255,
                 size=render_out.shape,
                 dtype=np.uint8,
             )
 
-        return np.where(mask[..., None], rnd_color, render_out)
+        return np.where(mask[..., None], noise, render_out)

--- a/tests/wrappers/test_white_noise_rendering.py
+++ b/tests/wrappers/test_white_noise_rendering.py
@@ -1,11 +1,7 @@
 """Test suite of AddWhiteNoise and ObstructView wrapper."""
 
-import re
-
-import pytest
-
 import gymnasium as gym
-from gymnasium.wrappers import AddWhiteNoise, ObstructView, HumanRendering
+from gymnasium.wrappers import AddWhiteNoise, HumanRendering, ObstructView
 
 
 def test_white_noise_rendering():

--- a/tests/wrappers/test_white_noise_rendering.py
+++ b/tests/wrappers/test_white_noise_rendering.py
@@ -1,0 +1,39 @@
+"""Test suite of AddWhiteNoise and ObstructView wrapper."""
+
+import re
+
+import pytest
+
+import gymnasium as gym
+from gymnasium.wrappers import AddWhiteNoise, ObstructView, HumanRendering
+
+
+def test_white_noise_rendering():
+    for mode in ["rgb_array"]:
+        env = gym.make("CartPole-v1", render_mode=mode, disable_env_checker=True)
+        env = AddWhiteNoise(env, probability_of_noise_per_pixel=0.5)
+        env = HumanRendering(env)
+
+        assert env.render_mode == "human"
+        env.reset()
+
+        for _ in range(75):
+            _, _, terminated, truncated, _ = env.step(env.action_space.sample())
+            if terminated or truncated:
+                env.reset()
+
+        env.close()
+
+        env = gym.make("CartPole-v1", render_mode=mode, disable_env_checker=True)
+        env = ObstructView(env, obstructed_pixels_ratio=0.5, obstruction_width=100)
+        env = HumanRendering(env)
+
+        assert env.render_mode == "human"
+        env.reset()
+
+        for _ in range(75):
+            _, _, terminated, truncated, _ = env.step(env.action_space.sample())
+            if terminated or truncated:
+                env.reset()
+
+        env.close()


### PR DESCRIPTION
# Description

Added two wrappers that add white noise to the rendering of the environments. 
The first simply randomly add white noise to every pixel according to some probability. 
The second adds biggers "patches" (the number of patches depends on the size of the patch and on what percentage of pixels we want to mask). 
Noise is different at every step. 

This is not a fix, but a new feature. It allows for noisy pixel observations and can easily make the environment partially-observable (especially the "patch" version). Helpful to turn MDPs into POMDPs from pixels. 

The reasons why I added it as a rendering wrapper and not an observation wrapper are:
1. It can be used with both RGB and grayscale rendering,
2. It can be used with other observation wrappers (e.g., both dictionary with both pixels and state),
3. It can be used with "human" rendering.

However, it currently does not work with "rgb_array_list", because the `render()` function expects a single frame but it receives a list of frames. I couldn't figure out how "rgb_array_list" work. The best thing would be to have the noise added right after the frame is created and before it is appened to the list, but I couldn't find where this happens. I am happy to look more into this and make this even more generic. 

One example of learning from pixels with noisy observation would be (`matplotlib` is just to show the noisy frame):

```python
import gymnasium as gym
from gymnasium.wrappers.rendering import ObstructView
from gymnasium.wrappers.transform_observation import AddRenderObservation

env = gym.make("LunarLander-v3", render_mode="rgb_array")
env = ObstructView(env, obstructed_pixels_ratio=0.5, obstruction_width=100)
env = AddRenderObservation(env)
obs, _ = env.reset(seed=123)

from matplotlib import pyplot as plt
plt.imshow(obs)
plt.show()
```

I am not sure if the name "ObstructedView" is the best, I am happy to rename it to a better fit. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### Screenshots

Here are some screenshots of the wrapper in action

```python
import gymnasium as gym
from gymnasium.wrappers.rendering import HumanRendering, AddWhiteNoise

env = gym.make("LunarLander-v3", render_mode="rgb_array")
env = AddWhiteNoise(env, probability_of_noise_per_pixel=0.5)
env = HumanRendering(env)
obs, _ = env.reset(seed=123)
obs, *_ = env.step(env.action_space.sample())
```

![image](https://github.com/user-attachments/assets/88a81398-7f41-4d31-bd2a-de73184c3269)


```python
import gymnasium as gym
from gymnasium.wrappers.rendering import HumanRendering, ObstructView

env = gym.make("LunarLander-v3", render_mode="rgb_array")
env = ObstructView(env, obstructed_pixels_ratio=0.5, obstruction_width=100)
env = HumanRendering(env)
obs, _ = env.reset(seed=123)
obs, *_ = env.step(env.action_space.sample())
```

![image](https://github.com/user-attachments/assets/3979777c-95a9-4890-bcef-81a2094640a1)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
