### PR TITLE
Fixup for 'Training An Agent' page

### DIFF
--- a/docs/introduction/train_agent.md
+++ b/docs/introduction/train_agent.md
@@ -155,37 +155,44 @@ You can use `matplotlib` to visualize the training reward and length.
 
 ```python
 from matplotlib import pyplot as plt
-# visualize the episode rewards, episode length and training error in one figure
-fig, axs = plt.subplots(1, 3, figsize=(20, 8))
 
-# np.convolve will compute the rolling mean for 100 episodes
+def get_moving_avgs(arr, window, convolution_mode):
+    return np.convolve(
+        np.array(arr).flatten(),
+        np.ones(window),
+        mode=convolution_mode
+    ) / window
 
-axs[0].plot(np.convolve(env.return_queue, np.ones(100)/100))
-axs[0].set_title("Episode Rewards")
-axs[0].set_xlabel("Episode")
-axs[0].set_ylabel("Reward")
-
-axs[1].plot(np.convolve(env.length_queue, np.ones(100)/100))
-axs[1].set_title("Episode Lengths")
-axs[1].set_xlabel("Episode")
-axs[1].set_ylabel("Length")
-
-axs[2].plot(np.convolve(agent.training_error, np.ones(100)/100))
+# Smooth over a 500 episode window 
+rolling_length = 500
+fig, axs = plt.subplots(ncols=3, figsize=(12, 5))
+axs[0].set_title("Episode rewards")
+# compute and assign a rolling average of the data to provide a smoother graph
+reward_moving_average = (
+    get_moving_avgs(env.return_queue, rolling_length, "valid")
+    / rolling_length
+)
+axs[0].plot(range(len(reward_moving_average)), reward_moving_average)
+axs[1].set_title("Episode lengths")
+length_moving_average = (
+    get_moving_avgs(env.length_queue, rolling_length, "valid")
+    / rolling_length
+)
+axs[1].plot(range(len(length_moving_average)), length_moving_average)
 axs[2].set_title("Training Error")
-axs[2].set_xlabel("Episode")
-axs[2].set_ylabel("Temporal Difference")
-
+training_error_moving_average = (
+    get_moving_avgs(agent.training_error, rolling_length, "same")
+    / rolling_length
+)
+axs[2].plot(range(len(training_error_moving_average)), training_error_moving_average)
 plt.tight_layout()
 plt.show()
+
+
+
 ```
 
 ![](../_static/img/tutorials/blackjack_training_plots.png "Training Plot")
-
-## Visualising the policy
-
-![](../_static/img/tutorials/blackjack_with_usable_ace.png "With a usable ace")
-
-![](../_static/img/tutorials/blackjack_without_usable_ace.png "Without a usable ace")
 
 Hopefully this tutorial helped you get a grip of how to interact with Gymnasium environments and sets you on a journey to solve many more RL challenges.
 

--- a/docs/introduction/train_agent.md
+++ b/docs/introduction/train_agent.md
@@ -163,7 +163,7 @@ def get_moving_avgs(arr, window, convolution_mode):
         mode=convolution_mode
     ) / window
 
-# Smooth over a 500 episode window 
+# Smooth over a 500 episode window
 rolling_length = 500
 fig, axs = plt.subplots(ncols=3, figsize=(12, 5))
 axs[0].set_title("Episode rewards")


### PR DESCRIPTION
# Description

"Training An Agent" code does not match visual outputs. Short term solution is to change visualization code to match outputs. Long-term proposal to change page to be specifically about agent training and let users go to tutorial for black jack, or do away with page entirely. If keeping page, could turn into a 2-arm bandit e-greedy bandit.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)

### Screenshots

N/A (viewing markdown changes should suffice but can attach)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
