### PR TITLE
Fix reinforce tutorial

### DIFF
--- a/docs/tutorials/training_agents/reinforce_invpend_gym_v26.py
+++ b/docs/tutorials/training_agents/reinforce_invpend_gym_v26.py
@@ -298,8 +298,7 @@ for seed in [1, 2, 3, 5, 8]:  # Fibonacci seeds
 # ~~~~~~~~~~~~~~~~~~~
 #
 
-rewards_to_plot = [[reward[0] for reward in rewards] for rewards in rewards_over_seeds]
-df1 = pd.DataFrame(rewards_to_plot).melt()
+df1 = pd.DataFrame(rewards_over_seeds).melt()
 df1.rename(columns={"variable": "episodes", "value": "reward"}, inplace=True)
 sns.set(style="darkgrid", context="talk", palette="rainbow")
 sns.lineplot(x="episodes", y="reward", data=df1).set(

--- a/docs/tutorials/training_agents/reinforce_invpend_gym_v26.py
+++ b/docs/tutorials/training_agents/reinforce_invpend_gym_v26.py
@@ -202,14 +202,11 @@ class REINFORCE:
 
         deltas = torch.tensor(gs)
 
-        log_probs = torch.stack(self.probs)
-
-        # Calculate the mean of log probabilities for all actions in the episode
-        log_prob_mean = log_probs.mean()
+        log_probs = torch.stack(self.probs).squeeze()
 
         # Update the loss with the mean log probability and deltas
         # Now, we compute the correct total loss by taking the sum of the element-wise products.
-        loss = -torch.sum(log_prob_mean * deltas)
+        loss = -torch.sum(log_probs * deltas)
 
         # Update the policy network
         self.optimizer.zero_grad()


### PR DESCRIPTION
# Description

This PR fixes two issues in the REINFORCE tutorial:

- **Fixes indexing error**: Previously, the rewards list was being rearranged incorrectly, causing issues in the learning process. This is now corrected.  
- **Fixes REINFORCE implementation**: The probability averaging was removed, ensuring a more accurate policy gradient update.  

See the **before/after** comparison below.  

Fixes #1335 #1336  

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) (BUG IN TUTORIAL DOCS)

### Screenshots

| Before | After |
| ------ | ----- |
| ![not working](https://github.com/user-attachments/assets/48af446f-869c-4845-b037-a3b0c30987fc)| ![working](https://github.com/user-attachments/assets/f5ee89ba-1737-4a3a-80e0-b6a02e8e3487)|
