### PR TITLE
Quit Pygame when cliffwalking environment is closed

### DIFF
--- a/gymnasium/envs/toy_text/cliffwalking.py
+++ b/gymnasium/envs/toy_text/cliffwalking.py
@@ -345,6 +345,13 @@ class CliffWalkingEnv(Env):
         with closing(outfile):
             return outfile.getvalue()
 
+    def close(self):
+        if self.window_surface is not None:
+            import pygame
+
+            pygame.display.quit()
+            pygame.quit()
+
 
 # Elf and stool from https://franuka.itch.io/rpg-snow-tileset
 # All other assets by ____


### PR DESCRIPTION
# Description

Environment `CliffWalking-v0` with human rendering enabled is not calling `pygame.quit()` when closing. This causes the rendered pygame window to stick until `pygame.quit()` is called manually.

This PR implements the missing method `close()` similarly as in other `toy_text` environments.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

I believe the missing items from the Checklist are not necessary for this bugfix.
