### PR TITLE
Add deformable_gym to third party environments

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -267,7 +267,12 @@ goal-RL ([Gymnasium-Robotics](https://robotics.farama.org/)).
 
   Highly scalable and customizable Safe Reinforcement Learning library.
 
+- [deformable_gym: RL environments for grasping deformable objects](https://github.com/dfki-ric/deformable_gym)
 
+  A collection of gymnasium environments for learning to grasp 3D deformable objects built with PyBullet and Mujoco.
+
+  ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v1.0.0-blue)
+  ![GitHub stars](https://img.shields.io/github/stars/dfki-ric/deformable_gym)
 ### Telecommunication Systems environments
 *Interact and/or manage wireless and/or wired telecommunication systems.*
 - [mobile-env: Environments for coordination of wireless mobile networks](https://github.com/stefanbschneider/mobile-env)


### PR DESCRIPTION
# Description

This PR adds [deformable_gym](https://github.com/dfki-ric/deformable_gym) to the list of external third-party environments in the robotics section. 

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)

