### PR TITLE
Update mujoco_env.py xml file reading

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -126,7 +126,9 @@ class MujocoEnv(gym.Env):
         """
         Initialize MuJoCo simulation data structures `mjModel` and `mjData`.
         """
-        model = mujoco.MjModel.from_xml_path(self.fullpath)
+        with open(self.fullpath, 'r') as f:
+            xml_content = f.read()
+        model = mujoco.MjModel.from_xml_string(xml_content)
         # MjrContext will copy model.vis.global_.off* to con.off*
         model.vis.global_.offwidth = self.width
         model.vis.global_.offheight = self.height


### PR DESCRIPTION
# Description

Change: Avoid calling `from_xml_path` and instead first read the file and then call `from_xml_string` with the content. 

Issue: Calling `from_xml_path` gives the following error (although the file exists):
`ValueError: ParseXML: Error opening file 'C:\Users\karab\Desktop\Archive\Tübingen Archive\ML-4350 Reinforcement Learning\code\env\lib\site-packages\gymnasium\envs\mujoco\assets\half_cheetah.xml': No such file or directory`

It may be because, MuJoCo's C++ backend might handle file paths differently than Python. (See https://github.com/google-deepmind/mujoco/issues/257#issuecomment-1111139463)

Python: 3.9.13
gymnasium: 1.0.0
mujoco: 3.2.6

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


