### PR TITLE
Add probability masking to `space.sample`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ pygame
 sphinx_github_changelog
 ale_py
 tabulate
+mujoco-py<2.2,>=2.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,4 +8,3 @@ pygame
 sphinx_github_changelog
 ale_py
 tabulate
-mujoco-py<2.2,>=2.1

--- a/gymnasium/spaces/box.py
+++ b/gymnasium/spaces/box.py
@@ -366,7 +366,7 @@ class Box(Space[NDArray[Any]]):
             )
         elif probability is not None:
             raise gym.error.Error(
-                f"Box.sample cannot be provided a probability, actual value: {probability}"
+                f"Box.sample cannot be provided a probability mask, actual value: {probability}"
             )
 
         high = self.high if self.dtype.kind == "f" else self.high.astype("int64") + 1

--- a/gymnasium/spaces/box.py
+++ b/gymnasium/spaces/box.py
@@ -342,7 +342,7 @@ class Box(Space[NDArray[Any]]):
                 f"manner is not in {{'below', 'above', 'both'}}, actual value: {manner}"
             )
 
-    def sample(self, mask: None = None) -> NDArray[Any]:
+    def sample(self, mask: None = None, probability: None = None) -> NDArray[Any]:
         r"""Generates a single random sample inside the Box.
 
         In creating a sample of the box, each coordinate is sampled (independently) from a distribution
@@ -355,6 +355,7 @@ class Box(Space[NDArray[Any]]):
 
         Args:
             mask: A mask for sampling values from the Box space, currently unsupported.
+            probability: A probability mask for sampling values from the Box space, currently unsupported.
 
         Returns:
             A sampled value from the Box
@@ -362,6 +363,10 @@ class Box(Space[NDArray[Any]]):
         if mask is not None:
             raise gym.error.Error(
                 f"Box.sample cannot be provided a mask, actual value: {mask}"
+            )
+        elif probability is not None:
+            raise gym.error.Error(
+                f"Box.sample cannot be provided a probability, actual value: {probability}"
             )
 
         high = self.high if self.dtype.kind == "f" else self.high.astype("int64") + 1

--- a/gymnasium/spaces/dict.py
+++ b/gymnasium/spaces/dict.py
@@ -149,15 +149,6 @@ class Dict(Space[typing.Dict[str, Any]], typing.Mapping[str, Space[Any]]):
                 f"Expected seed type: dict, int or None, actual type: {type(seed)}"
             )
 
-    def _verify_mask(self, mask: dict[str, Any], mask_name: str) -> None:
-        """Check the validity of the mask."""
-        assert isinstance(
-            mask, dict
-        ), f"Expected {mask_name} to be a dict, actual type: {type(mask)}"
-        assert (
-            mask.keys() == self.spaces.keys()
-        ), f"Expected {mask_name} keys to be same as space keys, mask keys: {mask.keys()}, space keys: {self.spaces.keys()}"
-
     def sample(
         self,
         mask: dict[str, Any] | None = None,
@@ -174,20 +165,33 @@ class Dict(Space[typing.Dict[str, Any]], typing.Mapping[str, Space[Any]]):
         Returns:
             A dictionary with the same key and sampled values from :attr:`self.spaces`
         """
-        if mask is not None:
+        if mask is not None and probability is not None:
+            raise ValueError(
+                f"Only one of `mask` or `probability` can be provided, actual values: mask={mask}, probability={probability}. "
+            )
+        elif mask is not None:
+            assert isinstance(
+                mask, dict
+            ), f"Expected sample mask to be a dict, actual type: {type(mask)}"
             assert (
-                probability is None
-            ), "Only one of `mask` or `probability` can be provided"
-            self._verify_mask(mask, "mask")
+                mask.keys() == self.spaces.keys()
+            ), f"Expected sample mask keys to be same as space keys, mask keys: {mask.keys()}, space keys: {self.spaces.keys()}"
+
             return {k: space.sample(mask=mask[k]) for k, space in self.spaces.items()}
         elif probability is not None:
-            self._verify_mask(probability, "probability")
+            assert isinstance(
+                probability, dict
+            ), f"Expected sample probability mask to be a dict, actual type: {type(probability)}"
+            assert (
+                probability.keys() == self.spaces.keys()
+            ), f"Expected sample probability mask keys to be same as space keys, mask keys: {probability.keys()}, space keys: {self.spaces.keys()}"
+
             return {
                 k: space.sample(probability=probability[k])
                 for k, space in self.spaces.items()
             }
-
-        return {k: space.sample() for k, space in self.spaces.items()}
+        else:
+            return {k: space.sample() for k, space in self.spaces.items()}
 
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""

--- a/gymnasium/spaces/dict.py
+++ b/gymnasium/spaces/dict.py
@@ -167,7 +167,7 @@ class Dict(Space[typing.Dict[str, Any]], typing.Mapping[str, Space[Any]]):
         """
         if mask is not None and probability is not None:
             raise ValueError(
-                f"Only one of `mask` or `probability` can be provided, actual values: mask={mask}, probability={probability}. "
+                f"Only one of `mask` or `probability` can be provided, actual values: mask={mask}, probability={probability}"
             )
         elif mask is not None:
             assert isinstance(

--- a/gymnasium/spaces/dict.py
+++ b/gymnasium/spaces/dict.py
@@ -177,7 +177,7 @@ class Dict(Space[typing.Dict[str, Any]], typing.Mapping[str, Space[Any]]):
         if mask is not None:
             assert (
                 probability is None
-            ), "Either mask or probability can be provided, not both"
+            ), "Only one of `mask` or `probability` can be provided"
             self._verify_mask(mask, "mask")
             return {k: space.sample(mask=mask[k]) for k, space in self.spaces.items()}
         elif probability is not None:

--- a/gymnasium/spaces/dict.py
+++ b/gymnasium/spaces/dict.py
@@ -149,25 +149,43 @@ class Dict(Space[typing.Dict[str, Any]], typing.Mapping[str, Space[Any]]):
                 f"Expected seed type: dict, int or None, actual type: {type(seed)}"
             )
 
-    def sample(self, mask: dict[str, Any] | None = None) -> dict[str, Any]:
+    def _verify_mask(self, mask: dict[str, Any], mask_name: str) -> None:
+        """Check the validity of the mask."""
+        assert isinstance(
+            mask, dict
+        ), f"Expected {mask_name} to be a dict, actual type: {type(mask)}"
+        assert (
+            mask.keys() == self.spaces.keys()
+        ), f"Expected {mask_name} keys to be same as space keys, mask keys: {mask.keys()}, space keys: {self.spaces.keys()}"
+
+    def sample(
+        self,
+        mask: dict[str, Any] | None = None,
+        probability: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
         """Generates a single random sample from this space.
 
         The sample is an ordered dictionary of independent samples from the constituent spaces.
 
         Args:
             mask: An optional mask for each of the subspaces, expects the same keys as the space
+            probability: An optional probability mask for each of the subspaces, expects the same keys as the space
 
         Returns:
             A dictionary with the same key and sampled values from :attr:`self.spaces`
         """
         if mask is not None:
-            assert isinstance(
-                mask, dict
-            ), f"Expects mask to be a dict, actual type: {type(mask)}"
             assert (
-                mask.keys() == self.spaces.keys()
-            ), f"Expect mask keys to be same as space keys, mask keys: {mask.keys()}, space keys: {self.spaces.keys()}"
+                probability is None
+            ), "Either mask or probability can be provided, not both"
+            self._verify_mask(mask, "mask")
             return {k: space.sample(mask=mask[k]) for k, space in self.spaces.items()}
+        elif probability is not None:
+            self._verify_mask(probability, "probability")
+            return {
+                k: space.sample(probability=probability[k])
+                for k, space in self.spaces.items()
+            }
 
         return {k: space.sample() for k, space in self.spaces.items()}
 

--- a/gymnasium/spaces/discrete.py
+++ b/gymnasium/spaces/discrete.py
@@ -120,7 +120,9 @@ class Discrete(Space[np.int64]):
             assert (
                 np.sum(probability) == 1
             ), f"The sum of all values of the probability mask should be 1, actual sum: {np.sum(probability)}"
-            normalized_probability = probability / np.sum(probability, dtype=float)
+            normalized_probability = probability / np.sum(
+                probability, dtype=float
+            )  # as recommended by the numpy.random.Generator.choice documentation
             return self.start + self.np_random.choice(
                 np.where(valid_action_mask)[0],
                 p=normalized_probability[valid_action_mask],

--- a/gymnasium/spaces/discrete.py
+++ b/gymnasium/spaces/discrete.py
@@ -113,7 +113,7 @@ class Discrete(Space[np.int64]):
             assert probability.shape == (
                 self.n,
             ), f"The expected shape of the probability mask is {(self.n,)}, actual shape: {probability.shape}"
-            valid_action_mask = 0 < probability <= 1
+            valid_action_mask = np.logical_and(probability > 0, probability <= 1)
             assert np.all(
                 np.logical_or(probability == 0, valid_action_mask)
             ), f"All values of a mask should be 0, 1, or in between, actual values: {probability}"

--- a/gymnasium/spaces/discrete.py
+++ b/gymnasium/spaces/discrete.py
@@ -80,55 +80,75 @@ class Discrete(Space[np.int64]):
         Returns:
             A sampled integer from the space
         """
