### PR TITLE
Add `TimeAwareObservation` support for environments without a `spec`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-symlinks
       - id: destroyed-symlinks
@@ -35,7 +35,7 @@ repos:
           - --show-source
           - --statistics
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
@@ -44,7 +44,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/python/black
-    rev: 24.8.0
+    rev: 24.10.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/pydocstyle

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -198,9 +198,18 @@ class TimeAwareObservation(
         if env.spec is not None and env.spec.max_episode_steps is not None:
             self.max_timesteps = env.spec.max_episode_steps
         else:
-            raise ValueError(
-                "The environment must be wrapped by a TimeLimit wrapper or the spec specify a `max_episode_steps`."
-            )
+            # else we need to loop through the environment stack to check if a `TimeLimit` wrapper exists
+            wrapped_env = env
+            while isinstance(wrapped_env, gym.Wrapper):
+                if isinstance(wrapped_env, gym.wrappers.TimeLimit):
+                    self.max_timesteps = wrapped_env._max_episode_steps
+                    break
+                wrapped_env = wrapped_env.env
+
+            if not isinstance(wrapped_env, gym.wrappers.TimeLimit):
+                raise ValueError(
+                    "The environment must be wrapped by a TimeLimit wrapper or the spec specify a `max_episode_steps`."
+                )
 
         self.timesteps: int = 0
 


### PR DESCRIPTION
# Description

Fixes https://github.com/Farama-Foundation/Gymnasium/issues/1282 that adds support to the `TimeAwareObservation` wrapper for environments without a `spec`
Adds tests to check that this works