### PR TITLE
Fixed Typo on speed_up_env.md

### DIFF
--- a/docs/introduction/speed_up_env.md
+++ b/docs/introduction/speed_up_env.md
@@ -27,6 +27,6 @@ For code written in PyTorch and Jax, they provide the ability to `jit` (just in 
 
 ## Algorithmic heuristics
 
-Academic researchers are consistently explore new optimizations to improve agent performance and reduce the number of samples required to train an agent.
+Academic researchers are consistently exploring new optimizations to improve agent performance and reduce the number of samples required to train an agent.
 In particular, sample efficient reinforcement learning is a specialist sub-field of reinforcement learning that explores optimizations for training algorithms and environment heuristics that reduce the number of agent observation need for an agent to maximise performance.
 As the field is consistently improving, we refer readers to find to survey papers and the latest research to know what the most efficient algorithmic improves that exist currently.


### PR DESCRIPTION
# Description

Fixed Typo on speed_up_env.md. The typo was changed from "Academic Researchers are consistently explore" to "Academic Researchers are consistently exploring"

Fixes #1374 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)

### Screenshots
<img width="1163" alt="image" src="https://github.com/user-attachments/assets/3bb497b3-a925-45fc-b686-a71941fe0b7f" />

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


