### PR TITLE
Refer to numpy instead of jax [for vars and docs] in vector NumpyToTorch

### DIFF
--- a/gymnasium/wrappers/vector/numpy_to_torch.py
+++ b/gymnasium/wrappers/vector/numpy_to_torch.py
@@ -42,7 +42,7 @@ class NumpyToTorch(VectorWrapper):
         """Wrapper class to change inputs and outputs of environment to PyTorch tensors.
 
         Args:
-            env: The Jax-based vector environment to wrap
+            env: The NumPy-based vector environment to wrap
             device: The device the torch Tensors should be moved to
         """
         super().__init__(env)
@@ -60,8 +60,8 @@ class NumpyToTorch(VectorWrapper):
         Returns:
             The PyTorch-based Tensor next observation, reward, termination, truncation, and extra info
         """
-        jax_action = torch_to_numpy(actions)
-        obs, reward, terminated, truncated, info = self.env.step(jax_action)
+        numpy_action = torch_to_numpy(actions)
+        obs, reward, terminated, truncated, info = self.env.step(numpy_action)
 
         return (
             numpy_to_torch(obs, self.device),
@@ -81,7 +81,7 @@ class NumpyToTorch(VectorWrapper):
 
         Args:
             seed: The seed for resetting the environment
-            options: The options for resetting the environment, these are converted to jax arrays.
+            options: The options for resetting the environment, these are converted to NumPy arrays.
 
         Returns:
             PyTorch-based observations and info


### PR DESCRIPTION
It seems that the vector `NumpyToTorch` class was created from `JaxToTorch`, so some misleading artifacts referring to JAX instead of NumPy still exist in the documentation and variable names.

# Description

Fixed:
- `jax_action` -> `numpy_action` variable name
- `Jax-based` + `jax arrays` -> `NumPy-based` + `NumPy arrays` in the docs

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] I have made corresponding changes to the documentation

I apologize that I haven't tested the changes — just made a quick fix via web github editor.

_PS. Thank you guys for your great job!_
