### PR TITLE
Fix CarRacing discrete action docstring

### DIFF
--- a/gymnasium/envs/box2d/car_racing.py
+++ b/gymnasium/envs/box2d/car_racing.py
@@ -129,8 +129,8 @@ class CarRacing(gym.Env, EzPickle):
 
     If discrete there are 5 actions:
     - 0: do nothing
-    - 1: steer left
-    - 2: steer right
+    - 1: steer right
+    - 2: steer left
     - 3: gas
     - 4: brake
 
@@ -258,7 +258,7 @@ class CarRacing(gym.Env, EzPickle):
             )  # steer, gas, brake
         else:
             self.action_space = spaces.Discrete(5)
-            # do nothing, left, right, gas, brake
+            # do nothing, right, left, gas, brake
 
         self.observation_space = spaces.Box(
             low=0, high=255, shape=(STATE_H, STATE_W, 3), dtype=np.uint8


### PR DESCRIPTION
# Description

This PR modifies the docstring for the discrete action descriptions (steer right, steer left) and also updates an in-line comment for consistency in `gymnasium/envs/box2d/car_racing.py`.

Fixes #1369 

## Type of change
- [x] Documentation only change (no code changed)

# Checklist:
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes