### PR TITLE
Add None to None conversion for JaxToNumpy, JaxToTorch and NumpyToTorch

### DIFF
--- a/gymnasium/wrappers/jax_to_numpy.py
+++ b/gymnasium/wrappers/jax_to_numpy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import functools
 import numbers
 from collections import abc
+from types import NoneType
 from typing import Any, Iterable, Mapping, SupportsFloat
 
 import numpy as np
@@ -68,6 +69,12 @@ def _iterable_numpy_to_jax(
         return type(value)(numpy_to_jax(v) for v in value)
 
 
+@numpy_to_jax.register(NoneType)
+def _none_numpy_to_jax(value: None) -> None:
+    """Passes through None values."""
+    return value
+
+
 @functools.singledispatch
 def jax_to_numpy(value: Any) -> Any:
     """Converts a value to a numpy array."""
@@ -84,7 +91,7 @@ def _devicearray_jax_to_numpy(value: jax.Array) -> np.ndarray:
 
 @jax_to_numpy.register(abc.Mapping)
 def _mapping_jax_to_numpy(
-    value: Mapping[str, jax.Array | Any]
+    value: Mapping[str, jax.Array | Any],
 ) -> Mapping[str, np.ndarray | Any]:
     """Converts a dictionary of Jax Array to a mapping of numpy arrays."""
     return type(value)(**{k: jax_to_numpy(v) for k, v in value.items()})
@@ -101,6 +108,12 @@ def _iterable_jax_to_numpy(
         return type(value)._make(jax_to_numpy(v) for v in value)
     else:
         return type(value)(jax_to_numpy(v) for v in value)
+
+
+@jax_to_numpy.register(NoneType)
+def _none_jax_to_numpy(value: None) -> None:
+    """Passes through None values."""
+    return value
 
 
 class JaxToNumpy(

--- a/gymnasium/wrappers/jax_to_numpy.py
+++ b/gymnasium/wrappers/jax_to_numpy.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import functools
 import numbers
 from collections import abc
-from types import NoneType
 from typing import Any, Iterable, Mapping, SupportsFloat
 
 import numpy as np
@@ -24,6 +23,9 @@ except ImportError:
     )
 
 __all__ = ["JaxToNumpy", "jax_to_numpy", "numpy_to_jax"]
+
+# The NoneType is not defined in Python 3.9. Remove when the minimal version is bumped to >=3.10
+_NoneType = type(None)
 
 
 @functools.singledispatch
@@ -69,7 +71,7 @@ def _iterable_numpy_to_jax(
         return type(value)(numpy_to_jax(v) for v in value)
 
 
-@numpy_to_jax.register(NoneType)
+@numpy_to_jax.register(_NoneType)
 def _none_numpy_to_jax(value: None) -> None:
     """Passes through None values."""
     return value
@@ -110,7 +112,7 @@ def _iterable_jax_to_numpy(
         return type(value)(jax_to_numpy(v) for v in value)
 
 
-@jax_to_numpy.register(NoneType)
+@jax_to_numpy.register(_NoneType)
 def _none_jax_to_numpy(value: None) -> None:
     """Passes through None values."""
     return value

--- a/gymnasium/wrappers/jax_to_torch.py
+++ b/gymnasium/wrappers/jax_to_torch.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import functools
 import numbers
 from collections import abc
-from types import NoneType
 from typing import Any, Iterable, Mapping, SupportsFloat, Union
 
 import gymnasium as gym
@@ -42,6 +41,9 @@ except ImportError:
 
 
 __all__ = ["JaxToTorch", "jax_to_torch", "torch_to_jax", "Device"]
+
+# The NoneType is not defined in Python 3.9. Remove when the minimal version is bumped to >=3.10
+_NoneType = type(None)
 
 
 @functools.singledispatch
@@ -81,7 +83,7 @@ def _iterable_torch_to_jax(value: Iterable[Any]) -> Iterable[Any]:
         return type(value)(torch_to_jax(v) for v in value)
 
 
-@torch_to_jax.register(NoneType)
+@torch_to_jax.register(_NoneType)
 def _none_torch_to_jax(value: None) -> None:
     """Passes through None values."""
     return value
@@ -130,7 +132,7 @@ def _jax_iterable_to_torch(
         return type(value)(jax_to_torch(v, device) for v in value)
 
 
-@jax_to_torch.register(NoneType)
+@jax_to_torch.register(_NoneType)
 def _none_jax_to_torch(value: None, device: Device | None = None) -> None:
     """Passes through None values."""
     return value

--- a/gymnasium/wrappers/numpy_to_torch.py
+++ b/gymnasium/wrappers/numpy_to_torch.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import functools
 import numbers
 from collections import abc
-from types import NoneType
 from typing import Any, Iterable, Mapping, SupportsFloat, Union
 
 import numpy as np
@@ -26,6 +25,9 @@ except ImportError:
 
 
 __all__ = ["NumpyToTorch", "torch_to_numpy", "numpy_to_torch"]
+
+# The NoneType is not defined in Python 3.9. Remove when the minimal version is bumped to >=3.10
+_NoneType = type(None)
 
 
 @functools.singledispatch
@@ -65,7 +67,7 @@ def _iterable_torch_to_numpy(value: Iterable[Any]) -> Iterable[Any]:
         return type(value)(torch_to_numpy(v) for v in value)
 
 
-@torch_to_numpy.register(NoneType)
+@torch_to_numpy.register(_NoneType)
 def _none_torch_to_numpy(value: None) -> None:
     """Passes through None values."""
     return value
@@ -111,7 +113,7 @@ def _numpy_iterable_to_torch(
         return type(value)(numpy_to_torch(v, device) for v in value)
 
 
-@numpy_to_torch.register(NoneType)
+@numpy_to_torch.register(_NoneType)
 def _none_numpy_to_torch(value: None) -> None:
     """Passes through None values."""
     return value

--- a/tests/wrappers/test_jax_to_numpy.py
+++ b/tests/wrappers/test_jax_to_numpy.py
@@ -72,6 +72,7 @@ class ExampleNamedTuple(NamedTuple):
                 b=np.array([1.0, 2.0], dtype=np.float32),
             ),
         ),
+        (None, None),
     ],
 )
 def test_roundtripping(value, expected_value):
@@ -128,3 +129,7 @@ def test_jax_to_numpy_wrapper():
     assert isinstance(reward, float)
     assert isinstance(terminated, bool) and isinstance(truncated, bool)
     assert isinstance(info, dict) and isinstance(info["data"], np.ndarray)
+
+    # Check that the wrapped environment can render. This implicitly returns None and requires  a
+    # None -> None conversion
+    numpy_env.render()

--- a/tests/wrappers/test_jax_to_torch.py
+++ b/tests/wrappers/test_jax_to_torch.py
@@ -94,6 +94,7 @@ class ExampleNamedTuple(NamedTuple):
                 b=torch.tensor([1.0, 2.0]),
             ),
         ),
