### PR TITLE
enum? not in discrete action space unless first converted to 'int' or…

### DIFF
--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -263,7 +263,7 @@ def play(
         else:
             assert isinstance(key, (str, int))
 
-        assert action in env.action_space
+        assert int(action) in env.action_space
 
     key_code_to_action = {}
     for key_combination, action in keys_to_action.items():


### PR DESCRIPTION
enum? not in discrete action space unless first converted to 'int' or… used with accessor .value

# Description

I'm trying to play (utils.play) "ALE/MontezumaRevenge-v5"

I got an assertion error: "assert action in env.action_space" 

Apparently it was Action.NOPE or so, that is indeed 0 (if you look at its value), but is not in 0..17

Fixes # (issue)

## Type of change

casting action to int

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
