### PR TITLE
Fix roundtrip test for ArrayConversion

### DIFF
--- a/tests/wrappers/test_array_conversion.py
+++ b/tests/wrappers/test_array_conversion.py
@@ -55,7 +55,8 @@ def xp_data_equivalence(data_1, data_2) -> bool:
                 xp_data_equivalence(o_1, o_2) for o_1, o_2 in zip(data_1, data_2)
             )
         elif is_array_api_obj(data_1):
-            return array_api_extra.isclose(data_1, data_2, atol=0.00001).all()
+            xp = array_namespace(data_1)
+            return xp.all(array_api_extra.isclose(data_1, data_2, atol=0.00001))
         else:
             return data_1 == data_2
     else:


### PR DESCRIPTION
# Description

The roundtrip test for `ArrayConversion` fails for `array-api-strict` if installed because of an unintentional use of `array.all()` instead of `xp.all(array)` in the test code itself. This PR fixes the test for array-api-strict.
 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes