### PR TITLE
Fix jax 0.6.0 regression in jax_to_numpy

### DIFF
--- a/gymnasium/wrappers/jax_to_numpy.py
+++ b/gymnasium/wrappers/jax_to_numpy.py
@@ -104,7 +104,13 @@ def _iterable_jax_to_numpy(
     value: Iterable[np.ndarray | Any],
 ) -> Iterable[jax.Array | Any]:
     """Converts an Iterable from Numpy arrays to an iterable of Jax Array."""
-    if hasattr(value, "_make"):
+    if isinstance(value, jax.Array):
+        # Since the update to jax 0.6.0, calling jax_to_numpy with a <class 'jaxlib.xla_extension.ArrayImpl'>
+        # argument wrongly dispatches to _iterable_jax_to_numpy which fails with:
+        # TypeError: (): incompatible function arguments.
+        # See: https://github.com/Farama-Foundation/Gymnasium/issues/1360
+        return _devicearray_jax_to_numpy(value)
+    elif hasattr(value, "_make"):
         # namedtuple - underline used to prevent potential name conflicts
         # noinspection PyProtectedMember
         return type(value)._make(jax_to_numpy(v) for v in value)

--- a/gymnasium/wrappers/jax_to_torch.py
+++ b/gymnasium/wrappers/jax_to_torch.py
@@ -124,7 +124,13 @@ def _jax_iterable_to_torch(
     value: Iterable[Any], device: Device | None = None
 ) -> Iterable[Any]:
     """Converts an Iterable from Jax Array to an iterable of PyTorch Tensors."""
-    if hasattr(value, "_make"):
+    if isinstance(value, jax.Array):
+        # Since the update to jax 0.6.0, calling jax_to_torch with a <class 'jaxlib.xla_extension.ArrayImpl'>
+        # argument wrongly dispatches to _iterable_jax_to_torch which fails with:
+        # TypeError: (): incompatible function arguments.
+        # See: https://github.com/Farama-Foundation/Gymnasium/issues/1360
+        return _devicearray_jax_to_torch(value)
+    elif hasattr(value, "_make"):
         # namedtuple - underline used to prevent potential name conflicts
         # noinspection PyProtectedMember
         return type(value)._make(jax_to_torch(v, device) for v in value)


### PR DESCRIPTION
# Description

The recently release `jax` 0.6.0 (https://github.com/jax-ml/jax/releases/tag/jax-v0.6.0), impacts the dispatch behavior of `jax_to_numpy`.
When called with an argument of type `<class 'jaxlib.xla_extension.ArrayImpl'>`, the `_iterable_jax_to_numpy` is called.
It crashes with:
```
>           return type(value)(jax_to_numpy(v) for v in value)
E           TypeError: (): incompatible function arguments. The following argument types are supported:
E               1. (self, aval: object, sharding: object, arrays: list, committed: bool, _skip_checks: bool = False) -> None
E
E           Invoked with types: jaxlib.xla_extension.ArrayImpl, generator

gymnasium/wrappers/jax_to_numpy.py:112: TypeError
```

Before, the `_device_array_jax_to_numpy` was called instead.
This patch adds a special case for when `jax.Array` is passed to `_iterable_jax_to_numpy` and fixes the error.

Fixes https://github.com/Farama-Foundation/Gymnasium/issues/1360

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
