### PR TITLE
Improve 'set_wrapper_attr'.

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -273,9 +273,12 @@ class Env(Generic[ObsType, ActType]):
         """Gets the attribute `name` from the environment."""
         return getattr(self, name)
 
-    def set_wrapper_attr(self, name: str, value: Any):
+    def set_wrapper_attr(self, name: str, value: Any, *, force: bool = True):
         """Sets the attribute `name` on the environment with `value`."""
-        setattr(self, name, value)
+        if force or hasattr(self, name):
+            setattr(self, name, value)
+        else:
+            raise AttributeError(f"{self} has no attribute {name!r}")
 
 
 WrapperObsType = TypeVar("WrapperObsType")
@@ -425,30 +428,27 @@ class Wrapper(
                     f"wrapper {self.class_name()} has no attribute {name!r}"
                 ) from e
 
-    def set_wrapper_attr(self, name: str, value: Any):
+    def set_wrapper_attr(self, name: str, value: Any, *, force: bool = True):
         """Sets an attribute on this wrapper or lower environment if `name` is already defined.
 
         Args:
             name: The variable name
             value: The new variable value
+            force: Whether to create the attribute on this wrapper if it does not exists on the
+                   lower environment instead of raising an exception
         """
-        sub_env = self
-
-        # loop through all the wrappers, checking if it has the variable name then setting it
-        #   otherwise stripping the wrapper to check the next.
-        #   end when the core env is reached
-        while isinstance(sub_env, Wrapper):
-            if hasattr(sub_env, name):
-                setattr(sub_env, name, value)
-                return
-
-            sub_env = sub_env.env
-
-        # check if the base environment has the wrapper, otherwise, we set it on the top (this) wrapper
-        if hasattr(sub_env, name):
-            setattr(sub_env, name, value)
-        else:
+        if hasattr(self, name):
             setattr(self, name, value)
+        else:
+            try:
+                self.env.set_wrapper_attr(name, value, force=False)
+            except AttributeError as e:
+                if force:
+                    setattr(self, name, value)
+                else:
+                    raise AttributeError(
+                        f"wrapper {self.class_name()} has no attribute {name!r}"
+                    ) from e
 
     def __str__(self):
         """Returns the wrapper name and the :attr:`env` representation string."""


### PR DESCRIPTION
# Description

I propose to further improve 'set_wrapper_attr' (as a follow-up of PR https://github.com/Farama-Foundation/Gymnasium/pull/1293). 

I added the optional keyword argument 'force'. Its role is to make sure that the attribute exists before setting it, so that no attribute while be create on the top-level wrapper. While this could already be done using 'has_wrapper_attr', but specifying the new optional argument is not only more convenient but also faster. Moreover, adding this extra argument enables to refactor the implementation of 'set_wrapper_attr' as a recursive function calling itself on the lower-level environment (in case of wrappers). This is not only more than twice faster (because `isinstance` is very slow...), but also more robust, as __it allows anybody to derive its own wrapper from `gym.Env` and provides its own implementation of 'set_wrapper_attr'__ (this aspect is very important to me, because my library is doing exactly this). Finally, the implementation is easier to understand and closely align with `get_wrapper_attr`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
