### PR TITLE
fix documentation of car-racing continuous argument

### DIFF
--- a/gymnasium/envs/box2d/car_racing.py
+++ b/gymnasium/envs/box2d/car_racing.py
@@ -165,8 +165,8 @@ class CarRacing(gym.Env, EzPickle):
     * `domain_randomize=False` enables the domain randomized variant of the environment.
      In this scenario, the background and track colours are different on every reset.
 
-    * `continuous=False` converts the environment to use discrete action space.
-     The discrete action space has 5 actions: [do nothing, left, right, gas, brake].
+    * `continuous=True` specifies if the agent has continuous (true) or discrete (false) actions.
+     See action space section for a description of each.
 
     ## Reset Arguments
 

--- a/gymnasium/envs/box2d/car_racing.py
+++ b/gymnasium/envs/box2d/car_racing.py
@@ -165,7 +165,7 @@ class CarRacing(gym.Env, EzPickle):
     * `domain_randomize=False` enables the domain randomized variant of the environment.
      In this scenario, the background and track colours are different on every reset.
 
-    * `continuous=True` converts the environment to use discrete action space.
+    * `continuous=False` converts the environment to use discrete action space.
      The discrete action space has 5 actions: [do nothing, left, right, gas, brake].
 
     ## Reset Arguments


### PR DESCRIPTION
# Description

The description of the continuous argument in the car_racing environment states:
```
`continuous=True` converts the environment to use discrete action space.
```
However, this is incorrect. Setting `continuous=True` actually enables a continuous action space, not a discrete one. This PR corrects the misleading comment.


## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
