### PR TITLE
use  `mujoco-py-cython3` to retain compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,9 @@ atari = ["ale_py >=0.9"]
 box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
-mujoco-py = ["mujoco-py >=2.1,<2.2", "cython<3"]
-mujoco_py = ["mujoco-py >=2.1,<2.2", "cython<3"]  # kept for backward compatibility
+mujoco-py = ["mujoco-py-cython3"]
+mujoco_py = ["mujoco-py-cython3"]  # kept for backward compatibility
+mujoco-py_original = ["mujoco-py >=2.1,<2.2", "cython<3"]
 mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1", "packaging >=23.0"]
 toy-text = ["pygame >=2.1.3"]
 toy_text = ["pygame >=2.1.3"]  # kept for backward compatibility
@@ -59,8 +60,7 @@ all = [
     # classic-control
     "pygame >=2.1.3",
     # mujoco-py
-    "mujoco-py >=2.1,<2.2",
-    "cython <3",
+    "mujoco-py-cython3"
     # mujoco
     "mujoco >=2.1.5",
     "imageio >=2.14.1",


### PR DESCRIPTION
# Description

https://github.com/Kallinteris-Andreas/mujoco-py is a soft fork `mujoco-py` that simply changes the build flags

if this gets merged or a similar solution is found, we can delay https://github.com/Farama-Foundation/Gymnasium/issues/993 for 1-2 years

this will also be merged in `gymnasium-robotics`

Alternative: simply remove `mujoco-py` https://github.com/Farama-Foundation/Gymnasium/issues/993 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

