### PR TITLE
Fixed misspelling of 'Quadruped' within MuJoCo documentation.

### DIFF
--- a/docs/environments/mujoco.md
+++ b/docs/environments/mujoco.md
@@ -56,7 +56,7 @@ There are eleven MuJoCo environments (in roughly increasing complexity):
 | Walker2d               | 2d biped with the goal of walking                                    |
 | **Swimmers**           |                                                                      |
 | Swimmer                | 3d robot with the goal of swimming                                   |
-| **Quarduped**          |                                                                      |
+| **Quadruped**          |                                                                      |
 | Ant                    | 3d quadruped with the goal of running                                |
 | **Humanoid Bipeds**    |                                                                      |
 | Humanoid               | 3d humanoid with the goal of running                                 |


### PR DESCRIPTION
# Description

Quadruped was misspelled as 'Quarduped' within the MuJoCo documentation. This change just swaps two letters. No change in functionality.

## Type of change

- [x] Documentation only change (no code changed)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas No
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
