### PR TITLE
Don't override SDL's audio driver on Linux

### DIFF
--- a/gymnasium/__init__.py
+++ b/gymnasium/__init__.py
@@ -22,16 +22,8 @@ from gymnasium.envs.registration import (
 )
 from gymnasium import spaces, utils, vector, wrappers, error, logger, experimental
 
-# Initializing pygame initializes audio connections through SDL. SDL uses alsa by default on all Linux systems
-# SDL connecting to alsa frequently create these giant lists of warnings every time you import an environment using
-#   pygame
-# DSP is far more benign (and should probably be the default in SDL anyways)
-
 import os
 import sys
-
-if sys.platform.startswith("linux"):
-    os.environ["SDL_AUDIODRIVER"] = "dsp"
 
 os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "hide"
 


### PR DESCRIPTION
# Description

This pull request is directly linked to the proposal of the same name, which is to stop overriding the SDL audio driver on Linux. See the proposal for more details as well as the related motivations.

Fixes #1386 (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

### Screenshots

N/A

# Checklist:

- [X] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes