### PR TITLE
Reenable `reportInvalidTypeForm` typing rule

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_py_env.py
+++ b/gymnasium/envs/mujoco/mujoco_py_env.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 from os import path
 from typing import Any, Dict, Optional, Tuple, Union
 

--- a/gymnasium/spaces/space.py
+++ b/gymnasium/spaces/space.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Generic, Iterable, Mapping, Sequence, TypeVar
+from typing import Any, Generic, Iterable, Mapping, Sequence, TypeAlias, TypeVar
 
 import numpy as np
 import numpy.typing as npt
@@ -13,7 +13,7 @@ from gymnasium.utils import seeding
 T_cov = TypeVar("T_cov", covariant=True)
 
 
-MaskNDArray = npt.NDArray[np.int8]
+MaskNDArray: TypeAlias = npt.NDArray[np.int8]
 
 
 class Space(Generic[T_cov]):

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import operator as op
 import typing
 from functools import reduce, singledispatch
-from typing import Any, TypeVar, Union, cast
+from typing import Any, TypeVar, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -329,7 +329,7 @@ def _unflatten_multidiscrete(
             f"{x} is not a concatenation of one-hot encoded vectors and can not be unflattened to space {space}. "
             "Not all valid samples in a flattened space can be unflattened."
         )
-    (indices,) = cast(type(offsets[:-1]), nonzero)
+    (indices,) = nonzero
     return (
         np.asarray(indices - offsets[:-1], dtype=space.dtype).reshape(space.shape)
         + space.start

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -323,13 +323,12 @@ def _unflatten_multidiscrete(
 ) -> NDArray[np.integer[Any]]:
     offsets = np.zeros((space.nvec.size + 1,), dtype=space.dtype)
     offsets[1:] = np.cumsum(space.nvec.flatten())
-    nonzero = np.nonzero(x)
-    if len(nonzero[0]) == 0:
+    (indices,) = np.nonzero(x)
+    if len(indices) == 0:
         raise ValueError(
             f"{x} is not a concatenation of one-hot encoded vectors and can not be unflattened to space {space}. "
             "Not all valid samples in a flattened space can be unflattened."
         )
-    (indices,) = nonzero
     return (
         np.asarray(indices - offsets[:-1], dtype=space.dtype).reshape(space.shape)
         + space.start

--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -6,6 +6,7 @@ from collections import deque
 from typing import Callable, List
 
 import numpy as np
+from matplotlib.axes import Axes
 
 import gymnasium as gym
 from gymnasium import Env, logger
@@ -369,7 +370,7 @@ class PlayPlot:
         for axis, name in zip(self.ax, plot_names):
             axis.set_title(name)
         self.t = 0
-        self.cur_plot: list[plt.Axes | None] = [None for _ in range(num_plots)]
+        self.cur_plot: list[Axes | None] = [None for _ in range(num_plots)]
         self.data = [deque(maxlen=horizon_timesteps) for _ in range(num_plots)]
 
     def callback(

--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 from collections import deque
-from typing import Callable, List
+from typing import TYPE_CHECKING, Callable, List
 
 import numpy as np
-from matplotlib.axes import Axes
 
 import gymnasium as gym
 from gymnasium import Env, logger
 from gymnasium.core import ActType, ObsType
 from gymnasium.error import DependencyNotInstalled
+
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
 
 
 try:

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from enum import Enum
 from multiprocessing import Queue
 from multiprocessing.connection import Connection
+from multiprocessing.sharedctypes import SynchronizedArray
 from typing import Any, Callable, Sequence
 
 import numpy as np
@@ -721,7 +722,7 @@ def _async_worker(
     env_fn: callable,
     pipe: Connection,
     parent_pipe: Connection,
-    shared_memory: multiprocessing.Array | dict[str, Any] | tuple[Any, ...],
+    shared_memory: SynchronizedArray | dict[str, Any] | tuple[Any, ...],
     error_queue: Queue,
     autoreset_mode: AutoresetMode,
 ):

--- a/gymnasium/vector/utils/shared_memory.py
+++ b/gymnasium/vector/utils/shared_memory.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import multiprocessing as mp
 from ctypes import c_bool
 from functools import singledispatch
+from multiprocessing.sharedctypes import SynchronizedArray
 from typing import Any
 
 import numpy as np
@@ -32,7 +33,7 @@ __all__ = ["create_shared_memory", "read_from_shared_memory", "write_to_shared_m
 @singledispatch
 def create_shared_memory(
     space: Space[Any], n: int = 1, ctx=mp
-) -> dict[str, Any] | tuple[Any, ...] | mp.Array:
+) -> dict[str, Any] | tuple[Any, ...] | SynchronizedArray:
     """Create a shared memory object, to be shared across processes.
 
     This eventually contains the observations from the vectorized environment.
@@ -109,7 +110,7 @@ def _create_dynamic_shared_memory(space: Graph | Sequence, n: int = 1, ctx=mp):
 
 @singledispatch
 def read_from_shared_memory(
-    space: Space, shared_memory: dict | tuple | mp.Array, n: int = 1
+    space: Space, shared_memory: dict | tuple | SynchronizedArray, n: int = 1
 ) -> dict[str, Any] | tuple[Any, ...] | np.ndarray:
     """Read the batch of observations from shared memory as a numpy array.
 
@@ -209,7 +210,7 @@ def write_to_shared_memory(
     space: Space,
     index: int,
     value: np.ndarray,
-    shared_memory: dict[str, Any] | tuple[Any, ...] | mp.Array,
+    shared_memory: dict[str, Any] | tuple[Any, ...] | SynchronizedArray,
 ):
     """Write the observation of a single environment into shared memory.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,6 @@ reportIndexIssue = "none"           # TODO fix one by one
 reportReturnType = "none"           # TODO fix one by one
 reportCallIssue = "none"            # TODO fix one by one
 reportOperatorIssue = "none"        # TODO fix one by one
-reportInvalidTypeForm = "none"      # TODO fix one by one
 reportOptionalMemberAccess = "none" # TODO fix one by one
 reportAssignmentType = "none"       # TODO fix one by one
 


### PR DESCRIPTION
# Description

Reenables the `reportInvalidTypeForm` pyright rule.

Since `mujoco_py_env.py` is no longer being maintained, I chose to silence all typing errors from the file instead of fixing the type annotation (on L322).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] ~I have commented my code, particularly in hard-to-understand areas~
- [x] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [x] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
