### PR TITLE
Remove Mujoco assert on metadata render-mode

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -82,12 +82,6 @@ class MujocoEnv(gym.Env):
 
         self.frame_skip = frame_skip
 
-        assert self.metadata["render_modes"] == [
-            "human",
-            "rgb_array",
-            "depth_array",
-            "rgbd_tuple",
-        ], self.metadata["render_modes"]
         if "render_fps" in self.metadata:
             assert (
                 int(np.round(1.0 / self.dt)) == self.metadata["render_fps"]

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -63,31 +63,31 @@ def test_offscreen_viewer_custom_dimensions(
 @pytest.mark.parametrize(
     "env_id",
     [
-        "Ant-v5",
-        "HalfCheetah-v5",
-        "HalfCheetah-v4",
-        "HalfCheetah-v3",
-        "Hopper-v5",
-        "Hopper-v4",
-        "Hopper-v3",
-        "Humanoid-v5",
-        "HumanoidStandup-v5",
-        "Swimmer-v5",
-        "Swimmer-v4",
-        "Swimmer-v3",
-        "Walker2d-v5",
-        "Walker2d-v4",
-        "Walker2d-v3",
+        "Ant",
+        "HalfCheetah",
+        "Hopper",
+        "Humanoid",
+        "HumanoidStandup",
+        "InvertedDoublePendulum",
+        "InvertedPendulum",
+        "Pusher",
+        "Reacher",
+        "Swimmer",
+        "Walker2d",
     ],
 )
-def test_mujoco_metadata_render_modes(env_id):
-    env = gymnasium.make(env_id)
+@pytest.mark.parametrize("version", ["v4", "v5"])
+def test_mujoco_metadata_render_modes(env_id, version):
+    if env_id == "Pusher" and version == "v4":
+        pytest.skip()
+    env = gymnasium.make(f"{env_id}-{version}")
     assert env.metadata["render_modes"] == [
         "human",
         "rgb_array",
         "depth_array",
         "rgbd_tuple",
     ]
+    env.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -61,6 +61,36 @@ def test_offscreen_viewer_custom_dimensions(
 
 
 @pytest.mark.parametrize(
+    "env_id",
+    [
+        "Ant-v5",
+        "HalfCheetah-v5",
+        "HalfCheetah-v4",
+        "HalfCheetah-v3",
+        "Hopper-v5",
+        "Hopper-v4",
+        "Hopper-v3",
+        "Humanoid-v5",
+        "HumanoidStandup-v5",
+        "Swimmer-v5",
+        "Swimmer-v4",
+        "Swimmer-v3",
+        "Walker2d-v5",
+        "Walker2d-v4",
+        "Walker2d-v3",
+    ],
+)
+def test_mujoco_metadata_render_modes(env_id):
+    env = gymnasium.make(env_id)
+    assert env.metadata["render_modes"] == [
+        "human",
+        "rgb_array",
+        "depth_array",
+        "rgbd_tuple",
+    ]
+
+
+@pytest.mark.parametrize(
     "render_mode", ["human", "rgb_array", "depth_array", "rgbd_tuple"]
 )
 @pytest.mark.parametrize("max_geom", [10, 100, 1000, 10000])


### PR DESCRIPTION
# Description

Fixes https://github.com/Farama-Foundation/Gymnasium-Robotics/issues/265 through removing the assertation check and moving the assertion into the tests 