### PR TITLE
Added BlueSky-Gym to third party envs

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -48,6 +48,12 @@ goal-RL ([Gymnasium-Robotics](https://robotics.farama.org/)).
 ### Autonomous Driving environments
 *Autonomous Vehicle and traffic management.*
 
+- [BlueSky-Gym: Reinforcement Learning Environments for Air Traffic Applications](https://github.com/TUDelft-CNS-ATM/bluesky-gym)
+  ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.28.1-blue)
+  ![GitHub stars](https://img.shields.io/github/stars/TUDelft-CNS-ATM/bluesky-gym)
+
+  A collection of Gymnasium environments for air traffic management tasks, allowing for both civil and urban aviation applications. Build on the open-source air traffic simulator [BlueSky](https://github.com/TUDelft-CNS-ATM/bluesky).
+
 - [gym-electric-motor: Gym environments for electric motor simulations](https://github.com/upb-lea/gym-electric-motor)
 
   An environment for simulating a wide variety of electric drives taking into account different types of electric motors and converters.
@@ -62,12 +68,6 @@ goal-RL ([Gymnasium-Robotics](https://robotics.farama.org/)).
   ![GitHub stars](https://img.shields.io/github/stars/LucasAlegre/sumo-rl)
 
   Gymnasium wrapper for various environments in the SUMO traffic simulator. Supports both single and multiagent settings (using [pettingzoo](https://pettingzoo.farama.org/)).
-
-- [BlueSky-Gym: Reinforcement Learning Environments for Air Traffic Applications](https://github.com/TUDelft-CNS-ATM/bluesky-gym)
-  ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.28.1-blue)
-  ![GitHub stars](https://img.shields.io/github/stars/TUDelft-CNS-ATM/bluesky-gym)
-
-  A collection of Gymnasium environments for air traffic management tasks, allowing for both civil and urban aviation applications. Build on the open-source air traffic simulator [BlueSky](https://github.com/TUDelft-CNS-ATM/bluesky).
 
 ### Biological / Medical environments
 *Interacting with Biological Systems.*

--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -63,6 +63,12 @@ goal-RL ([Gymnasium-Robotics](https://robotics.farama.org/)).
 
   Gymnasium wrapper for various environments in the SUMO traffic simulator. Supports both single and multiagent settings (using [pettingzoo](https://pettingzoo.farama.org/)).
 
+- [BlueSky-Gym: Reinforcement Learning Environments for Air Traffic Applications](https://github.com/TUDelft-CNS-ATM/bluesky-gym)
+  ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.28.1-blue)
+  ![GitHub stars](https://img.shields.io/github/stars/TUDelft-CNS-ATM/bluesky-gym)
+
+  A collection of Gymnasium environments for air traffic management tasks, allowing for both civil and urban aviation applications. Build on the open-source air traffic simulator [BlueSky](https://github.com/TUDelft-CNS-ATM/bluesky).
+
 ### Biological / Medical environments
 *Interacting with Biological Systems.*
 


### PR DESCRIPTION
# Description

Add BlueSky-Gym, a collection of air traffic management environments to the third party environments ([https://github.com/TUDelft-CNS-ATM/bluesky-gym](url)).

Unsure where it would fit best, placed in 'Autonomous Driving environments' because it belongs to the sub-category autonomous vehicle and traffic management. 

## Type of change
- [x] Documentation only change (no code changed)

