### PR TITLE
Fix broken links on the Basic Usage page

### DIFF
--- a/docs/introduction/basic_usage.md
+++ b/docs/introduction/basic_usage.md
@@ -111,7 +111,7 @@ Importantly, :attr:`Env.action_space` and :attr:`Env.observation_space` are inst
 - :class:`Graph`: describes a mathematical graph (network) with interlinking nodes and edges.
 - :class:`Sequence`: describes a variable length of simpler space elements.
 
-For example usage of spaces, see their `documentation <../api/spaces>`_ along with `utility functions <../api/spaces/utils>`_. There are a couple of more niche spaces :class:`Graph`, :class:`Sequence` and :class:`Text`.
+For example usage of spaces, see their `documentation </api/spaces>`_ along with `utility functions </api/spaces/utils>`_. There are a couple of more niche spaces :class:`Graph`, :class:`Sequence` and :class:`Text`.
 ```
 
 ## Modifying the environment


### PR DESCRIPTION
# Description

Fixed broken links on the Basic Usage page that were previously leading to 404 errors.

## Type of change

- [x] Documentation only change (no code changed)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
