### PR TITLE
`wrappers.vector.NumpyToTorch` uses `Device` from `wrappers.NumpyTorch` not `JaxToTorch`

### DIFF
--- a/gymnasium/wrappers/numpy_to_torch.py
+++ b/gymnasium/wrappers/numpy_to_torch.py
@@ -24,7 +24,7 @@ except ImportError:
     )
 
 
-__all__ = ["NumpyToTorch", "torch_to_numpy", "numpy_to_torch"]
+__all__ = ["NumpyToTorch", "torch_to_numpy", "numpy_to_torch", "Device"]
 
 
 @functools.singledispatch

--- a/gymnasium/wrappers/vector/numpy_to_torch.py
+++ b/gymnasium/wrappers/vector/numpy_to_torch.py
@@ -7,8 +7,7 @@ from typing import Any
 from gymnasium.core import ActType, ObsType
 from gymnasium.vector import VectorEnv, VectorWrapper
 from gymnasium.vector.vector_env import ArrayType
-from gymnasium.wrappers.jax_to_torch import Device
-from gymnasium.wrappers.numpy_to_torch import numpy_to_torch, torch_to_numpy
+from gymnasium.wrappers.numpy_to_torch import Device, numpy_to_torch, torch_to_numpy
 
 
 __all__ = ["NumpyToTorch"]


### PR DESCRIPTION
# Description

Fixes https://github.com/Farama-Foundation/Gymnasium/issues/1307