### PR TITLE
Fix scaling in plots

### DIFF
--- a/docs/introduction/train_agent.md
+++ b/docs/introduction/train_agent.md
@@ -160,17 +160,17 @@ fig, axs = plt.subplots(1, 3, figsize=(20, 8))
 
 # np.convolve will compute the rolling mean for 100 episodes
 
-axs[0].plot(np.convolve(env.return_queue, np.ones(100)))
+axs[0].plot(np.convolve(env.return_queue, np.ones(100)/100))
 axs[0].set_title("Episode Rewards")
 axs[0].set_xlabel("Episode")
 axs[0].set_ylabel("Reward")
 
-axs[1].plot(np.convolve(env.length_queue, np.ones(100)))
+axs[1].plot(np.convolve(env.length_queue, np.ones(100)/100))
 axs[1].set_title("Episode Lengths")
 axs[1].set_xlabel("Episode")
 axs[1].set_ylabel("Length")
 
-axs[2].plot(np.convolve(agent.training_error, np.ones(100)))
+axs[2].plot(np.convolve(agent.training_error, np.ones(100)/100))
 axs[2].set_title("Training Error")
 axs[2].set_xlabel("Episode")
 axs[2].set_ylabel("Temporal Difference")


### PR DESCRIPTION
# Description

The convolution added in https://github.com/Farama-Foundation/Gymnasium/pull/1237/commits/28d50ce5fe99ce9d23e30ae7aa80e7a457ab7d0a doesn't average over 100 frames but sums them instead.


## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (**code changed**)
