### PR TITLE
fixed incorrect spacing BlueSky-Gym third_party_environments.md file

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -49,6 +49,7 @@ goal-RL ([Gymnasium-Robotics](https://robotics.farama.org/)).
 *Autonomous Vehicle and traffic management.*
 
 - [BlueSky-Gym: Reinforcement Learning Environments for Air Traffic Applications](https://github.com/TUDelft-CNS-ATM/bluesky-gym)
+
   ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v0.28.1-blue)
   ![GitHub stars](https://img.shields.io/github/stars/TUDelft-CNS-ATM/bluesky-gym)
 


### PR DESCRIPTION
# Description

Initial PR #1276 by did not have appropriate spacing in the .md file, causing the gymnasium version dependencies to be displayed in line:

![Screenshot 2024-12-16 at 14 17 02](https://github.com/user-attachments/assets/cd5c1624-a2e6-4666-b4c3-6913034ad3fb)

With this PR the file is changed to ensure appropriate spacing, consistent with the other environments:

![Screenshot 2024-12-16 at 14 18 42](https://github.com/user-attachments/assets/2f74426f-e8f7-435d-a279-22211a1cb1ac)

Apologies for not catching this in the first PR

## Type of change

- [x] Documentation only change (no code changed)

