### PR TITLE
fix typo in docs/api/wrappers/table.md

### DIFF
--- a/docs/api/wrappers/table.md
+++ b/docs/api/wrappers/table.md
@@ -47,7 +47,7 @@ wrapper in the page on the wrapper type
     * - :class:`NumpyToTorch`
       - Wraps a NumPy-based environment such that it can be interacted with PyTorch Tensors.
     * - :class:`OrderEnforcing`
-      - Will produce an error if ``step`` or ``render`` is called before ``render``.
+      - Will produce an error if ``step`` or ``render`` is called before ``reset``.
     * - :class:`PassiveEnvChecker`
       - A passive environment checker wrapper that surrounds the ``step``, ``reset`` and ``render`` functions to check they follows gymnasium's API.
     * - :class:`RecordEpisodeStatistics`


### PR DESCRIPTION
# Description

Fix an error in the docs: the wrapper checks if ```step``` and ```render``` are called before ```reset```, rather than previous ```render```.

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)

