### PR TITLE
Fix discrete CarRacing-v3

### DIFF
--- a/gymnasium/envs/box2d/car_racing.py
+++ b/gymnasium/envs/box2d/car_racing.py
@@ -541,8 +541,8 @@ class CarRacing(gym.Env, EzPickle):
     def step(self, action: Union[np.ndarray, int]):
         assert self.car is not None
         if action is not None:
-            action = action.astype(np.float64)
             if self.continuous:
+                action = action.astype(np.float64)
                 self.car.steer(-action[0])
                 self.car.gas(action[1])
                 self.car.brake(action[2])

--- a/tests/envs/test_env_implementation.py
+++ b/tests/envs/test_env_implementation.py
@@ -8,6 +8,7 @@ from gymnasium.envs.box2d import BipedalWalker, CarRacing
 from gymnasium.envs.box2d.lunar_lander import demo_heuristic_lander
 from gymnasium.envs.toy_text import CliffWalkingEnv, TaxiEnv
 from gymnasium.envs.toy_text.frozen_lake import generate_random_map
+from gymnasium.error import InvalidAction
 
 
 def test_lunar_lander_heuristics():
@@ -343,3 +344,29 @@ def test_cartpole_vector_equiv():
 
     env.close()
     envs.close()
+
+
+def test_discrete_action_validation():
+    env_ids = ["CarRacing-v3", "LunarLander-v3"]
+
+    for env_id in env_ids:
+        # get continuous action
+        continuous_env = gym.make(env_id, continuous=True)
+        continuous_action = continuous_env.action_space.sample()
+        continuous_env.close()
+
+        # create discrete env
+        discrete_env = gym.make(env_id, continuous=False).unwrapped
+        discrete_env.reset()
+
+        # expect InvalidAction (caused by CarRacing) or AssertionError (caused by LunarLander)
+        try:
+            discrete_env.step(continuous_action)
+        except Exception as e:
+            assert isinstance(e, InvalidAction) or isinstance(e, AssertionError)
+
+        # expect no error
+        discrete_env.reset()
+        discrete_action = discrete_env.action_space.sample()
+        discrete_env.step(discrete_action)
+        discrete_env.close()


### PR DESCRIPTION
# Description

CarRacing-v3 in discrete mode first converts the action to a float value before checking if the action is part of the discrete action-space. This causes an error to be raised.

Minimal example to reproduce this error:

```
import gymnasium as gym
env = gym.make("CarRacing-v3", continuous=False)
_ = env.reset()
action = env.action_space.sample()
_ = env.step(action)
```

This problem can be fixed simply by moving the float conversion to after the `if self.continuous:` check such that for the discrete case `else:` the action will still be an integer. And the `InvalidAction` error is not raised.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [NA] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
