### PR TITLE
Update toytext.CliffWalking env version in envs registry

### DIFF
--- a/gymnasium/envs/__init__.py
+++ b/gymnasium/envs/__init__.py
@@ -147,8 +147,14 @@ register(
 )
 
 register(
-    id="CliffWalking-v0",
+    id="CliffWalking-v1",
     entry_point="gymnasium.envs.toy_text.cliffwalking:CliffWalkingEnv",
+)
+
+register(
+    id="CliffWalkingSlippery-v1",
+    entry_point="gymnasium.envs.toy_text.cliffwalking:CliffWalkingEnv",
+    kwargs={"is_slippery": True},
 )
 
 register(


### PR DESCRIPTION
# Description

Update toytext.CliffWalking env version in envs registry,
Motivation:
the example included in the documentation is not working.
https://gymnasium.farama.org/environments/toy_text/cliff_walking/
```python
    import gymnasium as gym
    gym.make('CliffWalking-v1')
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)