### PR TITLE
Add full support for dlpack API

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -10,11 +10,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         numpy-version: ['>=1.21,<2.0', '>=2.0']
-        exclude:
-          - python-version: '3.8'  # numpy>=2.0 requires Python>=3.9
-            numpy-version: '>=2.0'
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/gymnasium/wrappers/jax_to_torch.py
+++ b/gymnasium/wrappers/jax_to_torch.py
@@ -24,6 +24,19 @@ try:
     import jax
     import jax.numpy as jnp
     from jax import dlpack as jax_dlpack
+
+    def _at_least_version(version: str, target: str) -> bool:
+        """Check if a version string has at least a certain version."""
+        version = version.split("+")[0]  # Remove any local version identifiers
+        version_parts = list(map(int, version.split(".")))
+        target_parts = list(map(int, target.split(".")))
+        # Pad shorter version to match lengths for comparison (e.g., '0.4.8' vs '0.4')
+        version_parts.extend([0] * (len(target_parts) - len(version_parts)))
+        target_parts.extend([0] * (len(version_parts) - len(target_parts)))
+        return tuple(version_parts) >= tuple(target_parts)
+
+    # TODO: Remove when we drop support for older jax and torch versions
+    _FULL_DLPACK_SUPPORT = _at_least_version(jax.__version__, "0.4.16")
 except ImportError:
     raise DependencyNotInstalled(
         'Jax is not installed therefore cannot call `torch_to_jax`, run `pip install "gymnasium[jax]"`'
@@ -33,6 +46,7 @@ try:
     import torch
     from torch.utils import dlpack as torch_dlpack
 
+    _FULL_DLPACK_SUPPORT = _FULL_DLPACK_SUPPORT and _at_least_version(torch.__version__, "1.10.0")
     Device = Union[str, torch.device]
 except ImportError:
     raise DependencyNotInstalled(
@@ -60,6 +74,8 @@ def _number_torch_to_jax(value: numbers.Number) -> Any:
 @torch_to_jax.register(torch.Tensor)
 def _tensor_torch_to_jax(value: torch.Tensor) -> jax.Array:
     """Converts a PyTorch Tensor into a Jax Array."""
+    if _FULL_DLPACK_SUPPORT:
+        return jax_dlpack.from_dlpack(value)
     tensor = torch_dlpack.to_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
     tensor = jax_dlpack.from_dlpack(tensor)  # pyright: ignore[reportPrivateImportUsage]
     return tensor
@@ -96,8 +112,11 @@ def _devicearray_jax_to_torch(
 ) -> torch.Tensor:
     """Converts a Jax Array into a PyTorch Tensor."""
     assert jax_dlpack is not None and torch_dlpack is not None
-    dlpack = jax_dlpack.to_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
-    tensor = torch_dlpack.from_dlpack(dlpack)
+    if _FULL_DLPACK_SUPPORT:
+        tensor = torch_dlpack.from_dlpack(value)
+    else:
+        tensor = jax_dlpack.to_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
+        tensor = torch_dlpack.from_dlpack(tensor)  # pyright: ignore[reportPrivateImportUsage]
     if device:
         return tensor.to(device=device)
     return tensor

--- a/gymnasium/wrappers/jax_to_torch.py
+++ b/gymnasium/wrappers/jax_to_torch.py
@@ -46,7 +46,9 @@ try:
     import torch
     from torch.utils import dlpack as torch_dlpack
 
-    _FULL_DLPACK_SUPPORT = _FULL_DLPACK_SUPPORT and _at_least_version(torch.__version__, "1.10.0")
+    _FULL_DLPACK_SUPPORT = _FULL_DLPACK_SUPPORT and _at_least_version(
+        torch.__version__, "1.10.0"
+    )
     Device = Union[str, torch.device]
 except ImportError:
     raise DependencyNotInstalled(
@@ -75,7 +77,9 @@ def _number_torch_to_jax(value: numbers.Number) -> Any:
 def _tensor_torch_to_jax(value: torch.Tensor) -> jax.Array:
     """Converts a PyTorch Tensor into a Jax Array."""
     if _FULL_DLPACK_SUPPORT:
-        return jax_dlpack.from_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
+        return jax_dlpack.from_dlpack(  # pyright: ignore[reportPrivateImportUsage]
+            value
+        )
     tensor = torch_dlpack.to_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
     tensor = jax_dlpack.from_dlpack(tensor)  # pyright: ignore[reportPrivateImportUsage]
     return tensor
@@ -113,10 +117,16 @@ def _devicearray_jax_to_torch(
     """Converts a Jax Array into a PyTorch Tensor."""
     assert jax_dlpack is not None and torch_dlpack is not None
     if _FULL_DLPACK_SUPPORT:
-        tensor = torch_dlpack.from_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
+        tensor = torch_dlpack.from_dlpack(  # pyright: ignore[reportPrivateImportUsage]
+            value
+        )
     else:
-        tensor = jax_dlpack.to_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
-        tensor = torch_dlpack.from_dlpack(tensor)  # pyright: ignore[reportPrivateImportUsage]
+        tensor = jax_dlpack.to_dlpack(  # pyright: ignore[reportPrivateImportUsage]
+            value
+        )
+        tensor = torch_dlpack.from_dlpack(  # pyright: ignore[reportPrivateImportUsage]
+            tensor
+        )
     if device:
         return tensor.to(device=device)
     return tensor

--- a/gymnasium/wrappers/jax_to_torch.py
+++ b/gymnasium/wrappers/jax_to_torch.py
@@ -75,7 +75,7 @@ def _number_torch_to_jax(value: numbers.Number) -> Any:
 def _tensor_torch_to_jax(value: torch.Tensor) -> jax.Array:
     """Converts a PyTorch Tensor into a Jax Array."""
     if _FULL_DLPACK_SUPPORT:
-        return jax_dlpack.from_dlpack(value)
+        return jax_dlpack.from_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
     tensor = torch_dlpack.to_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
     tensor = jax_dlpack.from_dlpack(tensor)  # pyright: ignore[reportPrivateImportUsage]
     return tensor
@@ -113,7 +113,7 @@ def _devicearray_jax_to_torch(
     """Converts a Jax Array into a PyTorch Tensor."""
     assert jax_dlpack is not None and torch_dlpack is not None
     if _FULL_DLPACK_SUPPORT:
-        tensor = torch_dlpack.from_dlpack(value)
+        tensor = torch_dlpack.from_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
     else:
         tensor = jax_dlpack.to_dlpack(value)  # pyright: ignore[reportPrivateImportUsage]
         tensor = torch_dlpack.from_dlpack(tensor)  # pyright: ignore[reportPrivateImportUsage]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]  # kept for backward compatibil
 mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]  # kept for backward compatibility
-jax = ["jax >=0.4.0", "jaxlib >=0.4.0", "flax >=0.5.0"]
-torch = ["torch >=1.0.0"]
+jax = ["jax >=0.4.16", "jaxlib >=0.4.16", "flax >=0.5.0"]
+torch = ["torch >=1.13.0"]
 other = ["moviepy >=1.0.0", "matplotlib >=3.0", "opencv-python >=3.0", "seaborn >= 0.13"]
 all = [
     # All dependencies above except accept-rom-license
@@ -67,11 +67,11 @@ all = [
     # toy-text
     "pygame >=2.1.3",
     # jax
-    "jax >=0.4.0",
-    "jaxlib >=0.4.0",
+    "jax >=0.4.16",
+    "jaxlib >=0.4.16",
     "flax >= 0.5.0",
     # torch
-    "torch >=1.0.0",
+    "torch >=1.13.0",
     # other
     "opencv-python >=3.0",
     "matplotlib >=3.0",


### PR DESCRIPTION
# Description

This PR adds support for the modern dlpack API to transfer jax arrays to torch tensors and vice-versa. We now determine at initialization if the installed versions of jax and pytorch meet the API requirements, and select the suitable conversion path based on that flag.

Fixes #1298 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
