### PR TITLE
Fix "pygame is not responding" every time rendering the pygame window  in [ Taxi ] environment

### DIFF
--- a/gymnasium/envs/toy_text/taxi.py
+++ b/gymnasium/envs/toy_text/taxi.py
@@ -574,6 +574,7 @@ class TaxiEnv(Env):
             )
 
         if mode == "human":
+            pygame.event.pump()
             pygame.display.update()
             self.clock.tick(self.metadata["render_fps"])
         elif mode == "rgb_array":


### PR DESCRIPTION
# Description

I fix the bug that occur every time a program start rendering the pygame window using Taxi environment when I learning DQN.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Demo Source Code to Test the Bug:
```py
env = gym.make("Taxi-v3", render_mode="human")

state, _ = env.reset()
terminated = False

while not terminated:
    next_state, reward, terminated, truncated, info = env.step(0)
```

## Demo Test Peview

*Sorry if the gif quality is too bad :(*

**Before Fix:** 
![Before Fix](https://github.com/user-attachments/assets/9cf88c38-a167-4759-8b43-0561ef4433af)

**After Fix:**
 ![After Fix](https://github.com/user-attachments/assets/549c9cfe-8527-4d68-9223-a19159bdf01b)