+        (None, None),
     ],
 )
 def test_roundtripping(value, expected_value):
@@ -143,3 +144,7 @@ def test_jax_to_torch_wrapper():
     assert isinstance(reward, float)
     assert isinstance(terminated, bool) and isinstance(truncated, bool)
     assert isinstance(info, dict) and isinstance(info["data"], torch.Tensor)
+
+    # Check that the wrapped environment can render. This implicitly returns None and requires  a
+    # None -> None conversion
+    wrapped_env.render()

--- a/tests/wrappers/test_numpy_to_torch.py
+++ b/tests/wrappers/test_numpy_to_torch.py
@@ -72,6 +72,7 @@ class ExampleNamedTuple(NamedTuple):
                 b=np.array([1.0, 2.0], dtype=np.float32),
             ),
         ),
+        (None, None),
     ],
 )
 def test_roundtripping(value, expected_value):
@@ -123,3 +124,7 @@ def test_numpy_to_torch():
     assert isinstance(reward, float)
     assert isinstance(terminated, bool) and isinstance(truncated, bool)
     assert isinstance(info, dict) and isinstance(info["data"], torch.Tensor)
+
+    # Check that the wrapped environment can render. This implicitly returns None and requires a
+    # None -> None conversion
+    torch_env.render()


### PR DESCRIPTION
# Description

The `JaxToNumpy`, `JaxToTorch` and `NumpyToTorch` wrappers currently have no conversion registered for `None` values. This becomes an issue e.g. when calling `env.render()` in "human" render modes, which implicitly returns `None`. Consider the following code:

```python
from gymnasium.wrappers.jax_to_numpy import JaxToNumpy
from tests.testing_env import GenericTestEnv


jax_env = GenericTestEnv()
numpy_env = JaxToNumpy(jax_env)
numpy_env.render()
# Exception: No known conversion for Jax type (<class 'NoneType'>) to NumPy registered. Report as
# issue on github.
```
The snippet fails because there is no None type conversion between NumPy, torch and jax. This PR fixes the behavior for all conversion wrappers and adds appropriate tests. The direct propagation of `None` is reasonable because its meaning does not change across the frameworks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes