### PR TITLE
Add error message when terminating the MuJoCo renderer without calling `env.close`

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -367,7 +367,7 @@ class WindowViewer(BaseRender):
                     glfw.make_context_current(None)
                 glfw.destroy_window(self.window)
                 self.window = None
-        except AttributeError as e:
+        except AttributeError:
             # Handle cases where attributes are missing due to improper environment closure
             warn(
             "Environment was not properly closed using 'env.close()'. Please ensure to close the environment explicitly. "

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -1,11 +1,12 @@
 import os
 import time
 from typing import Dict, Optional
-
 import glfw
 import imageio
 import mujoco
 import numpy as np
+
+from gymnasium.logger import warn
 
 
 def _import_egl(width, height):
@@ -366,10 +367,12 @@ class WindowViewer(BaseRender):
                     glfw.make_context_current(None)
                 glfw.destroy_window(self.window)
                 self.window = None
-        except AttributeError:
+        except AttributeError as e:
             # Handle cases where attributes are missing due to improper environment closure
-            print("""Warning: Environment was not properly closed using 'env.close()'. Please ensure to close the environment explicitly. 
-                  GLFW module or dependencies are unloaded. Window cleanup might not have completed.""")
+            warn(
+            "Environment was not properly closed using 'env.close()'. Please ensure to close the environment explicitly. "
+            "GLFW module or dependencies are unloaded. Window cleanup might not have completed."
+            )
 
     def __del__(self):
         """Eliminate all of the OpenGL glfw contexts and windows"""

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -1,6 +1,7 @@
 import os
 import time
 from typing import Dict, Optional
+
 import glfw
 import imageio
 import mujoco
@@ -358,7 +359,7 @@ class WindowViewer(BaseRender):
 
     def free(self):
         """
-        Safely frees the OpenGL context and destroys the GLFW window, 
+        Safely frees the OpenGL context and destroys the GLFW window,
         handling potential issues during interpreter shutdown or resource cleanup.
         """
         try:
@@ -370,8 +371,8 @@ class WindowViewer(BaseRender):
         except AttributeError:
             # Handle cases where attributes are missing due to improper environment closure
             warn(
-            "Environment was not properly closed using 'env.close()'. Please ensure to close the environment explicitly. "
-            "GLFW module or dependencies are unloaded. Window cleanup might not have completed."
+                "Environment was not properly closed using 'env.close()'. Please ensure to close the environment explicitly. "
+                "GLFW module or dependencies are unloaded. Window cleanup might not have completed."
             )
 
     def __del__(self):

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -368,7 +368,8 @@ class WindowViewer(BaseRender):
                 self.window = None
         except AttributeError:
             # Handle cases where attributes are missing due to improper environment closure
-            print("Warning: Environment was not properly closed using 'env.close()'. Please ensure to close the environment explicitly. GLFW module or dependencies are unloaded. Window cleanup might not have completed.")
+            print("""Warning: Environment was not properly closed using 'env.close()'. Please ensure to close the environment explicitly. 
+                  GLFW module or dependencies are unloaded. Window cleanup might not have completed.""")
 
     def __del__(self):
         """Eliminate all of the OpenGL glfw contexts and windows"""

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -356,11 +356,19 @@ class WindowViewer(BaseRender):
         glfw.make_context_current(self.window)
 
     def free(self):
-        if self.window:
-            if glfw.get_current_context() == self.window:
-                glfw.make_context_current(None)
-            glfw.destroy_window(self.window)
-            self.window = None
+        """
+        Safely frees the OpenGL context and destroys the GLFW window, 
+        handling potential issues during interpreter shutdown or resource cleanup.
+        """
+        try:
+            if self.window:
+                if glfw.get_current_context() == self.window:
+                    glfw.make_context_current(None)
+                glfw.destroy_window(self.window)
+                self.window = None
+        except AttributeError:
+            # Handle cases where attributes are missing due to improper environment closure
+            print("Warning: Environment was not properly closed using 'env.close()'. Please ensure to close the environment explicitly. GLFW module or dependencies are unloaded. Window cleanup might not have completed.")
 
     def __del__(self):
         """Eliminate all of the OpenGL glfw contexts and windows"""


### PR DESCRIPTION
# Description

A detailed comment is provided in my name under the issue referenced. 

The change summary is:
- Added `AttributeError` exception handling to the `free()` method in `mujoco_rendering.py`.
- Gracefully handles freeing the OpenGL context and closing the GLFW window in the event that the user does not call `env.close()` before the program terminates when they've set `render_mode: 'human'`.
- Added docstring for the `free()` method.

Fixes  #1224

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
