### PR TITLE
Allow `AtariPreprocessing` non-square observations

### DIFF
--- a/gymnasium/wrappers/atari_preprocessing.py
+++ b/gymnasium/wrappers/atari_preprocessing.py
@@ -142,7 +142,7 @@ class AtariPreprocessing(gym.Wrapper, gym.utils.RecordConstructorArgs):
         self.game_over = False
 
         _low, _high, _dtype = (0, 1, np.float32) if scale_obs else (0, 255, np.uint8)
-        _shape = self.screen_size + (1 if grayscale_obs else 3,)
+        _shape = (self.screen_size[1], self.screen_size[0], 1 if grayscale_obs else 3)
         if grayscale_obs and not grayscale_newaxis:
             _shape = _shape[:-1]  # Remove channel axis
         self.observation_space = Box(low=_low, high=_high, shape=_shape, dtype=_dtype)

--- a/tests/wrappers/test_atari_preprocessing.py
+++ b/tests/wrappers/test_atari_preprocessing.py
@@ -47,6 +47,17 @@ pytest.importorskip("ale_py")
             ),
             (84, 84, 1),
         ),
+        (
+            AtariPreprocessing(
+                gym.make("ALE/Pong-v5"),
+                screen_size=(160, 210),
+                grayscale_obs=False,
+                frame_skip=1,
+                noop_max=0,
+                grayscale_newaxis=True,
+            ),
+            (210, 160, 3),
+        ),
     ],
 )
 def test_atari_preprocessing_grayscale(env, expected_obs_shape):


### PR DESCRIPTION
# Description

Fix observation shape of `AtariPreprocessing` when the screen is not square. Since screen size are directly passed into `cv2.resize`, its order should be width x height. Observation shape should be `height x width`.

https://github.com/Farama-Foundation/Gymnasium/blob/a4f8cfbcd8a350d5d11aa920adb9c220bd716d32/gymnasium/wrappers/atari_preprocessing.py#L219-L223
## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