-        if mask is not None:
-            assert (
-                probability is None
-            ), "Either mask or probability can be provided, not both"
-            assert isinstance(
-                mask, np.ndarray
-            ), f"The expected type of the mask is np.ndarray, actual type: {type(mask)}"
-            assert (
-                mask.dtype == np.int8
-            ), f"The expected dtype of the mask is np.int8, actual dtype: {mask.dtype}"
-            assert mask.shape == (
-                self.n,
-            ), f"The expected shape of the mask is {(self.n,)}, actual shape: {mask.shape}"
+        if mask is not None and probability is not None:
+            raise ValueError("Only one of `mask` or `probability` can be provided.")
+
+        mask_type = (
+            "mask"
+            if mask is not None
+            else "probability" if probability is not None else None
+        )
+        chosen_mask = mask if mask is not None else probability
+
+        if chosen_mask is not None:
+            self._validate_mask(
+                chosen_mask,
+                (self.n,),
+                np.int8 if mask is not None else np.float64,
+                mask_type,
+            )
+            valid_action_mask = self._get_valid_action_mask(chosen_mask, mask_type)
+            if mask_type == "mask":
+                if np.any(valid_action_mask):
+                    return self.start + self.np_random.choice(
+                        np.where(valid_action_mask)[0]
+                    )
+                return self.start
+            elif mask_type == "probability":
+                normalized_probability = probability / np.sum(
+                    probability, dtype=float
+                )  # as recommended by the numpy.random.Generator.choice documentation
+                return self.start + self.np_random.choice(
+                    np.where(valid_action_mask)[0],
+                    p=normalized_probability[valid_action_mask],
+                )
+
+        return self.start + self.np_random.integers(self.n)
+
+    def _validate_mask(
+        self,
+        mask: MaskNDArray,
+        expected_shape: tuple[int],
+        expected_dtype: type,
+        mask_type: str,
+    ):
+        """Validates the type, shape, and dtype of a mask."""
+        assert isinstance(
+            mask, np.ndarray
+        ), f"The expected type of `{mask_type}` is np.ndarray, actual type: {type(mask)}"
+        assert (
+            mask.shape == expected_shape
+        ), f"The expected shape of `{mask_type}` is {expected_shape}, actual shape: {mask.shape}"
+        assert (
+            mask.dtype == expected_dtype
+        ), f"The expected dtype of `{mask_type}` is {expected_dtype}, actual dtype: {mask.dtype}"
+
+    def _get_valid_action_mask(self, mask: MaskNDArray, mask_type: str) -> MaskNDArray:
+        """Returns a valid action mask based on the mask type."""
+        if mask_type == "mask":
             valid_action_mask = mask == 1
             assert np.all(
                 np.logical_or(mask == 0, valid_action_mask)
-            ), f"All values of a mask should be 0 or 1, actual values: {mask}"
-            if np.any(valid_action_mask):
-                return self.start + self.np_random.choice(
-                    np.where(valid_action_mask)[0]
-                )
-            else:
-                return self.start
-        elif probability is not None:
-            assert isinstance(
-                probability, np.ndarray
-            ), f"The expected type of the probability mask is np.ndarray, actual type: {type(probability)}"
-            assert (
-                probability.dtype == np.float64
-            ), f"The expected dtype of the probability mask is np.float64, actual dtype: {probability.dtype}"
-            assert probability.shape == (
-                self.n,
-            ), f"The expected shape of the probability mask is {(self.n,)}, actual shape: {probability.shape}"
-            valid_action_mask = np.logical_and(probability > 0, probability <= 1)
+            ), f"All values of `mask` should be 0 or 1, actual values: {mask}"
+        elif mask_type == "probability":
+            valid_action_mask = np.logical_and(mask > 0, mask <= 1)
             assert np.all(
-                np.logical_or(probability == 0, valid_action_mask)
-            ), f"All values of a mask should be 0, 1, or in between, actual values: {probability}"
-            assert (
-                np.sum(probability) == 1
-            ), f"The sum of all values of the probability mask should be 1, actual sum: {np.sum(probability)}"
-            normalized_probability = probability / np.sum(
-                probability, dtype=float
-            )  # as recommended by the numpy.random.Generator.choice documentation
-            return self.start + self.np_random.choice(
-                np.where(valid_action_mask)[0],
-                p=normalized_probability[valid_action_mask],
-            )
-
-        return self.start + self.np_random.integers(self.n)
+                np.logical_or(mask == 0, valid_action_mask)
+            ), f"All values of `probability mask` should be 0, 1, or in between, actual values: {mask}"
+            assert np.isclose(
+                np.sum(mask), 1
+            ), f"The sum of all values of `probability mask` should be 1, actual sum: {np.sum(mask)}"
+        return valid_action_mask
 
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""

--- a/gymnasium/spaces/discrete.py
+++ b/gymnasium/spaces/discrete.py
@@ -94,7 +94,7 @@ class Discrete(Space[np.int64]):
             ), f"The expected dtype of the sample mask is np.int8, actual dtype: {mask.dtype}"
             assert mask.shape == (
                 self.n,
-            ), f"The expected shape of the sample mask is {(self.n,)}, actual shape: {mask.shape}"
+            ), f"The expected shape of the sample mask is {(int(self.n),)}, actual shape: {mask.shape}"
 
             valid_action_mask = mask == 1
             assert np.all(
@@ -117,7 +117,7 @@ class Discrete(Space[np.int64]):
             ), f"The expected dtype of the sample probability is np.float64, actual dtype: {probability.dtype}"
             assert probability.shape == (
                 self.n,
-            ), f"The expected shape of the sample probability is {(self.n,)}, actual shape: {probability.shape}"
+            ), f"The expected shape of the sample probability is {(int(self.n),)}, actual shape: {probability.shape}"
 
             assert np.all(
                 np.logical_and(probability >= 0, probability <= 1)

--- a/gymnasium/spaces/discrete.py
+++ b/gymnasium/spaces/discrete.py
@@ -67,7 +67,7 @@ class Discrete(Space[np.int64]):
     ) -> np.int64:
         """Generates a single random sample from this space.
 
-        A sample will be chosen uniformly at random with a mask if provided
+        A sample will be chosen uniformly at random with the mask if provided, or it will be chosen according to a specified probability distribution if the probability mask is provided.
 
         Args:
             mask: An optional mask for if an action can be selected.

--- a/gymnasium/spaces/discrete.py
+++ b/gymnasium/spaces/discrete.py
@@ -67,7 +67,7 @@ class Discrete(Space[np.int64]):
     ) -> np.int64:
         """Generates a single random sample from this space.
 
-        A sample will be chosen uniformly at random with the mask if provided
+        A sample will be chosen uniformly at random with a mask if provided
 
         Args:
             mask: An optional mask for if an action can be selected.
@@ -113,7 +113,7 @@ class Discrete(Space[np.int64]):
             assert probability.shape == (
                 self.n,
             ), f"The expected shape of the probability mask is {(self.n,)}, actual shape: {probability.shape}"
-            valid_action_mask = probability > 0 and probability <= 1
+            valid_action_mask = 0 < probability <= 1
             assert np.all(
                 np.logical_or(probability == 0, valid_action_mask)
             ), f"All values of a mask should be 0, 1, or in between, actual values: {probability}"

--- a/gymnasium/spaces/discrete.py
+++ b/gymnasium/spaces/discrete.py
@@ -82,7 +82,7 @@ class Discrete(Space[np.int64]):
         """
         if mask is not None and probability is not None:
             raise ValueError(
-                f"Only one of `mask` or `probability` can be provided, actual values: mask={mask}, probability={probability}. "
+                f"Only one of `mask` or `probability` can be provided, actual values: mask={mask}, probability={probability}"
             )
         # binary mask sampling
         elif mask is not None:

--- a/gymnasium/spaces/discrete.py
+++ b/gymnasium/spaces/discrete.py
@@ -81,7 +81,7 @@ class Discrete(Space[np.int64]):
             A sampled integer from the space
         """
         if mask is not None and probability is not None:
-            raise ValueError("Only one of `mask` or `probability` can be provided.")
+            raise ValueError("Only one of `mask` or `probability` can be provided")
 
         mask_type = (
             "mask"

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -175,6 +175,59 @@ class Graph(Space[GraphInstance]):
                 f"Expects `None`, int or tuple of ints, actual type: {type(seed)}"
             )
 
+    def sample(
+        self,
+        mask: None | (
+            tuple[
+                NDArray[Any] | tuple[Any, ...] | None,
+                NDArray[Any] | tuple[Any, ...] | None,
+            ]
+        ) = None,
+        probability: None | (
+            tuple[
+                NDArray[Any] | tuple[Any, ...] | None,
+                NDArray[Any] | tuple[Any, ...] | None,
+            ]
+        ) = None,
+        num_nodes: int = 10,
+        num_edges: int | None = None,
+    ) -> GraphInstance:
+        """Generates a single sample graph with num_nodes between ``1`` and ``10`` sampled from the Graph.
+
+        Args:
+            mask: An optional tuple of optional node and edge mask that is only possible with Discrete spaces
+                (Box spaces don't support sample masks).
+                If no ``num_edges`` is provided then the ``edge_mask`` is multiplied by the number of edges
+            probability: An optional tuple of optional node and edge probability mask that is only possible with Discrete spaces
+                (Box spaces don't support sample masks).
+                If no ``num_edges`` is provided then the ``edge_mask`` is multiplied by the number of edges
+            num_nodes: The number of nodes that will be sampled, the default is `10` nodes
+            num_edges: An optional number of edges, otherwise, a random number between `0` and :math:`num_nodes^2`
+
+        Returns:
+            A :class:`GraphInstance` with attributes `.nodes`, `.edges`, and `.edge_links`.
+        """
+        assert (
+            num_nodes > 0
+        ), f"The number of nodes is expected to be greater than 0, actual value: {num_nodes}"
+
+        mask_type = None
+        if mask is not None:
+            assert (
+                probability is None
+            ), "Only one of `mask` or `probability` can be provided"
+            node_space_mask, edge_space_mask = mask
+            mask_type = "mask"
+        elif probability is not None:
+            node_space_mask, edge_space_mask = probability
+            mask_type = "probability"
+        else:
+            node_space_mask, edge_space_mask = None, None
+
+        return self._sample(
+            node_space_mask, edge_space_mask, num_nodes, num_edges, mask_type
+        )
+
     def _sample(
         self,
         node_space_mask: NDArray[Any] | tuple[Any, ...] | None,
@@ -231,59 +284,6 @@ class Graph(Space[GraphInstance]):
             )
 
         return GraphInstance(sampled_nodes, sampled_edges, sampled_edge_links)
