### PR TITLE
Fix all warnings in tests/spaces

### DIFF
--- a/tests/utils/test_env_checker.py
+++ b/tests/utils/test_env_checker.py
@@ -32,31 +32,19 @@ CHECK_ENV_IGNORE_WARNINGS = [
 ]
 
 
-@pytest.mark.parametrize(
-    "env",
-    [
-        gym.make("CartPole-v1", disable_env_checker=True).unwrapped,
-        gym.make("MountainCar-v0", disable_env_checker=True).unwrapped,
-        GenericTestEnv(
-            observation_space=spaces.Dict(
-                a=spaces.Discrete(10), b=spaces.Box(np.zeros(2), np.ones(2))
-            )
-        ),
-        GenericTestEnv(
-            observation_space=spaces.Tuple(
-                [spaces.Discrete(10), spaces.Box(np.zeros(2), np.ones(2))]
-            )
-        ),
-        GenericTestEnv(
-            observation_space=spaces.Dict(
-                a=spaces.Tuple(
-                    [spaces.Discrete(10), spaces.Box(np.zeros(2), np.ones(2))]
-                ),
-                b=spaces.Box(np.zeros(2), np.ones(2)),
-            )
-        ),
-    ],
-)
+def _no_error_warnings_envs():
+    yield gym.make("CartPole-v1", disable_env_checker=True).unwrapped
+    yield gym.make("MountainCar-v0", disable_env_checker=True).unwrapped
+    space_a = spaces.Discrete(10)
+    space_b = spaces.Box(np.zeros(2, np.float32), np.ones(2, np.float32))
+    yield GenericTestEnv(observation_space=spaces.Dict(a=space_a, b=space_b))
+    yield GenericTestEnv(observation_space=spaces.Tuple([space_a, space_b]))
+    yield GenericTestEnv(
+        observation_space=spaces.Dict(a=spaces.Tuple([space_a, space_b]), b=space_b)
+    )
+
+
+@pytest.mark.parametrize("env", _no_error_warnings_envs())
 def test_no_error_warnings(env):
     """A full version of this test with all gymnasium envs is run in tests/envs/test_envs.py."""
     with warnings.catch_warnings(record=True) as caught_warnings:

--- a/tests/utils/test_passive_env_checker.py
+++ b/tests/utils/test_passive_env_checker.py
@@ -34,17 +34,25 @@ def _modify_space(space: spaces.Space, attribute: str, value):
         # ===== Check box observation space ====
         [
             UserWarning,
-            spaces.Box(np.zeros(5), np.zeros(5)),
+            spaces.Box(np.zeros(5, np.float32), np.zeros(5, np.float32)),
             "A Box observation space maximum and minimum values are equal.",
         ],
         [
             AssertionError,
-            _modify_space(spaces.Box(np.zeros(2), np.ones(2)), "low", np.zeros(3)),
+            _modify_space(
+                spaces.Box(np.zeros(2, np.float32), np.ones(2, np.float32)),
+                "low",
+                np.zeros(3, np.float32),
+            ),
             "The Box observation space shape and low shape have different shapes, low shape: (3,), box shape: (2,)",
         ],
         [
             AssertionError,
-            _modify_space(spaces.Box(np.zeros(2), np.ones(2)), "high", np.ones(3)),
+            _modify_space(
+                spaces.Box(np.zeros(2, np.float32), np.ones(2, np.float32)),
+                "high",
+                np.ones(3, np.float32),
+            ),
             "The Box observation space shape and high shape have have different shapes, high shape: (3,), box shape: (2,)",
         ],
         # ==== Other observation spaces (Discrete, MultiDiscrete, MultiBinary, Tuple, Dict)
@@ -105,17 +113,25 @@ def test_check_observation_space(test, space, message: str):
         # ===== Check box observation space ====
         [
             UserWarning,
-            spaces.Box(np.zeros(5), np.zeros(5)),
+            spaces.Box(np.zeros(5, np.float32), np.zeros(5, np.float32)),
             "A Box action space maximum and minimum values are equal.",
         ],
         [
             AssertionError,
-            _modify_space(spaces.Box(np.zeros(2), np.ones(2)), "low", np.zeros(3)),
+            _modify_space(
+                spaces.Box(np.zeros(2, np.float32), np.ones(2, np.float32)),
+                "low",
+                np.zeros(3, np.float32),
+            ),
             "The Box action space shape and low shape have have different shapes, low shape: (3,), box shape: (2,)",
         ],
         [
             AssertionError,
-            _modify_space(spaces.Box(np.zeros(2), np.ones(2)), "high", np.ones(3)),
+            _modify_space(
+                spaces.Box(np.zeros(2, np.float32), np.ones(2, np.float32)),
+                "high",
+                np.ones(3, np.float32),
+            ),
             "The Box action space shape and high shape have different shapes, high shape: (3,), box shape: (2,)",
         ],
         # ==== Other observation spaces (Discrete, MultiDiscrete, MultiBinary, Tuple, Dict)
@@ -359,7 +375,12 @@ def test_passive_env_step_checker(
         with pytest.warns(
             UserWarning, match=f"^\\x1b\\[33mWARN: {re.escape(message)}\\x1b\\[0m$"
         ):
-            env_step_passive_checker(GenericTestEnv(step_func=func), 0)
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message="^\\x1b\\[33mWARN: Core environment is written in old step API *",
+                )
+                env_step_passive_checker(GenericTestEnv(step_func=func), 0)
     else:
         with warnings.catch_warnings(record=True) as caught_warnings:
             with pytest.raises(test, match=f"^{re.escape(message)}$"):
@@ -377,7 +398,7 @@ def test_passive_env_step_checker(
         ],
         [
             UserWarning,
-            GenericTestEnv(metadata={"render_modes": "Testing mode"}),
+            GenericTestEnv(metadata={"render_modes": "Testing mode", "render_fps": 1}),
             "Expects the render_modes to be a sequence (i.e. list, tuple), actual type: <class 'str'>",
         ],
         [


### PR DESCRIPTION
# Description

This PR fixes all warnings emitted in `tests/spaces`. I started working on supporting generic Array frameworks for spaces and extensively use the spaces test suite to that end. Cleaning up the existing warnings makes it easier to catch any new errors and should be useful for others. No test functionality needs to be changed.

Edit: Now also fixes all warnings that can be fixed in tests/utils.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
