### PR TITLE
Fix RecordEpisodeStatistics param in Blackjack Tutorial (one line)

### DIFF
--- a/docs/tutorials/training_agents/blackjack_tutorial.py
+++ b/docs/tutorials/training_agents/blackjack_tutorial.py
@@ -275,7 +275,7 @@ agent = BlackjackAgent(
 #
 
 
-env = gym.wrappers.RecordEpisodeStatistics(env, buffer_length=n_episodes)
+env = gym.wrappers.RecordEpisodeStatistics(env, deque_size=n_episodes)
 for episode in tqdm(range(n_episodes)):
     obs, info = env.reset()
     done = False


### PR DESCRIPTION
Looks like the API for RecordEpisodeStatistics changed at some point. Quick one-liner to get this working.

# Description

I tried running the tutorial and it didn't work without this change. Looks like it was out of date. Quick one-liner to get this tutorial working by using the update API for RecordEpisodeStatistics. 

https://github.com/openai/gym/blob/dcd185843a62953e27c2d54dc8c2d647d604b635/gym/wrappers/record_episode_statistics.py#L84C29-L84C29


## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