-
-    def sample(
-        self,
-        mask: None | (
-            tuple[
-                NDArray[Any] | tuple[Any, ...] | None,
-                NDArray[Any] | tuple[Any, ...] | None,
-            ]
-        ) = None,
-        probability: None | (
-            tuple[
-                NDArray[Any] | tuple[Any, ...] | None,
-                NDArray[Any] | tuple[Any, ...] | None,
-            ]
-        ) = None,
-        num_nodes: int = 10,
-        num_edges: int | None = None,
-    ) -> GraphInstance:
-        """Generates a single sample graph with num_nodes between ``1`` and ``10`` sampled from the Graph.
-
-        Args:
-            mask: An optional tuple of optional node and edge mask that is only possible with Discrete spaces
-                (Box spaces don't support sample masks).
-                If no ``num_edges`` is provided then the ``edge_mask`` is multiplied by the number of edges
-            probability: An optional tuple of optional node and edge probability mask that is only possible with Discrete spaces
-                (Box spaces don't support sample masks).
-                If no ``num_edges`` is provided then the ``edge_mask`` is multiplied by the number of edges
-            num_nodes: The number of nodes that will be sampled, the default is `10` nodes
-            num_edges: An optional number of edges, otherwise, a random number between `0` and :math:`num_nodes^2`
-
-        Returns:
-            A :class:`GraphInstance` with attributes `.nodes`, `.edges`, and `.edge_links`.
-        """
-        assert (
-            num_nodes > 0
-        ), f"The number of nodes is expected to be greater than 0, actual value: {num_nodes}"
-
-        mask_type = None
-        if mask is not None:
-            assert (
-                probability is None
-            ), "Only one of `mask` or `probability` can be provided"
-            node_space_mask, edge_space_mask = mask
-            mask_type = "mask"
-        elif probability is not None:
-            node_space_mask, edge_space_mask = probability
-            mask_type = "probability"
-        else:
-            node_space_mask, edge_space_mask = None, None
-
-        return self._sample(
-            node_space_mask, edge_space_mask, num_nodes, num_edges, mask_type
-        )
 
     def contains(self, x: GraphInstance) -> bool:
         """Return boolean specifying if x is a valid member of this space."""

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -272,7 +272,7 @@ class Graph(Space[GraphInstance]):
         if mask is not None:
             assert (
                 probability is None
-            ), "Either mask or probability can be provided, not both"
+            ), "Only one of `mask` or `probability` can be provided"
             node_space_mask, edge_space_mask = mask
             mask_type = "mask"
         elif probability is not None:

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -213,7 +213,7 @@ class Graph(Space[GraphInstance]):
 
         if mask is not None and probability is not None:
             raise ValueError(
-                f"Only one of `mask` or `probability` can be provided, actual value mask={mask}, probability={probability}"
+                f"Only one of `mask` or `probability` can be provided, actual values: mask={mask}, probability={probability}"
             )
         elif mask is not None:
             node_space_mask, edge_space_mask = mask

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -199,7 +199,7 @@ class Graph(Space[GraphInstance]):
                 (Box spaces don't support sample masks).
                 If no ``num_edges`` is provided then the ``edge_mask`` is multiplied by the number of edges
             probability: An optional tuple of optional node and edge probability mask that is only possible with Discrete spaces
-                (Box spaces don't support sample masks).
+                (Box spaces don't support sample probability masks).
                 If no ``num_edges`` is provided then the ``edge_mask`` is multiplied by the number of edges
             num_nodes: The number of nodes that will be sampled, the default is `10` nodes
             num_edges: An optional number of edges, otherwise, a random number between `0` and :math:`num_nodes^2`

--- a/gymnasium/spaces/multi_binary.py
+++ b/gymnasium/spaces/multi_binary.py
@@ -61,7 +61,7 @@ class MultiBinary(Space[NDArray[np.int8]]):
         return True
 
     def sample(
-        self, mask: MaskNDArray | None = None, probability: MaskNDArray | None = None
+        self, mask: MaskNDArray | None = None, probability: None = None
     ) -> NDArray[np.int8]:
         """Generates a single random sample from this space.
 

--- a/gymnasium/spaces/multi_binary.py
+++ b/gymnasium/spaces/multi_binary.py
@@ -7,6 +7,7 @@ from typing import Any, Sequence
 import numpy as np
 from numpy.typing import NDArray
 
+import gymnasium as gym
 from gymnasium.spaces.space import MaskNDArray, Space
 
 
@@ -59,7 +60,9 @@ class MultiBinary(Space[NDArray[np.int8]]):
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return True
 
-    def sample(self, mask: MaskNDArray | None = None) -> NDArray[np.int8]:
+    def sample(
+        self, mask: MaskNDArray | None = None, probability: MaskNDArray | None = None
+    ) -> NDArray[np.int8]:
         """Generates a single random sample from this space.
 
         A sample is drawn by independent, fair coin tosses (one toss per binary variable of the space).
@@ -68,11 +71,15 @@ class MultiBinary(Space[NDArray[np.int8]]):
             mask: An optional np.ndarray to mask samples with expected shape of ``space.shape``.
                 For ``mask == 0`` then the samples will be ``0`` and ``mask == 1` then random samples will be generated.
                 The expected mask shape is the space shape and mask dtype is ``np.int8``.
+            probability: A probability mask for sampling values from the MultiBinary space, currently unsupported.
 
         Returns:
             Sampled values from space
         """
         if mask is not None:
+            assert (
+                probability is None
+            ), "Only one of `mask` or `probability` can be provided, and `probability` is currently unsupported"
             assert isinstance(
                 mask, np.ndarray
             ), f"The expected type of the mask is np.ndarray, actual type: {type(mask)}"
@@ -90,6 +97,10 @@ class MultiBinary(Space[NDArray[np.int8]]):
                 mask == 2,
                 self.np_random.integers(low=0, high=2, size=self.n, dtype=self.dtype),
                 mask.astype(self.dtype),
+            )
+        elif probability is not None:
+            raise gym.error.Error(
+                f"MultiBinary.sample cannot be provided a probability, actual value: {probability}"
             )
 
         return self.np_random.integers(low=0, high=2, size=self.n, dtype=self.dtype)

--- a/gymnasium/spaces/multi_binary.py
+++ b/gymnasium/spaces/multi_binary.py
@@ -60,7 +60,7 @@ class MultiBinary(Space[NDArray[np.int8]]):
         return True
 
     def sample(
-        self, mask: MaskNDArray | None = None, probability: None = None
+        self, mask: MaskNDArray | None = None, probability: MaskNDArray | None = None
     ) -> NDArray[np.int8]:
         """Generates a single random sample from this space.
 
@@ -71,15 +71,16 @@ class MultiBinary(Space[NDArray[np.int8]]):
                 For ``mask == 0`` then the samples will be ``0``, for a ``mask == 1`` then the samples will be ``1``.
                 For random samples, using a mask value of ``2``.
                 The expected mask shape is the space shape and mask dtype is ``np.int8``.
-            probability: An optional ``np.ndarray`` to mask samples with expected shape of ``space.shape`` where element
-                represent the probability of 1
+            probability: An optional ``np.ndarray`` to mask samples with expected shape of space.shape where each element
+                represents the probability of the corresponding sample element being a 1.
+                The expected mask shape is the space shape and mask dtype is ``np.float64``.
 
         Returns:
             Sampled values from space
         """
         if mask is not None and probability is not None:
             raise ValueError(
-                "Only one of `mask` or `probability` can be provided, and `probability` is currently unsupported"
+                f"Only one of `mask` or `probability` can be provided, actual values: mask={mask}, probability={probability}"
             )
         if mask is not None:
             assert isinstance(

--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -96,70 +96,107 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
         return True
 
     def sample(
-        self, mask: tuple[MaskNDArray, ...] | None = None
+        self,
+        mask: tuple[MaskNDArray, ...] | None = None,
+        probability: tuple[MaskNDArray, ...] | None = None,
     ) -> NDArray[np.integer[Any]]:
-        """Generates a single random sample this space.
+        """Generates a single random sample from this space.
 
         Args:
             mask: An optional mask for multi-discrete, expects tuples with a ``np.ndarray`` mask in the position of each
                 action with shape ``(n,)`` where ``n`` is the number of actions and ``dtype=np.int8``.
                 Only ``mask values == 1`` are possible to sample unless all mask values for an action are ``0`` then the default action ``self.start`` (the smallest element) is sampled.
+            probability: An optional probability mask for multi-discrete, expects tuples with a ``np.ndarray`` probability mask in the position of each
+                action with shape ``(n,)`` where ``n`` is the number of actions and ``dtype=np.float64``.
+                Only ``0 <= probability mask values <= 1`` are possible to sample as long as the sum of all values is ``1``.
 
         Returns:
             An ``np.ndarray`` of :meth:`Space.shape`
         """
-        if mask is not None:
+        if mask is not None and probability is not None:
+            raise ValueError("Only one of `mask` or `probability` can be provided.")
 
-            def _apply_mask(
-                sub_mask: MaskNDArray | tuple[MaskNDArray, ...],
-                sub_nvec: MaskNDArray | np.integer[Any],
-                sub_start: MaskNDArray | np.integer[Any],
-            ) -> int | list[Any]:
-                if isinstance(sub_nvec, np.ndarray):
-                    assert isinstance(
-                        sub_mask, tuple
-                    ), f"Expects the mask to be a tuple for sub_nvec ({sub_nvec}), actual type: {type(sub_mask)}"
-                    assert len(sub_mask) == len(
-                        sub_nvec
-                    ), f"Expects the mask length to be equal to the number of actions, mask length: {len(sub_mask)}, nvec length: {len(sub_nvec)}"
-                    return [
-                        _apply_mask(new_mask, new_nvec, new_start)
-                        for new_mask, new_nvec, new_start in zip(
-                            sub_mask, sub_nvec, sub_start
-                        )
-                    ]
-                else:
-                    assert np.issubdtype(
-                        type(sub_nvec), np.integer
-                    ), f"Expects the sub_nvec to be an action, actually: {sub_nvec}, {type(sub_nvec)}"
-                    assert isinstance(
-                        sub_mask, np.ndarray
-                    ), f"Expects the sub mask to be np.ndarray, actual type: {type(sub_mask)}"
-                    assert (
-                        len(sub_mask) == sub_nvec
-                    ), f"Expects the mask length to be equal to the number of actions, mask length: {len(sub_mask)}, action: {sub_nvec}"
-                    assert (
-                        sub_mask.dtype == np.int8
-                    ), f"Expects the mask dtype to be np.int8, actual dtype: {sub_mask.dtype}"
+        mask_type = (
+            "mask"
+            if mask is not None
+            else "probability" if probability is not None else None
+        )
+        chosen_mask = mask if mask is not None else probability
 
-                    valid_action_mask = sub_mask == 1
-                    assert np.all(
-                        np.logical_or(sub_mask == 0, valid_action_mask)
-                    ), f"Expects all masks values to 0 or 1, actual values: {sub_mask}"
-
-                    if np.any(valid_action_mask):
-                        return (
-                            self.np_random.choice(np.where(valid_action_mask)[0])
-                            + sub_start
-                        )
-                    else:
-                        return sub_start
-
-            return np.array(_apply_mask(mask, self.nvec, self.start), dtype=self.dtype)
+        if chosen_mask is not None:
+            return np.array(
+                self._apply_mask(chosen_mask, self.nvec, self.start, mask_type),
+                dtype=self.dtype,
+            )
 
         return (self.np_random.random(self.nvec.shape) * self.nvec).astype(
             self.dtype
         ) + self.start
+
+    def _apply_mask(
+        self,
+        sub_mask: MaskNDArray | tuple[MaskNDArray, ...],
+        sub_nvec: MaskNDArray | np.integer[Any],
+        sub_start: MaskNDArray | np.integer[Any],
+        mask_type: str,
+    ) -> int | list[Any]:
+        if isinstance(sub_nvec, np.ndarray):
+            assert isinstance(
+                sub_mask, tuple
+            ), f"Expects the mask to be a tuple for sub_nvec ({sub_nvec}), actual type: {type(sub_mask)}"
+            assert len(sub_mask) == len(
+                sub_nvec
+            ), f"Expects the mask length to be equal to the number of actions, mask length: {len(sub_mask)}, nvec length: {len(sub_nvec)}"
+            return [
+                self._apply_mask(new_mask, new_nvec, new_start, mask_type)
+                for new_mask, new_nvec, new_start in zip(sub_mask, sub_nvec, sub_start)
+            ]
+
+        assert np.issubdtype(
+            type(sub_nvec), np.integer
+        ), f"Expects the sub_nvec to be an action, actually: {sub_nvec}, {type(sub_nvec)}"
+        assert isinstance(
+            sub_mask, np.ndarray
+        ), f"Expects the sub mask to be np.ndarray, actual type: {type(sub_mask)}"
+        assert (
+            len(sub_mask) == sub_nvec
+        ), f"Expects the mask length to be equal to the number of actions, mask length: {len(sub_mask)}, action: {sub_nvec}"
+        if mask_type == "mask":
+            assert (
+                sub_mask.dtype == np.int8
+            ), f"Expects the mask dtype to be np.int8, actual dtype: {sub_mask.dtype}"
+
+            valid_action_mask = sub_mask == 1
+            assert np.all(
+                np.logical_or(sub_mask == 0, valid_action_mask)
+            ), f"Expects all masks values to 0 or 1, actual values: {sub_mask}"
+
+            if np.any(valid_action_mask):
+                return self.np_random.choice(np.where(valid_action_mask)[0]) + sub_start
+            else:
+                return sub_start
+        elif mask_type == "probability":
+            assert (
+                sub_mask.dtype == np.float64
+            ), f"Expects the mask dtype to be np.float64, actual dtype: {sub_mask.dtype}"
+            valid_action_mask = np.logical_and(sub_mask > 0, sub_mask <= 1)
+            assert np.all(
+                np.logical_or(sub_mask == 0, valid_action_mask)
+            ), f"Expects all masks values to be between 0 and 1, actual values: {sub_mask}"
+            assert np.isclose(
+                np.sum(sub_mask), 1
+            ), f"Expects the sum of all mask values to be 1, actual sum: {np.sum(sub_mask)}"
+            normalized_sub_mask = sub_mask / np.sum(
+                sub_mask, dtype=float
+            )  # as recommended by the numpy.random.Generator.choice documentation
+            return (
+                self.np_random.choice(
+                    np.where(valid_action_mask)[0],
+                    p=normalized_sub_mask[valid_action_mask],
+                )
+                + sub_start
+            )
+        raise ValueError(f"Unsupported mask type: {mask_type}")
 
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""

--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -108,7 +108,7 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
                 Only ``mask values == 1`` are possible to sample unless all mask values for an action are ``0`` then the default action ``self.start`` (the smallest element) is sampled.
             probability: An optional probability mask for multi-discrete, expects tuples with a ``np.ndarray`` probability mask in the position of each
                 action with shape ``(n,)`` where ``n`` is the number of actions and ``dtype=np.float64``.
-                Only ``0 <= probability mask values <= 1`` are possible to sample as long as the sum of all values is ``1``.
+                Only probability mask values within ``[0,1]`` are possible to sample as long as the sum of all values is ``1``.
 
         Returns:
             An ``np.ndarray`` of :meth:`Space.shape`

--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -140,6 +140,7 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
         sub_start: MaskNDArray | np.integer[Any],
         mask_type: str,
     ) -> int | list[Any]:
+        """Returns a sample using the provided mask or probability mask."""
         if isinstance(sub_nvec, np.ndarray):
             assert isinstance(
                 sub_mask, tuple

--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -114,7 +114,9 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
             An ``np.ndarray`` of :meth:`Space.shape`
         """
         if mask is not None and probability is not None:
-            raise ValueError("Only one of `mask` or `probability` can be provided.")
+            raise ValueError(
+                f"Only one of `mask` or `probability` can be provided, actual values: mask={mask}, probability={probability}"
+            )
         elif mask is not None:
             return np.array(
                 self._apply_mask(mask, self.nvec, self.start, "mask"),

--- a/gymnasium/spaces/oneof.py
+++ b/gymnasium/spaces/oneof.py
@@ -124,27 +124,28 @@ class OneOf(Space[Any]):
         if mask is not None and probability is not None:
             raise ValueError("Only one of `mask` or `probability` can be provided.")
 
-        mask_type = (
-            "mask"
-            if mask is not None
-            else "probability" if probability is not None else None
-        )
-        chosen_mask = mask if mask is not None else probability
-
-        if chosen_mask is not None:
+        elif mask is not None:
             assert isinstance(
-                chosen_mask, tuple
-            ), f"Expected type of `{mask_type}` is tuple, actual type: {type(chosen_mask)}"
-            assert len(chosen_mask) == len(
+                mask, tuple
+            ), f"Expected type of `mask` is tuple, actual type: {type(mask)}"
+            assert len(mask) == len(
                 self.spaces
-            ), f"Expected length of `{mask_type}` is {len(self.spaces)}, actual length: {len(chosen_mask)}"
-            chosen_mask = chosen_mask[subspace_idx]
+            ), f"Expected length of `mask` is {len(self.spaces)}, actual length: {len(mask)}"
 
-        subspace_sample = (
-            subspace.sample(mask=chosen_mask)
-            if mask_type == "mask"
-            else subspace.sample(probability=chosen_mask)
-        )
+            subspace_sample = subspace.sample(mask=mask[subspace_idx])
+
+        elif probability is not None:
+            assert isinstance(
+                probability, tuple
+            ), f"Expected type of `probability` is tuple, actual type: {type(probability)}"
+            assert len(probability) == len(
+                self.spaces
+            ), f"Expected length of `probability` is {len(self.spaces)}, actual length: {len(probability)}"
+
+            subspace_sample = subspace.sample(probability=probability[subspace_idx])
+        else:
+            subspace_sample = subspace.sample()
+
         return subspace_idx, subspace_sample
 
     def contains(self, x: tuple[int, Any]) -> bool:

--- a/gymnasium/spaces/oneof.py
+++ b/gymnasium/spaces/oneof.py
@@ -122,8 +122,9 @@ class OneOf(Space[Any]):
         subspace = self.spaces[subspace_idx]
 
         if mask is not None and probability is not None:
-            raise ValueError("Only one of `mask` or `probability` can be provided.")
-
+            raise ValueError(
+                f"Only one of `mask` or `probability` can be provided, actual values: mask={mask}, probability={probability}"
+            )
         elif mask is not None:
             assert isinstance(
                 mask, tuple

--- a/gymnasium/spaces/oneof.py
+++ b/gymnasium/spaces/oneof.py
@@ -18,9 +18,9 @@ class OneOf(Space[Any]):
     Example:
         >>> from gymnasium.spaces import OneOf, Box, Discrete
         >>> observation_space = OneOf((Discrete(2), Box(-1, 1, shape=(2,))), seed=123)
-        >>> observation_space.sample()  # the first element is the space index (Box in this case) and the second element is the sample from Box
+        >>> observation_space.sample()  # the first element is the space index (Discrete in this case) and the second element is the sample from Discrete
         (np.int64(0), np.int64(0))
-        >>> observation_space.sample()  # this time the Discrete space was sampled as index=0
+        >>> observation_space.sample()  # this time the Box space was sampled as index=1
         (np.int64(1), array([-0.00711833, -0.7257502 ], dtype=float32))
         >>> observation_space[0]
         Discrete(2)

--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -177,13 +177,13 @@ class Sequence(Space[Union[typing.Tuple[Any, ...], Any]]):
                 The second element of the mask tuple ``sample_mask`` specifies a mask that is applied when
                 sampling elements from the base space. The mask is applied for each feature space sample.
             probability: An optional probability mask for (optionally) the length of the sequence and (optionally) the values in the sequence.
-                If you specify ``probability``, it is expected to be a tuple of the form ``(length_probability, sample_probability)`` where ``length_probability`` is
+                If you specify ``probability``, it is expected to be a tuple of the form ``(length_mask, sample_mask)`` where ``length_mask`` is
 
                 * ``None`` The length will be randomly drawn from a geometric distribution
                 * ``np.ndarray`` of integers, in which case the length of the sampled sequence is randomly drawn from this array.
                 * ``int`` for a fixed length sample
 
-                The second element of the probability tuple ``sample_probability` specifies a probability mask that is applied when
+                The second element of the probability tuple ``sample_mask`` specifies a probability mask that is applied when
                 sampling elements from the base space. The probability mask is applied for each feature space sample.
 
         Returns:

--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -103,13 +103,13 @@ class Sequence(Space[Union[typing.Tuple[Any, ...], Any]]):
         self,
         mask: None | (
             tuple[
-                None | np.integer | NDArray[np.integer],
+                None | int | NDArray[np.integer],
                 Any,
             ]
         ) = None,
         probability: None | (
             tuple[
-                None | np.integer | NDArray[np.integer],
+                None | int | NDArray[np.integer],
                 Any,
             ]
         ) = None,
@@ -120,21 +120,13 @@ class Sequence(Space[Union[typing.Tuple[Any, ...], Any]]):
             mask: An optional mask for (optionally) the length of the sequence and (optionally) the values in the sequence.
                 If you specify ``mask``, it is expected to be a tuple of the form ``(length_mask, sample_mask)`` where ``length_mask`` is
 
-                * ``None`` The length will be randomly drawn from a geometric distribution
-                * ``np.ndarray`` of integers, in which case the length of the sampled sequence is randomly drawn from this array.
-                * ``int`` for a fixed length sample
+                * ``None`` - The length will be randomly drawn from a geometric distribution
+                * ``int`` - Fixed length
+                * ``np.ndarray`` of integers - Length of the sampled sequence is randomly drawn from this array.
 
-                The second element of the mask tuple ``sample_mask`` specifies a mask that is applied when
-                sampling elements from the base space. The mask is applied for each feature space sample.
-            probability: An optional probability mask for (optionally) the length of the sequence and (optionally) the values in the sequence.
-                If you specify ``probability``, it is expected to be a tuple of the form ``(length_mask, sample_mask)`` where ``length_mask`` is
-
-                * ``None`` The length will be randomly drawn from a geometric distribution
-                * ``np.ndarray`` of integers, in which case the length of the sampled sequence is randomly drawn from this array.
-                * ``int`` for a fixed length sample
-
-                The second element of the probability tuple ``sample_mask`` specifies a probability mask that is applied when
-                sampling elements from the base space. The probability mask is applied for each feature space sample.
+                The second element of the tuple ``sample_mask`` specifies how the feature space will be sampled.
+                Depending on if mask or probability is used will affect what argument is used.
+            probability: See mask description above, the only difference is on the ``sample_mask`` for the feature space being probability rather than mask.
 
         Returns:
             A tuple of random length with random samples of elements from the :attr:`feature_space`.
@@ -142,31 +134,45 @@ class Sequence(Space[Union[typing.Tuple[Any, ...], Any]]):
         if mask is not None and probability is not None:
             raise ValueError("Only one of `mask` or `probability` can be provided.")
 
-        mask_type = (
-            "mask"
-            if mask is not None
-            else "probability" if probability is not None else None
-        )
-        chosen_mask = mask if mask is not None else probability
-
-        if chosen_mask is not None:
-            length_mask, feature_mask = chosen_mask
+        if mask is not None:
+            sample_length = self.generate_sample_length(mask[0], "mask")
+            sampled_values = tuple(
+                self.feature_space.sample(mask=mask[1]) for _ in range(sample_length)
+            )
+        elif probability is not None:
+            sample_length = self.generate_sample_length(probability[0], "probability")
+            sampled_values = tuple(
+                self.feature_space.sample(probability=probability[1])
+                for _ in range(sample_length)
+            )
         else:
-            length_mask, feature_mask = None, None
-        return self._sample(length_mask, feature_mask, mask_type)
+            sample_length = self.np_random.geometric(0.25)
+            sampled_values = tuple(
+                self.feature_space.sample() for _ in range(sample_length)
+            )
 
-    def _sample(
+        if self.stack:
+            # Concatenate values if stacked.
+            out = gym.vector.utils.create_empty_array(
+                self.feature_space, len(sampled_values)
+            )
+            return gym.vector.utils.concatenate(self.feature_space, sampled_values, out)
+
+        return sampled_values
+
+    def generate_sample_length(
         self,
         length_mask: None | np.integer | NDArray[np.integer],
-        feature_mask: Any,
         mask_type: None | str,
-    ) -> tuple[Any] | Any:
+    ) -> int:
+        """Generate the sample length for a given length mask and mask type."""
         if length_mask is not None:
             if np.issubdtype(type(length_mask), np.integer):
                 assert (
                     0 <= length_mask
                 ), f"Expects the length mask of `{mask_type}` to be greater than or equal to zero, actual value: {length_mask}"
-                length = length_mask
+
+                return length_mask
             elif isinstance(length_mask, np.ndarray):
                 assert (
                     len(length_mask.shape) == 1
@@ -177,33 +183,15 @@ class Sequence(Space[Union[typing.Tuple[Any, ...], Any]]):
                 assert np.issubdtype(
                     length_mask.dtype, np.integer
                 ), f"Expects the length mask array of `{mask_type}` to have dtype of np.integer, actual type: {length_mask.dtype}"
-                length = self.np_random.choice(length_mask)
+
+                return self.np_random.choice(length_mask)
             else:
                 raise TypeError(
                     f"Expects the type of length_mask of `{mask_type}` to be an integer or a np.ndarray, actual type: {type(length_mask)}"
                 )
         else:
             # The choice of 0.25 is arbitrary
-            length = self.np_random.geometric(0.25)
-
-        # Generate sample values from feature_space.
-        sample_kwargs = (
-            {"probability": feature_mask}
-            if mask_type == "probability"
-            else {"mask": feature_mask}
-        )
-        sampled_values = tuple(
-            self.feature_space.sample(**sample_kwargs) for _ in range(length)
-        )
-
-        if self.stack:
-            # Concatenate values if stacked.
-            out = gym.vector.utils.create_empty_array(
-                self.feature_space, len(sampled_values)
-            )
-            return gym.vector.utils.concatenate(self.feature_space, sampled_values, out)
-
-        return sampled_values
+            return self.np_random.geometric(0.25)
 
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""

--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -132,9 +132,10 @@ class Sequence(Space[Union[typing.Tuple[Any, ...], Any]]):
             A tuple of random length with random samples of elements from the :attr:`feature_space`.
         """
         if mask is not None and probability is not None:
-            raise ValueError("Only one of `mask` or `probability` can be provided.")
-
-        if mask is not None:
+            raise ValueError(
+                f"Only one of `mask` or `probability` can be provided, actual values: mask={mask}, probability={probability}"
+            )
+        elif mask is not None:
             sample_length = self.generate_sample_length(mask[0], "mask")
             sampled_values = tuple(
                 self.feature_space.sample(mask=mask[1]) for _ in range(sample_length)

--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -99,9 +99,65 @@ class Sequence(Space[Union[typing.Tuple[Any, ...], Any]]):
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return False
 
+    def _sample(
+        self,
+        length_mask: None | np.integer | NDArray[np.integer],
+        feature_mask: Any,
+        mask_type: None | str,
+    ) -> tuple[Any] | Any:
+        if length_mask is not None:
+            if np.issubdtype(type(length_mask), np.integer):
+                assert (
+                    0 <= length_mask
+                ), f"Expects the length mask of {mask_type} to be greater than or equal to zero, actual value: {length_mask}"
+                length = length_mask
+            elif isinstance(length_mask, np.ndarray):
+                assert (
+                    len(length_mask.shape) == 1
+                ), f"Expects the shape of the length mask of {mask_type} to be 1-dimensional, actual shape: {length_mask.shape}"
+                assert np.all(
+                    0 <= length_mask
+                ), f"Expects all values in the length_mask of {mask_type} to be greater than or equal to zero, actual values: {length_mask}"
+                assert np.issubdtype(
+                    length_mask.dtype, np.integer
+                ), f"Expects the length mask array of {mask_type} to have dtype to be an numpy integer, actual type: {length_mask.dtype}"
+                length = self.np_random.choice(length_mask)
+            else:
+                raise TypeError(
+                    f"Expects the type of length_mask of {mask_type} to be an integer or a np.ndarray, actual type: {type(length_mask)}"
+                )
+        else:
+            # The choice of 0.25 is arbitrary
+            length = self.np_random.geometric(0.25)
+
+        # Generate sample values from feature_space.
+        sample_kwargs = (
+            {"probability": feature_mask}
+            if mask_type == "probability"
+            else {"mask": feature_mask}
+        )
+        sampled_values = tuple(
+            self.feature_space.sample(**sample_kwargs) for _ in range(length)
+        )
+
+        if self.stack:
+            # Concatenate values if stacked.
+            out = gym.vector.utils.create_empty_array(
+                self.feature_space, len(sampled_values)
+            )
+            return gym.vector.utils.concatenate(self.feature_space, sampled_values, out)
+
+        return sampled_values
+
     def sample(
         self,
         mask: None | (
+            tuple[
+                None | np.integer | NDArray[np.integer],
+                Any,
+            ]
+        ) = None,
+        probability: None | (
             tuple[
                 None | np.integer | NDArray[np.integer],
                 Any,
@@ -118,55 +174,34 @@ class Sequence(Space[Union[typing.Tuple[Any, ...], Any]]):
                 * ``np.ndarray`` of integers, in which case the length of the sampled sequence is randomly drawn from this array.
                 * ``int`` for a fixed length sample
 
-                The second element of the mask tuple ``sample`` mask specifies a mask that is applied when
+                The second element of the mask tuple ``sample_mask`` specifies a mask that is applied when
                 sampling elements from the base space. The mask is applied for each feature space sample.
+            probability: An optional probability mask for (optionally) the length of the sequence and (optionally) the values in the sequence.
+                If you specify ``probability``, it is expected to be a tuple of the form ``(length_probability, sample_probability)`` where ``length_probability`` is
+
+                * ``None`` The length will be randomly drawn from a geometric distribution
+                * ``np.ndarray`` of integers, in which case the length of the sampled sequence is randomly drawn from this array.
+                * ``int`` for a fixed length sample
+
+                The second element of the probability tuple ``sample_probability` specifies a probability mask that is applied when
+                sampling elements from the base space. The probability mask is applied for each feature space sample.
 
         Returns:
             A tuple of random length with random samples of elements from the :attr:`feature_space`.
         """
+        mask_type = None
         if mask is not None:
+            assert (
+                probability is None
+            ), "Either mask or probability can be provided, not both"
             length_mask, feature_mask = mask
+            mask_type = "mask"
+        elif probability is not None:
+            length_mask, feature_mask = probability
+            mask_type = "probability"
         else:
             length_mask, feature_mask = None, None
-
-        if length_mask is not None:
-            if np.issubdtype(type(length_mask), np.integer):
-                assert (
-                    0 <= length_mask
-                ), f"Expects the length mask to be greater than or equal to zero, actual value: {length_mask}"
-                length = length_mask
-            elif isinstance(length_mask, np.ndarray):
-                assert (
-                    len(length_mask.shape) == 1
-                ), f"Expects the shape of the length mask to be 1-dimensional, actual shape: {length_mask.shape}"
-                assert np.all(
-                    0 <= length_mask
-                ), f"Expects all values in the length_mask to be greater than or equal to zero, actual values: {length_mask}"
-                assert np.issubdtype(
-                    length_mask.dtype, np.integer
-                ), f"Expects the length mask array to have dtype to be an numpy integer, actual type: {length_mask.dtype}"
-                length = self.np_random.choice(length_mask)
-            else:
-                raise TypeError(
-                    f"Expects the type of length_mask to an integer or a np.ndarray, actual type: {type(length_mask)}"
-                )
-        else:
-            # The choice of 0.25 is arbitrary
-            length = self.np_random.geometric(0.25)
-
-        # Generate sample values from feature_space.
-        sampled_values = tuple(
-            self.feature_space.sample(mask=feature_mask) for _ in range(length)
-        )
-
-        if self.stack:
-            # Concatenate values if stacked.
-            out = gym.vector.utils.create_empty_array(
-                self.feature_space, len(sampled_values)
-            )
-            return gym.vector.utils.concatenate(self.feature_space, sampled_values, out)
-
-        return sampled_values
+        return self._sample(length_mask, feature_mask, mask_type)
 
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""

--- a/gymnasium/spaces/space.py
+++ b/gymnasium/spaces/space.py
@@ -95,6 +95,8 @@ class Space(Generic[T_cov]):
 
         Can be uniform or non-uniform sampling based on boundedness of space.
 
+        The binary mask and the probability mask can't be used at the same time.
+
         Args:
             mask: A mask used for random sampling, expected ``dtype=np.int8`` and see sample implementation for expected shape.
             probability: A probability mask used for sampling according to the given probability distribution, expected ``dtype=np.float64`` and see sample implementation for expected shape.

--- a/gymnasium/spaces/space.py
+++ b/gymnasium/spaces/space.py
@@ -90,13 +90,14 @@ class Space(Generic[T_cov]):
         """Checks whether this space can be flattened to a :class:`gymnasium.spaces.Box`."""
         raise NotImplementedError
 
-    def sample(self, mask: Any | None = None) -> T_cov:
+    def sample(self, mask: Any | None = None, probability: Any | None = None) -> T_cov:
         """Randomly sample an element of this space.
 
         Can be uniform or non-uniform sampling based on boundedness of space.
 
         Args:
-            mask: A mask used for sampling, expected ``dtype=np.int8`` and see sample implementation for expected shape.
+            mask: A mask used for random sampling, expected ``dtype=np.int8`` and see sample implementation for expected shape.
+            probability: A probability mask used for sampling according to the given probability distribution, expected ``dtype=np.float64`` and see sample implementation for expected shape.
 
         Returns:
             A sampled actions from the space

--- a/gymnasium/spaces/text.py
+++ b/gymnasium/spaces/text.py
@@ -84,11 +84,11 @@ class Text(Space[str]):
 
         Args:
             mask: An optional tuples of length and mask for the text.
-                The length is expected to be between the ``min_length`` and ``max_length`` otherwise a random integer between ``min_length`` and ``max_length`` is selected.
+                The length is expected to be between the ``min_length`` and ``max_length``. Otherwise, a random integer between ``min_length`` and ``max_length`` is selected.
                 For the mask, we expect a numpy array of length of the charset passed with ``dtype == np.int8``.
                 If the charlist mask is all zero then an empty string is returned no matter the ``min_length``
             probability: An optional tuples of length and probability mask for the text.
-                The length is expected to be between the ``min_length`` and ``max_length`` otherwise a random integer between ``min_length`` and ``max_length`` is selected.
+                The length is expected to be between the ``min_length`` and ``max_length``. Otherwise, a random integer between ``min_length`` and ``max_length`` is selected.
                 For the probability mask, we expect a numpy array of length of the charset passed with ``dtype == np.float64``.
                 The sum of the probability mask should be 1, otherwise an exception is raised.
 

--- a/gymnasium/spaces/text.py
+++ b/gymnasium/spaces/text.py
@@ -84,11 +84,13 @@ class Text(Space[str]):
 
         Args:
             mask: An optional tuples of length and mask for the text.
-                The length is expected to be between the ``min_length`` and ``max_length``. Otherwise, a random integer between ``min_length`` and ``max_length`` is selected.
+                The length is expected to be between the ``min_length`` and ``max_length``.
+                Otherwise, a random integer between ``min_length`` and ``max_length`` is selected.
                 For the mask, we expect a numpy array of length of the charset passed with ``dtype == np.int8``.
                 If the charlist mask is all zero then an empty string is returned no matter the ``min_length``
             probability: An optional tuples of length and probability mask for the text.
-                The length is expected to be between the ``min_length`` and ``max_length``. Otherwise, a random integer between ``min_length`` and ``max_length`` is selected.
+                The length is expected to be between the ``min_length`` and ``max_length``.
+                Otherwise, a random integer between ``min_length`` and ``max_length`` is selected.
                 For the probability mask, we expect a numpy array of length of the charset passed with ``dtype == np.float64``.
                 The sum of the probability mask should be 1, otherwise an exception is raised.
 
@@ -96,8 +98,9 @@ class Text(Space[str]):
             A sampled string from the space
         """
         if mask is not None and probability is not None:
-            raise ValueError("Only one of `mask` or `probability` can be provided.")
-
+            raise ValueError(
+                f"Only one of `mask` or `probability` can be provided, actual values: mask={mask}, probability={probability}"
+            )
         elif mask is not None:
             length, charlist_mask = self._validate_mask(mask, np.int8, "mask")
 
@@ -117,7 +120,7 @@ class Text(Space[str]):
             if charlist_mask is not None:
                 assert np.all(
                     np.logical_and(charlist_mask >= 0, charlist_mask <= 1)
-                ), f"Expects all probability mask values to be within [0,1], actual values: {charlist_mask}"
+                ), f"Expects all probability mask values to be within 0 and 1, actual values: {charlist_mask}"
                 assert np.isclose(
                     np.sum(charlist_mask), 1
                 ), f"Expects the sum of the probability mask to be 1, actual sum: {np.sum(charlist_mask)}"
@@ -135,7 +138,7 @@ class Text(Space[str]):
             else:
                 # Otherwise the string will not be contained in the space
                 raise ValueError(
-                    f"Trying to sample with a minimum length > 0 ({self.min_length}) but the character mask is all zero meaning that no character could be sampled."
+                    f"Trying to sample with a minimum length > 0 (actual minimum length={self.min_length}) but the character mask is all zero meaning that no character could be sampled."
                 )
 
         string = self.np_random.choice(

--- a/gymnasium/spaces/tuple.py
+++ b/gymnasium/spaces/tuple.py
@@ -106,8 +106,9 @@ class Tuple(Space[typing.Tuple[Any, ...]], typing.Sequence[Any]):
             Tuple of the subspace's samples
         """
         if mask is not None and probability is not None:
-            raise ValueError("Only one of `mask` or `probability` can be provided.")
-
+            raise ValueError(
+                f"Only one of `mask` or `probability` can be provided, actual values: mask={mask}, probability={probability}"
+            )
         elif mask is not None:
             assert isinstance(
                 mask, tuple

--- a/gymnasium/spaces/tuple.py
+++ b/gymnasium/spaces/tuple.py
@@ -108,30 +108,33 @@ class Tuple(Space[typing.Tuple[Any, ...]], typing.Sequence[Any]):
         if mask is not None and probability is not None:
             raise ValueError("Only one of `mask` or `probability` can be provided.")
 
-        mask_type = (
-            "mask"
-            if mask is not None
-            else "probability" if probability is not None else None
-        )
-        chosen_mask = mask if mask is not None else probability
+        elif mask is not None:
+            assert isinstance(
+                mask, tuple
+            ), f"Expected type of `mask` to be tuple, actual type: {type(mask)}"
+            assert len(mask) == len(
+                self.spaces
+            ), f"Expected length of `mask` to be {len(self.spaces)}, actual length: {len(mask)}"
 
-        if chosen_mask is not None:
-            self._verify_mask(chosen_mask, mask_type)
             return tuple(
-                space.sample(**{mask_type: sub_mask})
-                for space, sub_mask in zip(self.spaces, chosen_mask)
+                space.sample(mask=space_mask)
+                for space, space_mask in zip(self.spaces, mask)
             )
 
-        return tuple(space.sample() for space in self.spaces)
+        elif probability is not None:
+            assert isinstance(
+                probability, tuple
+            ), f"Expected type of `probability` to be tuple, actual type: {type(probability)}"
+            assert len(probability) == len(
+                self.spaces
+            ), f"Expected length of `probability` to be {len(self.spaces)}, actual length: {len(probability)}"
 
-    def _verify_mask(self, mask: tuple[Any | None, ...], mask_type: str) -> None:
-        """Checks the validity of the provided mask or probability."""
-        assert isinstance(
-            mask, tuple
-        ), f"Expected type of `{mask_type}` to be tuple, actual type: {type(mask)}"
-        assert len(mask) == len(
-            self.spaces
-        ), f"Expected length of `{mask_type}` to be {len(self.spaces)}, actual length: {len(mask)}"
+            return tuple(
+                space.sample(probability=space_probability)
+                for space, space_probability in zip(self.spaces, probability)
+            )
+        else:
+            return tuple(space.sample() for space in self.spaces)
 
     def contains(self, x: Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""

--- a/tests/spaces/test_box.py
+++ b/tests/spaces/test_box.py
@@ -373,3 +373,15 @@ def test_sample_mask():
         match=re.escape("Box.sample cannot be provided a mask, actual value: "),
     ):
         space.sample(mask=np.array([0, 1, 0], dtype=np.int8))
+
+
+def test_sample_probability_mask():
+    """Box cannot have a probability mask applied."""
+    space = Box(0, 1)
+    with pytest.raises(
+        gym.error.Error,
+        match=re.escape(
+            "Box.sample cannot be provided a probability mask, actual value: "
+        ),
+    ):
+        space.sample(probability=np.array([0, 1, 0], dtype=np.float64))

--- a/tests/spaces/test_dict.py
+++ b/tests/spaces/test_dict.py
@@ -226,18 +226,31 @@ def test_sample_with_invalid_mask():
         }
     )
 
-    invalid_mask = {
-        "a": np.array([1, 0, 0], dtype=np.float64),  # Length mismatch
-        "b": None,
-    }
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "The expected shape of the sample mask is (np.int64(5),), actual shape: (3,)"
+        ),
+    ):
+        space.sample(
+            mask={
+                "a": np.array([1, 0, 0], dtype=np.int8),  # Length mismatch
+                "b": None,
+            }
+        )
 
     with pytest.raises(
         AssertionError,
         match=re.escape(
-            "The expected shape of `mask` is (np.int64(5),), actual shape: (3,)"
+            "The expected dtype of the sample mask is np.int8, actual dtype: float32"
         ),
     ):
-        space.sample(mask=invalid_mask)
+        space.sample(
+            mask={
+                "a": np.array([1, 0, 0, 1, 1], dtype=np.float32),  # dtype mismatch
+                "b": None,
+            }
+        )
 
 
 def test_sample_with_invalid_probability():
@@ -249,18 +262,31 @@ def test_sample_with_invalid_probability():
         }
     )
 
-    invalid_probability = {
-        "a": np.array([0.5, 0.5], dtype=np.float64),  # Length mismatch
-        "b": None,
-    }
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "The expected shape of the sample probability is (np.int64(5),), actual shape: (2,)"
+        ),
+    ):
+        space.sample(
+            probability={
+                "a": np.array([0.5, 0.5], dtype=np.float64),  # Length mismatch
+                "b": None,
+            }
+        )
 
     with pytest.raises(
         AssertionError,
         match=re.escape(
-            "The expected shape of `probability` is (np.int64(5),), actual shape: (2,)"
+            "The expected dtype of the sample probability is np.float64, actual dtype: int8"
         ),
     ):
-        space.sample(probability=invalid_probability)
+        space.sample(
+            probability={
+                "a": np.array([0.5, 0.5], dtype=np.int8),  # dtype mismatch
+                "b": None,
+            }
+        )
 
 
 def test_sample_with_mask_and_probability():
@@ -283,7 +309,7 @@ def test_sample_with_mask_and_probability():
     }
 
     with pytest.raises(
-        AssertionError,
+        ValueError,
         match=re.escape("Only one of `mask` or `probability` can be provided"),
     ):
         space.sample(mask=mask, probability=probability)

--- a/tests/spaces/test_dict.py
+++ b/tests/spaces/test_dict.py
@@ -229,7 +229,7 @@ def test_sample_with_invalid_mask():
     with pytest.raises(
         AssertionError,
         match=re.escape(
-            "The expected shape of the sample mask is (np.int64(5),), actual shape: (3,)"
+            "The expected shape of the sample mask is (5,), actual shape: (3,)"
         ),
     ):
         space.sample(
@@ -265,7 +265,7 @@ def test_sample_with_invalid_probability():
     with pytest.raises(
         AssertionError,
         match=re.escape(
-            "The expected shape of the sample probability is (np.int64(5),), actual shape: (2,)"
+            "The expected shape of the sample probability is (5,), actual shape: (2,)"
         ),
     ):
         space.sample(

--- a/tests/spaces/test_dict.py
+++ b/tests/spaces/test_dict.py
@@ -182,7 +182,9 @@ def test_sample_with_mask():
     )
 
     mask = {
-        "a": [0, 1, 0, 0, 0],  # Only allow sampling the value 1
+        "a": np.array(
+            [0, 1, 0, 0, 0], dtype=np.int8
+        ),  # Only allow sampling the value 1
         "b": None,  # No mask for Box space
     }
 
@@ -202,7 +204,9 @@ def test_sample_with_probability():
     )
 
     probability = {
-        "a": [0.1, 0.7, 0.2],  # Sampling probabilities for Discrete space
+        "a": np.array(
+            [0.1, 0.7, 0.2], dtype=np.float64
+        ),  # Sampling probabilities for Discrete space
         "b": None,  # No probability for Box space
     }
 
@@ -223,12 +227,15 @@ def test_sample_with_invalid_mask():
     )
 
     invalid_mask = {
-        "a": [1, 0, 0],  # Length mismatch
+        "a": np.array([1, 0, 0], dtype=np.float64),  # Length mismatch
         "b": None,
     }
 
     with pytest.raises(
-        AssertionError, match="Expected mask keys to be same as space keys"
+        AssertionError,
+        match=re.escape(
+            "The expected shape of `mask` is (np.int64(5),), actual shape: (3,)"
+        ),
     ):
         space.sample(mask=invalid_mask)
 
@@ -243,12 +250,15 @@ def test_sample_with_invalid_probability():
     )
 
     invalid_probability = {
-        "a": [0.5, 0.5],  # Length mismatch
+        "a": np.array([0.5, 0.5], dtype=np.float64),  # Length mismatch
         "b": None,
     }
 
     with pytest.raises(
-        AssertionError, match="Expected probability keys to be same as space keys"
+        AssertionError,
+        match=re.escape(
+            "The expected shape of `probability` is (np.int64(5),), actual shape: (2,)"
+        ),
     ):
         space.sample(probability=invalid_probability)
 
@@ -263,16 +273,17 @@ def test_sample_with_mask_and_probability():
     )
 
     mask = {
-        "a": [1, 0, 1],
+        "a": np.array([1, 0, 1], dtype=np.int8),
         "b": None,
     }
 
     probability = {
-        "a": [0.5, 0.2, 0.3],
+        "a": np.array([0.5, 0.2, 0.3], dtype=np.float64),
         "b": None,
     }
 
     with pytest.raises(
-        AssertionError, match="Only one of `mask` or `probability` can be provided"
+        AssertionError,
+        match=re.escape("Only one of `mask` or `probability` can be provided"),
     ):
         space.sample(mask=mask, probability=probability)

--- a/tests/spaces/test_discrete.py
+++ b/tests/spaces/test_discrete.py
@@ -76,7 +76,7 @@ def test_invalid_probability_mask_dtype():
     with pytest.raises(
         AssertionError,
         match=re.escape(
-            "The expected dtype of `probability` is <class 'numpy.float64'>, actual dtype: int8"
+            "The expected dtype of the sample probability is np.float64, actual dtype: int8"
         ),
     ):
         space.sample(probability=np.array([0, 1, 0, 0], dtype=np.int8))
@@ -89,7 +89,7 @@ def test_invalid_probability_mask_values():
     with pytest.raises(
         AssertionError,
         match=re.escape(
-            "All values of `probability mask` should be 0, 1, or in between, actual values: [-0.5  1.   0.5  0. ]"
+            "All values of the sample probability should be between 0 and 1, actual values: [-0.5  1.   0.5  0. ]"
         ),
     ):
         space.sample(probability=np.array([-0.5, 1, 0.5, 0], dtype=np.float64))
@@ -97,7 +97,7 @@ def test_invalid_probability_mask_values():
     with pytest.raises(
         AssertionError,
         match=re.escape(
-            "The sum of all values of `probability mask` should be 1, actual sum: 1.1"
+            "The sum of the sample probability should be equal to 1, actual sum: 1.1"
         ),
     ):
         space.sample(probability=np.array([0.2, 0.3, 0.4, 0.2], dtype=np.float64))
@@ -105,7 +105,7 @@ def test_invalid_probability_mask_values():
     with pytest.raises(
         AssertionError,
         match=re.escape(
-            "The sum of all values of `probability mask` should be 1, actual sum: 0.0"
+            "The sum of the sample probability should be equal to 1, actual sum: 0.0"
         ),
     ):
         space.sample(probability=np.array([0, 0, 0, 0], dtype=np.float64))

--- a/tests/spaces/test_discrete.py
+++ b/tests/spaces/test_discrete.py
@@ -68,7 +68,7 @@ def test_invalid_probability_mask():
     except AssertionError as e:
         assert (
             str(e)
-            == "The expected dtype of the probability mask is np.float64, actual dtype: np.int8"
+            == "The expected dtype of the probability mask is np.float64, actual dtype: int8"
         ), f"unexpected error message: {e}"
     else:
         assert False, "Expected AssertionError not raised"
@@ -78,7 +78,7 @@ def test_invalid_probability_mask():
     except AssertionError as e:
         assert (
             str(e)
-            == "All values of a mask should be 0, 1, or in between, actual values: [-0.5  1.   0.5]"
+            == "All values of a mask should be 0, 1, or in between, actual values: [-0.5  1.   0.5  0. ]"
         ), f"unexpected error message: {e}"
     else:
         assert False, "Expected AssertionError not raised"
@@ -98,7 +98,7 @@ def test_invalid_probability_mask():
     except AssertionError as e:
         assert (
             str(e)
-            == "The sum of all values of the probability mask should be 1, actual sum: 0"
+            == "The sum of all values of the probability mask should be 1, actual sum: 0.0"
         ), f"unexpected error message: {e}"
     else:
         assert False, "Expected AssertionError not raised"

--- a/tests/spaces/test_discrete.py
+++ b/tests/spaces/test_discrete.py
@@ -27,8 +27,78 @@ def test_space_legacy_pickling():
 
 
 def test_sample_mask():
+    """Test that the mask parameter of the sample function works as expected."""
     space = Discrete(4, start=2)
     assert 2 <= space.sample() < 6
     assert space.sample(mask=np.array([0, 1, 0, 0], dtype=np.int8)) == 3
     assert space.sample(mask=np.array([0, 0, 0, 0], dtype=np.int8)) == 2
     assert space.sample(mask=np.array([0, 1, 0, 1], dtype=np.int8)) in [3, 5]
+
+
+def test_probability_mask():
+    """Test that the probability parameter of the sample function works as expected."""
+    space = Discrete(4, start=2)
+    assert space.sample(probability=np.array([0, 1, 0, 0], dtype=np.float64)) == 3
+    assert space.sample(mask=np.array([0, 0.5, 0, 0.5], dtype=np.float64)) in [3, 5]
+    assert space.sample(mask=np.array([0.1, 0.2, 0.3, 0.4], dtype=np.float64)) in [
+        2,
+        3,
+        4,
+        5,
+    ]
+
+
+def test_invalid_probability_mask():
+    """Test that invalid activities raise the correct exception."""
+    space = Discrete(4, start=2)
+    try:
+        space.sample(
+            mask=np.array([0, 1, 0, 0], dtype=np.int8),
+            probability=np.array([0, 1, 0, 0], dtype=np.float64),
+        )
+    except AssertionError as e:
+        assert (
+            str(e) == "Either mask or probability can be provided, not both"
+        ), f"unexpected error message: {e}"
+    else:
+        assert False, "Expected AssertionError not raised"
+
+    try:
+        space.sample(probability=np.array([0, 1, 0, 0], dtype=np.int8))
+    except AssertionError as e:
+        assert (
+            str(e)
+            == "The expected dtype of the probability mask is np.float64, actual dtype: np.int8"
+        ), f"unexpected error message: {e}"
+    else:
+        assert False, "Expected AssertionError not raised"
+
+    try:
+        space.sample(probability=np.array([-0.5, 1, 0.5, 0], dtype=np.float64))
+    except AssertionError as e:
+        assert (
+            str(e)
+            == "All values of a mask should be 0, 1, or in between, actual values: [-0.5  1.   0.5]"
+        ), f"unexpected error message: {e}"
+    else:
+        assert False, "Expected AssertionError not raised"
+
+    try:
+        space.sample(probability=np.array([0.2, 0.3, 0.4, 0.2], dtype=np.float64))
+    except AssertionError as e:
+        assert (
+            str(e)
+            == "The sum of all values of the probability mask should be 1, actual sum: 1.1"
+        ), f"unexpected error message: {e}"
+    else:
+        assert False, "Expected AssertionError not raised"
+
+    try:
+        space.sample(probability=np.array([0, 0, 0, 0], dtype=np.float64))
+    except AssertionError as e:
+        assert (
+            str(e)
+            == "The sum of all values of the probability mask should be 1, actual sum: 0"
+        ), f"unexpected error message: {e}"
+    else:
+        assert False, "Expected AssertionError not raised"

--- a/tests/spaces/test_graph.py
+++ b/tests/spaces/test_graph.py
@@ -135,3 +135,96 @@ def test_edge_space_sample():
 def test_not_contains(sample):
     space = Graph(node_space=Discrete(2), edge_space=Discrete(2))
     assert sample not in space
+
+
+def test_probability_node_sampling():
+    """
+    Test the probability parameter for node sampling.
+    Ensures nodes are sampled according to the given probability distribution.
+    """
+    space = Graph(node_space=Discrete(3), edge_space=None)
+    space.seed(42)
+
+    # Define a probability distribution for nodes
+    probability = np.array([0.7, 0.2, 0.1], dtype=np.float32)
+    num_samples = 1000
+
+    # Collect samples with the given probability
+    samples = [
+        space.sample(mask=(probability, None), num_nodes=1).nodes[0]
+        for _ in range(num_samples)
+    ]
+
+    # Check the empirical distribution of the samples
+    counts = np.bincount(samples, minlength=3)
+    empirical_distribution = counts / num_samples
+
+    assert np.allclose(
+        empirical_distribution, probability, atol=0.05
+    ), f"Empirical distribution {empirical_distribution} does not match expected probability {probability}"
+
+
+def test_probability_edge_sampling():
+    """
+    Test the probability parameter for edge sampling.
+    Ensures edges are sampled according to the given probability distribution.
+    """
+    space = Graph(node_space=Discrete(3), edge_space=Discrete(3))
+    space.seed(42)
+
+    # Define a probability distribution for edges
+    probability = np.array([0.5, 0.3, 0.2], dtype=np.float32)
+    num_samples = 1000
+
+    # Collect samples with the given probability
+    samples = [
+        space.sample(mask=(None, probability), num_edges=1).edges[0]
+        for _ in range(num_samples)
+    ]
+
+    # Check the empirical distribution of the samples
+    counts = np.bincount(samples, minlength=3)
+    empirical_distribution = counts / num_samples
+
+    assert np.allclose(
+        empirical_distribution, probability, atol=0.05
+    ), f"Empirical distribution {empirical_distribution} does not match expected probability {probability}"
+
+
+def test_probability_node_and_edge_sampling():
+    """
+    Test the probability parameter for both node and edge sampling.
+    Ensures nodes and edges are sampled correctly according to their respective probability distributions.
+    """
+    space = Graph(node_space=Discrete(3), edge_space=Discrete(3))
+    space.seed(42)
+
+    # Define probability distributions for nodes and edges
+    node_probability = np.array([0.6, 0.3, 0.1], dtype=np.float32)
+    edge_probability = np.array([0.4, 0.4, 0.2], dtype=np.float32)
+    num_samples = 1000
+
+    # Collect samples with the given probabilities
+    node_samples = []
+    edge_samples = []
+    for _ in range(num_samples):
+        sample = space.sample(
+            mask=(node_probability, edge_probability), num_nodes=1, num_edges=1
+        )
+        node_samples.append(sample.nodes[0])
+        edge_samples.append(sample.edges[0])
+
+    # Check the empirical distributions of the samples
+    node_counts = np.bincount(node_samples, minlength=3)
+    edge_counts = np.bincount(edge_samples, minlength=3)
+
+    node_empirical_distribution = node_counts / num_samples
+    edge_empirical_distribution = edge_counts / num_samples
+
+    assert np.allclose(
+        node_empirical_distribution, node_probability, atol=0.05
+    ), f"Node empirical distribution {node_empirical_distribution} does not match expected probability {node_probability}"
+
+    assert np.allclose(
+        edge_empirical_distribution, edge_probability, atol=0.05
+    ), f"Edge empirical distribution {edge_empirical_distribution} does not match expected probability {edge_probability}"

--- a/tests/spaces/test_graph.py
+++ b/tests/spaces/test_graph.py
@@ -146,12 +146,12 @@ def test_probability_node_sampling():
     space.seed(42)
 
     # Define a probability distribution for nodes
-    probability = np.array([0.7, 0.2, 0.1], dtype=np.float32)
+    probability = np.array([0.7, 0.2, 0.1], dtype=np.float64)
     num_samples = 1000
 
     # Collect samples with the given probability
     samples = [
-        space.sample(mask=(probability, None), num_nodes=1).nodes[0]
+        space.sample(probability=((probability,), None), num_nodes=1).nodes[0]
         for _ in range(num_samples)
     ]
 
@@ -173,12 +173,12 @@ def test_probability_edge_sampling():
     space.seed(42)
 
     # Define a probability distribution for edges
-    probability = np.array([0.5, 0.3, 0.2], dtype=np.float32)
+    probability = np.array([0.5, 0.3, 0.2], dtype=np.float64)
     num_samples = 1000
 
     # Collect samples with the given probability
     samples = [
-        space.sample(mask=(None, probability), num_edges=1).edges[0]
+        space.sample(probability=(None, (probability,)), num_edges=1).edges[0]
         for _ in range(num_samples)
     ]
 
@@ -200,8 +200,8 @@ def test_probability_node_and_edge_sampling():
     space.seed(42)
 
     # Define probability distributions for nodes and edges
-    node_probability = np.array([0.6, 0.3, 0.1], dtype=np.float32)
-    edge_probability = np.array([0.4, 0.4, 0.2], dtype=np.float32)
+    node_probability = np.array([0.6, 0.3, 0.1], dtype=np.float64)
+    edge_probability = np.array([0.4, 0.4, 0.2], dtype=np.float64)
     num_samples = 1000
 
     # Collect samples with the given probabilities
@@ -209,7 +209,9 @@ def test_probability_node_and_edge_sampling():
     edge_samples = []
     for _ in range(num_samples):
         sample = space.sample(
-            mask=(node_probability, edge_probability), num_nodes=1, num_edges=1
+            probability=((node_probability,), (edge_probability,)),
+            num_nodes=1,
+            num_edges=1,
         )
         node_samples.append(sample.nodes[0])
         edge_samples.append(sample.edges[0])

--- a/tests/spaces/test_multibinary.py
+++ b/tests/spaces/test_multibinary.py
@@ -17,3 +17,18 @@ def test_sample():
     space = MultiBinary(np.array([2, 3]))
     sample = space.sample(mask=np.array([[0, 0, 0], [1, 1, 1]], dtype=np.int8))
     assert np.all(sample == [[0, 0, 0], [1, 1, 1]]), sample
+
+
+def test_sample_probabilities():
+    # Test sampling with probabilities
+    space = MultiBinary(4)
+    probabilities = np.array([0, 1, 0.5, 0.25], dtype=np.float64)
+
+    samples = [space.sample(probability=probabilities) for _ in range(10000)]
+    assert all(sample in space for sample in samples)
+    samples = np.array(samples)
+
+    # Check empirical probabilities
+    for i in range(4):
+        counts = np.sum(samples[:, i]) / len(samples)
+        np.testing.assert_allclose(counts, probabilities[i], atol=0.05)

--- a/tests/spaces/test_multidiscrete.py
+++ b/tests/spaces/test_multidiscrete.py
@@ -222,23 +222,30 @@ def test_multidiscrete_sample():
 
 def test_multidiscrete_sample_with_mask():
     # Test sampling with a mask
-    space = MultiDiscrete([5, 2, 3])
-    mask = np.array([[1, 0, 1], [1, 1, 0], [1, 0, 1]])
+    space = MultiDiscrete([2, 3, 4])
+    mask = (
+        np.array([1, 0], dtype=np.int8),
+        np.array([1, 1, 0], dtype=np.int8),
+        np.array([1, 0, 1, 0], dtype=np.int8),
+    )
     samples = [space.sample(mask=mask) for _ in range(1000)]
     samples = np.array(samples)
 
     # Check that the samples respect the mask
     for i, dim in enumerate(space.nvec):
         for j in range(dim):
-            if mask[i, j] == 0:
+            if mask[i][j] == 0:
                 assert np.all(samples[:, i] != j)
 
 
 def test_multidiscrete_sample_probabilities():
     # Test sampling with probabilities
     space = MultiDiscrete([3, 3])
-    probabilities = np.array([[0.1, 0.7, 0.2], [0.3, 0.3, 0.4]])
-    samples = [space.sample(probabilities=probabilities) for _ in range(10000)]
+    probabilities = (
+        np.array([0.1, 0.7, 0.2], dtype=np.float64),
+        np.array([0.3, 0.3, 0.4], dtype=np.float64),
+    )
+    samples = [space.sample(probability=probabilities) for _ in range(10000)]
     samples = np.array(samples)
 
     # Check empirical probabilities

--- a/tests/spaces/test_multidiscrete.py
+++ b/tests/spaces/test_multidiscrete.py
@@ -229,6 +229,7 @@ def test_multidiscrete_sample_with_mask():
         np.array([1, 0, 1, 0], dtype=np.int8),
     )
     samples = [space.sample(mask=mask) for _ in range(1000)]
+    assert all(sample in space for sample in samples)
     samples = np.array(samples)
 
     # Check that the samples respect the mask
@@ -246,6 +247,7 @@ def test_multidiscrete_sample_probabilities():
         np.array([0.3, 0.3, 0.4], dtype=np.float64),
     )
     samples = [space.sample(probability=probabilities) for _ in range(10000)]
+    assert all(sample in space for sample in samples)
     samples = np.array(samples)
 
     # Check empirical probabilities

--- a/tests/spaces/test_text.py
+++ b/tests/spaces/test_text.py
@@ -39,3 +39,37 @@ def test_sample_mask():
     sample = space.sample(mask=(3, np.array([0, 1, 0, 0], dtype=np.int8)))
     assert sample in space
     assert sample == "bbb"
+
+
+def test_sample_probability():
+    space = Text(min_length=1, max_length=5)
+
+    # Test the sample length
+    sample = space.sample(probability=(3, None))
+    assert sample in space
+    assert len(sample) == 3
+
+    sample = space.sample(probability=None)
+    assert sample in space
+    assert 1 <= len(sample) <= 5
+
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "Expects the sum of the probability mask to be 1, actual sum: 0.0"
+        ),
+    ):
+        space.sample(
+            probability=(3, np.zeros(len(space.character_set), dtype=np.float64))
+        )
+
+    # Test the sample characters
+    space = Text(max_length=5, charset="abcd")
+
+    sample = space.sample(probability=(3, np.array([0, 1, 0, 0], dtype=np.float64)))
+    assert sample in space
+    assert sample == "bbb"
+
+    sample = space.sample(probability=(2, np.array([0.5, 0.5, 0, 0], dtype=np.float64)))
+    assert sample in space
+    assert sample in ["aa", "bb", "ab", "ba"]

--- a/tests/spaces/test_text.py
+++ b/tests/spaces/test_text.py
@@ -21,7 +21,7 @@ def test_sample_mask():
     with pytest.raises(
         ValueError,
         match=re.escape(
-            "Trying to sample with a minimum length > 0 (1) but the character mask is all zero meaning that no character could be sampled."
+            "Trying to sample with a minimum length > 0 (actual minimum length=1) but the character mask is all zero meaning that no character could be sampled."
         ),
     ):
         space.sample(mask=(3, np.zeros(len(space.character_set), dtype=np.int8)))
@@ -30,6 +30,10 @@ def test_sample_mask():
     sample = space.sample(
         mask=(None, np.zeros(len(space.character_set), dtype=np.int8))
     )
+    assert sample in space
+    assert sample == ""
+
+    sample = space.sample(mask=(0, None))
     assert sample in space
     assert sample == ""
 

--- a/tests/spaces/test_tuple.py
+++ b/tests/spaces/test_tuple.py
@@ -105,3 +105,68 @@ def test_bad_seed():
         match="Expected seed type: list, tuple, int or None, actual type: <class 'float'>",
     ):
         space.seed(0.0)
+
+
+def test_oneof_sample():
+    """Tests the sample method with and without masks or probabilities."""
+    space = gym.spaces.Tuple([Discrete(2), Box(-1, 1, shape=(2,))])
+
+    # Unmasked sampling
+    sample = space.sample()
+    assert isinstance(sample, tuple)
+    assert len(sample) == 2
+    assert space.spaces[0].contains(sample[0])
+    assert space.spaces[1].contains(sample[1])
+
+    # Masked sampling
+    mask = (np.array([1, 0], dtype=np.int8), None)
+    sample = space.sample(mask=mask)
+    assert space.spaces[0].contains(sample[0])
+    assert space.spaces[1].contains(sample[1])
+    assert sample[0] == 0
+
+    # Probability sampling
+    probability = (np.array([0.8, 0.2], dtype=np.float64), None)
+    samples_discrete = np.array(
+        [space.sample(probability=probability)[0] for _ in range(1000)]
+    )
+    counts = np.bincount(samples_discrete, minlength=2) / len(samples_discrete)
+    np.testing.assert_allclose(counts, probability[0], atol=0.05)
+
+
+def test_invalid_sample_inputs():
+    """Tests that invalid inputs to sample raise appropriate errors."""
+    space = gym.spaces.Tuple([Discrete(2), Box(-1, 1, shape=(2,))])
+
+    # Providing both mask and probability
+    with pytest.raises(
+        ValueError, match="Only one of `mask` or `probability` can be provided."
+    ):
+        space.sample(mask=(None, None), probability=(0.5, 0.5))
+
+    # Invalid mask type
+    with pytest.raises(
+        AssertionError,
+        match="Expected type of `mask` to be tuple, actual type: <class 'dict'>",
+    ):
+        space.sample(mask={"low": 0, "high": 1})
+
+    # Invalid mask length
+    with pytest.raises(
+        AssertionError, match="Expected length of `mask` to be 2, actual length: 1"
+    ):
+        space.sample(mask=(None,))
+
+    # Invalid probability length
+    with pytest.raises(
+        AssertionError,
+        match="Expected length of `probability` to be 2, actual length: 1",
+    ):
+        space.sample(probability=(0.5,))
+
+    # Invalid probability type
+    with pytest.raises(
+        AssertionError,
+        match="Expected type of `probability` to be tuple, actual type: <class 'list'>",
+    ):
+        space.sample(probability=[0.5, 0.5])


### PR DESCRIPTION
# Description

Adds a probability mask feature (`probability`) to the `sample()` method of all spaces. This allows you to specify the probability of choosing each action. Similarly to the `mask` parameter, the `probability` parameter is a numpy array with the same shape as `n`, the number of elements in the space. Each value in the array describes the probability of the corresponding value being chosen, with 0 meaning it will not be chosen and 1 meaning that it will be chosen. All of the values in the array must sum to 1. `probability` is unsupported for the Box space.


## Motivation

This is helpful in instances where values need to be chosen at random, such that some values are given higher priority (a higher likelihood) over others. For example, when implementing an Ant Colony Optimization algorithm, each action needs to be assigned a different probability of being chosen.

Fixes #1255 and the completion of #1296

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
