### PR TITLE
Fix `get_wrapper_attr` / `set_wrapper_attr`.

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -447,8 +447,8 @@ class Wrapper(
         # check if the base environment has the wrapper, otherwise, we set it on the top (this) wrapper
         if hasattr(sub_env, name):
             setattr(sub_env, name, value)
-
-        setattr(self, name, value)
+        else:
+            setattr(self, name, value)
 
     def __str__(self):
         """Returns the wrapper name and the :attr:`env` representation string."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -215,6 +215,16 @@ def test_get_set_wrapper_attr():
         env.unwrapped._disable_render_order_enforcing
     assert env.get_wrapper_attr("_disable_render_order_enforcing") is True
 
+    # Test with top-most wrapper
+    env.MY_ATTRIBUTE_1 = True
+    assert env.get_wrapper_attr("MY_ATTRIBUTE_1") is True
+    env.set_wrapper_attr("MY_ATTRIBUTE_1", False)
+    assert env.get_wrapper_attr("MY_ATTRIBUTE_1") is False
+
+    # Test with non-existing attribute
+    env.set_wrapper_attr("MY_ATTRIBUTE_2", True)
+    assert getattr(env, "MY_ATTRIBUTE_2") is True
+
 
 class TestRandomSeeding:
     @staticmethod


### PR DESCRIPTION
# Description

IMHO, the current implementation of `get_wrapper_attr` and `set_wrapper_attr` is flawed because they act inconsistently wrt each other. For instance, these two snippets is failing:
```python
import gymnasium as gym
env = gym.make("CartPole-v1")
env.MY_ATTRIBUTE = True
assert env.get_wrapper_attr("MY_ATTRIBUTE")
env.set_wrapper_attr("MY_ATTRIBUTE", False)
assert not env.get_wrapper_attr("MY_ATTRIBUTE")
```

```python
import gymnasium as gym
env = gym.make("CartPole-v1")
env.set_wrapper_attr("MY_ATTRIBUTE", False)
assert hasattr(env, "MY_ATTRIBUTE")
```

First, I think that if the top-most wrapper has the attribute, `set_wrapper_attr` should set it (by the way, this is what the documentation is stating). When it does not, then it is not clear whether it should raise an exception (basically the same than `get_wrapper_attr` or create the attribute (at a level to be determined). In the latter case, I think it definitely makes more sense to add the attribute to the top-most wrapper, otherwise the second snippet right above would still be failing. Since `has_wrapper_attr` is provided, it would still be possible for the user to implement its custom logic to rather add the attribute to the unwrapped environment, but I think in most cases `env.unwrapped.MY_ATTRIBUTE  = False` would do fine. Besides, I think that adding the attribute to the top-most wrapper makes more sense, because it means that `set_wrapper_attr` and `get_wrapper_attr` behave exactly as `set_attr`, `get_attr` when an attribute exists for a given wrapper, which is what one would expect intuitively I think. Regarding whether `set_wrapper_attr` should raise an exception when an attribute does not exist at any level in the stack, I think it is more appropriate to add the missing attribute to the top-most layer because it maintains consistency with both `set_attr` and `get_attr` once again.

PS: I also made `get_wrapper_attr` faster by avoiding calling `has_attr` in conjunction with `get_attr`. This trick is quite common in the standard library. `set_wrapper_attr ` should also be slightly faster.

## Type of change

Please delete options that are not relevant.

- [x] (SILENTLY) Breaking change (fix or feature that would cause some existing functionality that were untested and undocumented to not work as expected)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
