### PR TITLE
fixed typo in gymnasium/envs/toy_text/blackjack.py, 2-10 instead of 2-9

### DIFF
--- a/gymnasium/envs/toy_text/blackjack.py
+++ b/gymnasium/envs/toy_text/blackjack.py
@@ -59,7 +59,7 @@ class BlackjackEnv(gym.Env):
     The card values are:
     - Face cards (Jack, Queen, King) have a point value of 10.
     - Aces can either count as 11 (called a 'usable ace') or 1.
-    - Numerical cards (2-9) have a value equal to their number.
+    - Numerical cards (2-10) have a value equal to their number.
 
     The player has the sum of cards held. The player can request
     additional cards (hit) until they decide to stop (stick) or exceed 21 (bust,


### PR DESCRIPTION
# Description

This PR fixes a comment in line 62 in gymnasium/envs/toy_text/blackjack.py. The comment should say `- Numerical cards (2-10) have a value equal to their number.` instead of `- Numerical cards (2-9) have a value equal to their number.`

Fixes #1249 

## Type of change
- [x] Documentation only change (no code changed)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] My changes generate no new warnings

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
