### PR TITLE
Fix MuJoCo add_markers for mujoco>=3.2

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -96,7 +96,7 @@ class BaseRender:
         if self.scn.ngeom >= self.scn.maxgeom:
             raise RuntimeError(f"Ran out of geoms. maxgeom: {self.scn.maxgeom}")
 
-        if _MUJOCO_MARKER_LEGACY_MODE:
+        if _MUJOCO_MARKER_LEGACY_MODE:  # Old API for markers requires special handling
             self._legacy_add_marker_to_scene(marker)
         else:
             geom_type = marker.get("type", mujoco.mjtGeom.mjGEOM_SPHERE)
@@ -116,6 +116,15 @@ class BaseRender:
         self.scn.ngeom += 1
 
     def _legacy_add_marker_to_scene(self, marker: dict):
+        """Add a marker to the scene compatible with older versions of MuJoCo.
+
+        MuJoCo 3.2 introduced breaking changes to the visual geometries API. To maintain
+        compatibility with older versions, we use the legacy API when an older version of MuJoCo is
+        detected.
+
+        Args:
+            marker: A dictionary containing the marker parameters.
+        """
         g = self.scn.geoms[self.scn.ngeom]
         # default values.
         g.dataid = -1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
 mujoco-py = ["mujoco-py >=2.1,<2.2", "cython<3"]
 mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]  # kept for backward compatibility
-mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1"]
+mujoco = ["mujoco >=2.3.6", "imageio >=2.14.1", "packaging >=23.0"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]  # kept for backward compatibility
 jax = ["jax >=0.4.16", "jaxlib >=0.4.16", "flax >=0.5.0"]
@@ -62,8 +62,9 @@ all = [
     "mujoco-py >=2.1,<2.2",
     "cython <3",
     # mujoco
-    "mujoco >=2.1.5",
+    "mujoco >=2.3.6",
     "imageio >=2.14.1",
+    "packaging >=23.0",
     # toy-text
     "pygame >=2.1.3",
     # jax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
 mujoco-py = ["mujoco-py >=2.1,<2.2", "cython<3"]
 mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]  # kept for backward compatibility
-mujoco = ["mujoco >=2.3.6", "imageio >=2.14.1", "packaging >=23.0"]
+mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1", "packaging >=23.0"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]  # kept for backward compatibility
 jax = ["jax >=0.4.16", "jaxlib >=0.4.16", "flax >=0.5.0"]
@@ -62,7 +62,7 @@ all = [
     "mujoco-py >=2.1,<2.2",
     "cython <3",
     # mujoco
-    "mujoco >=2.3.6",
+    "mujoco >=2.1.5",
     "imageio >=2.14.1",
     "packaging >=23.0",
     # toy-text

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -120,13 +120,11 @@ def test_max_geom_attribute(
 @pytest.mark.parametrize(
     "render_mode", ["human", "rgb_array", "depth_array", "rgbd_tuple"]
 )
-def test_add_markers(
-    model: mujoco.MjModel, data: mujoco.MjData, render_mode: str, max_geom: int
-):
+def test_add_markers(model: mujoco.MjModel, data: mujoco.MjData, render_mode: str):
     """Test that the add_markers function works correctly."""
     # initialize renderer
     renderer = ExposedViewerRenderer(
-        model, data, width=DEFAULT_SIZE, height=DEFAULT_SIZE, max_geom=max_geom
+        model, data, width=DEFAULT_SIZE, height=DEFAULT_SIZE, max_geom=10
     )
     # initialize viewer via render
     viewer = renderer.get_viewer(render_mode)
@@ -135,6 +133,8 @@ def test_add_markers(
         size=np.array([1, 1, 1]),
         rgba=np.array([1, 0, 0, 1]),
     )
+    args = tuple() if render_mode == "human" else (render_mode,)
+    viewer.render(*args)  # We need to render to trigger the marker addition in MuJoCo
     # close viewer after usage
     viewer.close()
 

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -120,6 +120,28 @@ def test_max_geom_attribute(
 @pytest.mark.parametrize(
     "render_mode", ["human", "rgb_array", "depth_array", "rgbd_tuple"]
 )
+def test_add_markers(
+    model: mujoco.MjModel, data: mujoco.MjData, render_mode: str, max_geom: int
+):
+    """Test that the add_markers function works correctly."""
+    # initialize renderer
+    renderer = ExposedViewerRenderer(
+        model, data, width=DEFAULT_SIZE, height=DEFAULT_SIZE, max_geom=max_geom
+    )
+    # initialize viewer via render
+    viewer = renderer.get_viewer(render_mode)
+    viewer.add_marker(
+        pos=np.array([0, 0, 0]),
+        size=np.array([1, 1, 1]),
+        rgba=np.array([1, 0, 0, 1]),
+    )
+    # close viewer after usage
+    viewer.close()
+
+
+@pytest.mark.parametrize(
+    "render_mode", ["human", "rgb_array", "depth_array", "rgbd_tuple"]
+)
 def test_camera_id(render_mode: str):
     """Assert that the camera_id parameter works correctly."""
     env_a = gymnasium.make("Ant-v5", camera_id=0, render_mode=render_mode).unwrapped


### PR DESCRIPTION
# Description

This PR fixes the `add_markers` function for mujoco's `BaseRender`. The API had a breaking change in between 3.1.x and 3.2. We now check the mujoco version on import and set a feature flag that switches between legacy behaviour and new (standard) behaviour.

Fixes #1326

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies
This fix adds `packaging` as dependency. This is required to compare against all possible versions that comply with [PEP 440](https://peps.python.org/pep-0440/).

>**Note:** It also bumps the required mujoco version to 2.3.6. Prior versions fail all unit tests because gymnasium uses type annotations that did not exist prior to 2.3.6.

>**WARNING:** The test suite still fails for `tests/envs/mujoco/test_mujoco_v5.py::test_model_object_count[v5]` with mujoco<3.1.4. To get all tests to pass, the mujoco version would have to be raised to at least 3.1.4. Since this restriction is more severe then the slight version bump to 2.3.6 and only concerns a single test case, it is omitted in this PR. **_These errors are unrelated to the current PR and exist in the current version._**

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
