### PR TITLE
Fix MountainCarContinuous documentation

### DIFF
--- a/gymnasium/envs/classic_control/continuous_mountain_car.py
+++ b/gymnasium/envs/classic_control/continuous_mountain_car.py
@@ -50,10 +50,10 @@ class Continuous_MountainCarEnv(gym.Env):
 
     The observation is a `ndarray` with shape `(2,)` where the elements correspond to the following:
 
-    | Num | Observation                          | Min  | Max | Unit         |
-    |-----|--------------------------------------|------|-----|--------------|
-    | 0   | position of the car along the x-axis | -Inf | Inf | position (m) |
-    | 1   | velocity of the car                  | -Inf | Inf | position (m) |
+    | Num | Observation                          | Min   | Max  | Unit          |
+    |-----|--------------------------------------|-------|------|---------------|
+    | 0   | position of the car along the x-axis | -1.2  | 0.6  | position (m)  |
+    | 1   | velocity of the car                  | -0.07 | 0.07 | position (m)  |
 
     ## Action Space
 


### PR DESCRIPTION
# Description

The `MountainCarContinuous` documentation states that the observation space is unbounded (`-inf` to `inf`) for both dimensions - this is not the case. This PR updates the documentation to reflect the actual bounds of the observation space.

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
