### PR TITLE
Add CI for testing tutorial implementations

### DIFF
--- a/.github/workflows/run-tutorial.yml
+++ b/.github/workflows/run-tutorial.yml
@@ -1,0 +1,191 @@
+name: Test Gymnasium Tutorials
+
+on:
+  # Run all tests when merging to main
+  push:
+    branches: [ main ]
+
+  # Run tests only for modified tutorials in PRs
+  pull_request:
+    paths:
+      - 'docs/tutorials/**/*.py'
+      - '.github/workflows/test-tutorials.yml'
+
+  # Allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  test-tutorials:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9"]
+        tutorial-group:
+          - gymnasium_basics
+          - training_agents
+
+    timeout-minutes: 30  # Set a reasonable timeout for all tests
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # Install Gymnasium and its dependencies
+        pip install -e .
+        # Install additional dependencies for tutorials
+        pip install torch torchvision tqdm matplotlib seaborn pandas pygame
+        # Install MuJoCo dependencies if needed
+        sudo apt-get update
+        sudo apt-get install -y patchelf libosmesa6-dev libgl1-mesa-glx libglfw3 libglew-dev
+
+    - name: Install MuJoCo (for MuJoCo tutorials)
+      if: matrix.tutorial-group == 'training_agents'
+      run: |
+        pip install mujoco gymnasium[mujoco]
+
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v41
+      with:
+        files: docs/tutorials/**/*.py
+      if: github.event_name == 'pull_request'
+
+    - name: Test tutorials (${{ matrix.tutorial-group }})
+      id: run-tutorials
+      run: |
+        echo "::group::Running tutorials in ${{ matrix.tutorial-group }}"
+        mkdir -p test-results
+
+        # Determine which tutorials to test
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "PR detected - testing only modified tutorials"
+          # Get the list of modified tutorial files in this group
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            if [[ $file == docs/tutorials/${{ matrix.tutorial-group }}/* && $file == *.py ]]; then
+              echo $file >> tutorial_files.txt
+            fi
+          done
+
+          # If no tutorials in this group were modified, skip this job
+          if [ ! -f tutorial_files.txt ] || [ ! -s tutorial_files.txt ]; then
+            echo "No tutorials modified in ${{ matrix.tutorial-group }} - skipping tests"
+            echo "total=0" >> $GITHUB_OUTPUT
+            echo "passed=0" >> $GITHUB_OUTPUT
+            echo "failed=0" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+        else
+          echo "Main branch or manual run - testing all tutorials"
+          # Find all Python files in the tutorial group
+          find docs/tutorials/${{ matrix.tutorial-group }} -name "*.py" -type f | sort > tutorial_files.txt
+        fi
+
+        # Initialize counters
+        total=0
+        passed=0
+        failed=0
+
+        # Run each tutorial with timeout
+        while IFS= read -r tutorial; do
+          echo "Running tutorial: $tutorial"
+          total=$((total+1))
+
+          # Set max time based on complexity (can be adjusted)
+          max_time=300  # 5 minutes default
+
+          # Create a marker to skip rendering for headless environment
+          sed -i 's/render_mode="human"/render_mode="rgb_array"/g' "$tutorial" || true
+
+          # Run the tutorial with timeout and record results
+          start_time=$(date +%s)
+          timeout $max_time python "$tutorial" > "test-results/$(basename "$tutorial").log" 2>&1
+          exit_code=$?
+          end_time=$(date +%s)
+          execution_time=$((end_time-start_time))
+
+          if [ $exit_code -eq 0 ]; then
+            echo "✅ Passed: $tutorial (${execution_time}s)"
+            passed=$((passed+1))
+            echo "$tutorial,pass,$execution_time" >> test-results/summary.csv
+          elif [ $exit_code -eq 124 ]; then
+            echo "⚠️ Timeout: $tutorial (exceeded ${max_time}s)"
+            failed=$((failed+1))
+            echo "$tutorial,timeout,$max_time" >> test-results/summary.csv
+          else
+            echo "❌ Failed: $tutorial (${execution_time}s)"
+            failed=$((failed+1))
+            echo "$tutorial,fail,$execution_time" >> test-results/summary.csv
+          fi
+
+          echo "----------------------------------------"
+        done < tutorial_files.txt
+
+        echo "::endgroup::"
+
+        # Set output variables
+        echo "total=$total" >> $GITHUB_OUTPUT
+        echo "passed=$passed" >> $GITHUB_OUTPUT
+        echo "failed=$failed" >> $GITHUB_OUTPUT
+
+        # Generate summary
+        echo "### Tutorial Test Results for ${{ matrix.tutorial-group }} 📊" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "**Mode:** Testing only modified tutorials in PR #${{ github.event.pull_request.number }}" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "**Mode:** Testing all tutorials (main branch or manual run)" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "" >> $GITHUB_STEP_SUMMARY
+
+        echo "| Metric | Count |" >> $GITHUB_STEP_SUMMARY
+        echo "| ------ | ----- |" >> $GITHUB_STEP_SUMMARY
+        echo "| ✅ Passed | $passed |" >> $GITHUB_STEP_SUMMARY
+        echo "| ❌ Failed | $failed |" >> $GITHUB_STEP_SUMMARY
+        echo "| 📚 Total | $total |" >> $GITHUB_STEP_SUMMARY
+
+        # List all tested tutorials
+        if [ $total -gt 0 ]; then
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Tested Tutorials 📝" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          while IFS=, read -r file status time; do
+            if [ "$status" == "pass" ]; then
+              echo "- ✅ $file (${time}s)" >> $GITHUB_STEP_SUMMARY
+            elif [ "$status" == "timeout" ]; then
+              echo "- ⚠️ $file (timeout after ${time}s)" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "- ❌ $file (failed after ${time}s)" >> $GITHUB_STEP_SUMMARY
+            fi
+          done < test-results/summary.csv
+        fi
+
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: tutorial-test-results-${{ matrix.tutorial-group }}
+        path: test-results/
+        retention-days: 7
+
+    - name: Check test results
+      if: always()
+      run: |
+        if [ "${{ steps.run-tutorials.outputs.total }}" -eq 0 ]; then
+          echo "::notice::No tutorials were tested in this group."
+        elif [ "${{ steps.run-tutorials.outputs.failed }}" -gt 0 ]; then
+          echo "::error::${{ steps.run-tutorials.outputs.failed }} out of ${{ steps.run-tutorials.outputs.total }} tutorials failed."
+          exit 1
+        else
+          echo "::notice::All ${{ steps.run-tutorials.outputs.total }} tutorials passed."
+        fi


### PR DESCRIPTION
# Description

For the main project we have a large amount of testing in `tests` that will run for every PR to ensure that bugs are catch. 
However, for the documentation, we don't have such automated testing. 

This PR addes testing for all the tutorials to ensure that they still work as expected. 
These tests are only run in PRs on tutorials that are modified (to ensure quick responses) and for all tutorials once merged to check if any unintended changes were made.
