### PR TITLE
Fix Mujoco Rendering for `rgb_array` that is upside down

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -258,7 +258,7 @@ class OffScreenViewer(BaseRender):
 
         # Process rendered images according to render_mode
         if render_mode in ["depth_array", "rgbd_tuple"]:
-            depth_img = depth_arr.reshape((self.viewport.width, self.viewport.height))
+            depth_img = depth_arr.reshape((self.viewport.height, self.viewport.width))
             # original image is upside-down, so flip it
             depth_img = depth_img[::-1, :]
         if render_mode in ["rgb_array", "rgbd_tuple"]:

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -258,11 +258,13 @@ class OffScreenViewer(BaseRender):
 
         # Process rendered images according to render_mode
         if render_mode in ["depth_array", "rgbd_tuple"]:
-            depth_img = depth_arr.reshape(self.viewport.height, self.viewport.width)
+            depth_img = depth_arr.reshape((self.viewport.width, self.viewport.height))
             # original image is upside-down, so flip it
             depth_img = depth_img[::-1, :]
         if render_mode in ["rgb_array", "rgbd_tuple"]:
-            rgb_img = rgb_arr.reshape(self.viewport.height, self.viewport.width, 3)
+            rgb_img = rgb_arr.reshape((self.viewport.height, self.viewport.width, 3))
+            # original image is upside-down, so flip it
+            rgb_img = rgb_img[::-1, :]
 
             if segmentation:
                 seg_img = (
@@ -281,8 +283,6 @@ class OffScreenViewer(BaseRender):
                         seg_ids[geom.segid + 1, 0] = geom.objtype
                         seg_ids[geom.segid + 1, 1] = geom.objid
                 rgb_img = seg_ids[seg_img]
-                # original image is upside-down, so flip it
-                rgb_img = rgb_img[::-1, :, :]
 
         # Return processed images based on render_mode
         if render_mode == "rgb_array":


### PR DESCRIPTION
# Description

Fixes #1261 as #1229 accidentally moved the `rgb_img = rgb_img[::-1, :, :]` to only be run when `segmentation` is True. 

