### PR TITLE
Add compatibility note for Python versions in usage documentation

### DIFF
--- a/docs/introduction/basic_usage.md
+++ b/docs/introduction/basic_usage.md
@@ -3,8 +3,9 @@ layout: "contents"
 title: Basic Usage
 firstpage:
 ---
+<!-- See docs/tutorials/run_python310_example.py for an executable version of this code. -->
 
-> **Note:** The code and tools used in this page are compatible with **Python 3.10+**. Earlier versions (e.g., 3.8, 3.9) are not supported and may fail because some required libraries and features are only available in Python 3.10 or newer.
+> **Note:** The code and tools used in this page require **Python 3.10+** and are only guaranteed to work with the latest version of Gymnasium. Earlier Python versions or older Gymnasium releases may not be compatible.
 
 # Basic Usage
 

--- a/docs/introduction/basic_usage.md
+++ b/docs/introduction/basic_usage.md
@@ -4,6 +4,8 @@ title: Basic Usage
 firstpage:
 ---
 
+> **Note:** The code and tools used in this page are compatible with **Python 3.10+**. Earlier versions (e.g., 3.8, 3.9) are not supported and may fail because some required libraries and features are only available in Python 3.10 or newer.
+
 # Basic Usage
 
 ```{eval-rst}

--- a/docs/introduction/create_custom_env.md
+++ b/docs/introduction/create_custom_env.md
@@ -3,6 +3,8 @@ layout: "contents"
 title: Create custom env
 ---
 
+> **Note:** The code and tools used in this page are compatible with **Python 3.10+**. Earlier versions (e.g., 3.8, 3.9) are not supported and may fail.
+
 # Create a Custom Environment
 
 This page provides a short outline of how to create custom environments with Gymnasium, for a more [complete tutorial](../tutorials/gymnasium_basics/environment_creation) with rendering, please read [basic usage](basic_usage)  before reading this page.

--- a/docs/introduction/create_custom_env.md
+++ b/docs/introduction/create_custom_env.md
@@ -20,7 +20,6 @@ while not done:
     done = terminated or truncated
 ```
 
-Fo
 
 # Create a Custom Environment
 

--- a/docs/introduction/create_custom_env.md
+++ b/docs/introduction/create_custom_env.md
@@ -2,10 +2,28 @@
 layout: "contents"
 title: Create custom env
 ---
+<!-- See docs/tutorials/run_python310_example.py for an executable version of this code. -->
+> **Note:** The code and tools used in this page require **Python 3.10+** and are only guaranteed to work with the latest version of Gymnasium. Earlier Python versions or older Gymnasium releases may not be compatible.
 
-> **Note:** The code and tools used in this page are compatible with **Python 3.10+**. Earlier versions (e.g., 3.8, 3.9) are not supported and may fail.
+
+## Testing Your Custom Environment
+
+To ensure your environment works as expected, you can run a simple test loop:
+
+```python
+env = GridWorldEnv(size=5)
+obs, info = env.reset()
+done = False
+while not done:
+    action = env.action_space.sample()
+    obs, reward, terminated, truncated, info = env.step(action)
+    done = terminated or truncated
+```
+
+Fo
 
 # Create a Custom Environment
+
 
 This page provides a short outline of how to create custom environments with Gymnasium, for a more [complete tutorial](../tutorials/gymnasium_basics/environment_creation) with rendering, please read [basic usage](basic_usage)  before reading this page.
 

--- a/docs/tutorials/run_python310_example.py
+++ b/docs/tutorials/run_python310_example.py
@@ -4,6 +4,7 @@ Demonstrates that Gymnasium code examples require Python 3.10+ and the latest Gy
 
 import gymnasium as gym
 
+
 env = gym.make("CartPole-v1")
 observation, info = env.reset(seed=123)
 
@@ -14,4 +15,3 @@ while not done:
     done = terminated or truncated
 
 env.close()
-

--- a/docs/tutorials/run_python310_example.py
+++ b/docs/tutorials/run_python310_example.py
@@ -1,0 +1,17 @@
+"""
+Demonstrates that Gymnasium code examples require Python 3.10+ and the latest Gymnasium version.
+"""
+
+import gymnasium as gym
+
+env = gym.make("CartPole-v1")
+observation, info = env.reset(seed=123)
+
+done = False
+while not done:
+    action = env.action_space.sample()
+    observation, reward, terminated, truncated, info = env.step(action)
+    done = terminated or truncated
+
+env.close()
+


### PR DESCRIPTION
#Changes Introduced
1. docs/introduction/basic_usage.md

    =>  Added a note block indicating Python 3.10+ is required.

2. docs/introduction/create_custom_env.md

    => Added the same Python compatibility note for consistency.