### PR TITLE
Vector RecordVideo

### DIFF
--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -183,8 +183,6 @@ class RecordVideo(
     However, you can also create recordings of fixed length (possibly spanning several episodes)
     by passing a strictly positive value for ``video_length``.
 
-    No vector version of the wrapper exists.
-
     Examples - Run the environment for 50 episodes, and save the video every 10 episodes starting from the 0th:
         >>> import os
         >>> import gymnasium as gym

--- a/gymnasium/wrappers/vector/__init__.py
+++ b/gymnasium/wrappers/vector/__init__.py
@@ -5,7 +5,7 @@ import importlib
 
 from gymnasium.wrappers.vector.common import RecordEpisodeStatistics
 from gymnasium.wrappers.vector.dict_info_to_list import DictInfoToList
-from gymnasium.wrappers.vector.rendering import HumanRendering
+from gymnasium.wrappers.vector.rendering import HumanRendering, RecordVideo
 from gymnasium.wrappers.vector.stateful_observation import NormalizeObservation
 from gymnasium.wrappers.vector.stateful_reward import NormalizeReward
 from gymnasium.wrappers.vector.vectorize_action import (
@@ -64,7 +64,7 @@ __all__ = [
     "RecordEpisodeStatistics",
     # --- Rendering ---
     # "RenderCollection",
-    # "RecordVideo",
+    "RecordVideo",
     "HumanRendering",
     # --- Conversion ---
     "ArrayConversion",

--- a/gymnasium/wrappers/vector/rendering.py
+++ b/gymnasium/wrappers/vector/rendering.py
@@ -1,13 +1,18 @@
-"""File for rendering of vector-based environments."""
+"""File for rendering and recording of vector-based environments."""
 
 from __future__ import annotations
 
+import gc
+import os
+from collections.abc import Callable
 from copy import deepcopy
-from typing import Any
+from typing import Any, Generic, SupportsFloat
 
 import numpy as np
 
-from gymnasium.core import ActType, ObsType
+import gymnasium as gym
+from gymnasium import error, logger
+from gymnasium.core import ActType, ObsType, RenderFrame
 from gymnasium.error import DependencyNotInstalled
 from gymnasium.vector import VectorEnv, VectorWrapper
 from gymnasium.vector.vector_env import ArrayType
@@ -182,3 +187,278 @@ class HumanRendering(VectorWrapper):
             pygame.display.quit()
             pygame.quit()
         super().close()
+
+
+class RecordVideo(
+    gym.vector.VectorWrapper,
+    Generic[ObsType, ActType, RenderFrame],
+    gym.utils.RecordConstructorArgs,
+):
+    """Adds support for video recording for Vector-based environments.
+
+    The class is the same as gymnasium.wrappers.rendering.RecordVideo, but
+    expects multiple frames when rendering the environment (one for each
+    environment of the VectorEnv). Frames are concatenated into one frame such
+    that its aspect ratio is as close as possible to the desired one.
+
+    Examples - Run 9 environments for 50 episodes of random length, and save the video every 10 episodes starting from the 0th:
+    >>> import os
+    >>> import numpy as np
+    >>> import gymnasium as gym
+    >>> def make_env():
+    ...     return gym.make("LunarLander-v3", render_mode="rgb_array")
+    ...
+    >>> n_envs = 9
+    >>> env = gym.vector.SyncVectorEnv([make_env for _ in range(n_envs)])
+    >>> trigger = lambda t: t % 10 == 0
+    >>> env = RecordVideo(env, video_folder="./save_videos1", aspect_ratio=(1,1), episode_trigger=trigger, disable_logger=True)
+    >>> rng_generator = np.random.default_rng(seed=42)
+    >>> n_episodes = 50
+    >>> episodes_length = rng_generator.integers(100, 200, n_episodes)
+    >>> for i in range(n_episodes):
+    ...     _ = env.reset(seed=123)
+    ...     for _ in range(episodes_length[i]):
+    ...         _ = env.step(env.action_space.sample())
+    ...
+    >>> env.close()
+    >>> len(os.listdir("./save_videos1"))
+    5
+    """
+
+    def __init__(
+        self,
+        env: gym.VectorEnv[ObsType, ActType],
+        video_folder: str,
+        aspect_ratio: tuple[int, int],
+        episode_trigger: Callable[[int], bool] | None = None,
+        step_trigger: Callable[[int], bool] | None = None,
+        video_length: int = 0,
+        name_prefix: str = "rl-video",
+        fps: int | None = None,
+        disable_logger: bool = True,
+        gc_trigger: Callable[[int], bool] | None = lambda episode: True,
+    ):
+        """Wrapper records videos of rollouts.
+
+        Args:
+            env: The environment that will be wrapped
+            video_folder (str): The folder where the recordings will be stored
+            aspect_ratio (tuple): the desired aspect ratio of the video concatenating all environments. For example, (1, 1) means an
+                aspect ratio of 1:1, while (16, 9) means 16:9.
+            episode_trigger: Function that accepts an integer and returns ``True`` iff a recording should be started at this episode
+            step_trigger: Function that accepts an integer and returns ``True`` iff a recording should be started at this step
+            video_length (int): The length of recorded episodes. If 0, entire episodes are recorded.
+                Otherwise, snippets of the specified length are captured
+            name_prefix (str): Will be prepended to the filename of the recordings
+            fps (int): The frame per second in the video. Provides a custom video fps for environment, if ``None`` then
+                the environment metadata ``render_fps`` key is used if it exists, otherwise a default value of 30 is used.
+            disable_logger (bool): Whether to disable moviepy logger or not, default it is disabled
+            gc_trigger: Function that accepts an integer and returns ``True`` iff garbage collection should be performed after this episode
+        """
+        gym.utils.RecordConstructorArgs.__init__(
+            self,
+            video_folder=video_folder,
+            episode_trigger=episode_trigger,
+            step_trigger=step_trigger,
+            video_length=video_length,
+            name_prefix=name_prefix,
+            disable_logger=disable_logger,
+        )
+        gym.vector.VectorWrapper.__init__(self, env)
+
+        if env.render_mode in {None, "human", "ansi"}:
+            raise ValueError(
+                f"Render mode is {env.render_mode}, which is incompatible with RecordVideo.",
+                "Initialize your environment with a render_mode that returns an image, such as rgb_array.",
+            )
+
+        if episode_trigger is None and step_trigger is None:
+            from gymnasium.utils.save_video import capped_cubic_video_schedule
+
+            episode_trigger = capped_cubic_video_schedule
+
+        self.episode_trigger = episode_trigger
+        self.step_trigger = step_trigger
+        self.disable_logger = disable_logger
+        self.gc_trigger = gc_trigger
+
+        self.aspect_ratio = aspect_ratio
+        self.frame_cols = None
+        self.frame_rows = None
+
+        self.video_folder = os.path.abspath(video_folder)
+        if os.path.isdir(self.video_folder):
+            logger.warn(
+                f"Overwriting existing videos at {self.video_folder} folder "
+                f"(try specifying a different `video_folder` for the `RecordVideo` wrapper if this is not desired)"
+            )
+        os.makedirs(self.video_folder, exist_ok=True)
+
+        if fps is None:
+            fps = self.metadata.get("render_fps", 30)
+        self.frames_per_sec: int = fps
+        self.name_prefix: str = name_prefix
+        self._video_name: str | None = None
+        self.video_length: int = video_length if video_length != 0 else float("inf")
+        self.recording: bool = False
+        self.recorded_frames: list[RenderFrame] = []
+        self.render_history: list[RenderFrame] = []
+
+        self.step_id = -1
+        self.episode_id = -1
+
+        try:
+            import moviepy  # noqa: F401
+        except ImportError as e:
+            raise error.DependencyNotInstalled(
+                'MoviePy is not installed, run `pip install "gymnasium[other]"`'
+            ) from e
+
+    def _get_concat_frame_shape(self, n_frames, h, w):
+        """Finds the right shape to concatenate frames from all environments into one frame."""
+        target_aspect_ratio = self.aspect_ratio[0] / self.aspect_ratio[1]
+        best_rows, best_cols = 1, n_frames
+        min_diff = np.inf
+        for rows in range(1, int(n_frames**0.5) + 1):
+            if n_frames % rows == 0:
+                cols = n_frames // rows
+                total_height = rows * h
+                total_width = cols * w
+                aspect = total_width / total_height
+                diff = abs(aspect - target_aspect_ratio)
+                if diff < min_diff:
+                    min_diff = diff
+                    best_rows, best_cols = rows, cols
+        self.frame_rows = best_rows
+        self.frame_cols = best_cols
+
+    def _concat_frames(self, frames):
+        """Concatenates a list of frames into one large frame."""
+        frames = np.array(frames)
+        n_frames, h, w, c = frames.shape
+        grid = np.zeros(
+            (self.frame_rows * h, self.frame_cols * w, c), dtype=frames.dtype
+        )
+        for idx in range(n_frames):
+            r = idx // self.frame_cols
+            c_ = idx % self.frame_cols
+            grid[r * h : (r + 1) * h, c_ * w : (c_ + 1) * w] = frames[idx]
+        return grid
+
+    def _capture_frame(self):
+        assert self.recording, "Cannot capture a frame, recording wasn't started."
+
+        frame = self.env.render()
+
+        if isinstance(frame, list):
+            if len(frame) == 0:  # render was called
+                return
+            self.render_history += frame
+            frame = frame[-1]
+
+        if isinstance(frame, tuple):
+            if self.frame_cols is None or self.frame_rows is None:
+                n_frames = len(frame)
+                h, w, c = frame[0].shape
+                self._get_concat_frame_shape(n_frames, h, w)
+
+            self.recorded_frames.append(self._concat_frames(frame))
+        else:
+            self.stop_recording()
+            logger.warn(
+                f"Recording stopped: expected type of frame returned by render to be a list, got instead {type(frame)}."
+            )
+
+    def reset(
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[ObsType, dict[str, Any]]:
+        """Reset the environment and eventually starts a new recording."""
+        obs, info = super().reset(seed=seed, options=options)
+        self.episode_id += 1
+
+        if self.recording and self.video_length == float("inf"):
+            self.stop_recording()
+
+        if self.episode_trigger and self.episode_trigger(self.episode_id):
+            self.start_recording(f"{self.name_prefix}-episode-{self.episode_id}")
+        if self.recording:
+            self._capture_frame()
+            if len(self.recorded_frames) > self.video_length:
+                self.stop_recording()
+
+        return obs, info
+
+    def step(
+        self, action: ActType
+    ) -> tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]:
+        """Steps through the environment using action, recording observations if :attr:`self.recording`."""
+        obs, rew, terminated, truncated, info = self.env.step(action)
+        self.step_id += 1
+
+        if self.step_trigger and self.step_trigger(self.step_id):
+            self.start_recording(f"{self.name_prefix}-step-{self.step_id}")
+        if self.recording:
+            self._capture_frame()
+
+            if len(self.recorded_frames) > self.video_length:
+                self.stop_recording()
+
+        return obs, rew, terminated, truncated, info
+
+    def render(self) -> RenderFrame | list[RenderFrame]:
+        """Compute the render frames as specified by render_mode attribute during initialization of the environment."""
+        render_out = super().render()
+        if self.recording and isinstance(render_out, list):
+            self.recorded_frames += render_out
+
+        if len(self.render_history) > 0:
+            tmp_history = self.render_history
+            self.render_history = []
+            return tmp_history + render_out
+        else:
+            return render_out
+
+    def close(self):
+        """Closes the wrapper then the video recorder."""
+        super().close()
+        if self.recording:
+            self.stop_recording()
+
+    def start_recording(self, video_name: str):
+        """Start a new recording. If it is already recording, stops the current recording before starting the new one."""
+        if self.recording:
+            self.stop_recording()
+
+        self.recording = True
+        self._video_name = video_name
+
+    def stop_recording(self):
+        """Stop current recording and saves the video."""
+        assert self.recording, "stop_recording was called, but no recording was started"
+
+        if len(self.recorded_frames) == 0:
+            logger.warn("Ignored saving a video as there were zero frames to save.")
+        else:
+            try:
+                from moviepy.video.io.ImageSequenceClip import ImageSequenceClip
+            except ImportError as e:
+                raise error.DependencyNotInstalled(
+                    'MoviePy is not installed, run `pip install "gymnasium[other]"`'
+                ) from e
+
+            clip = ImageSequenceClip(self.recorded_frames, fps=self.frames_per_sec)
+            moviepy_logger = None if self.disable_logger else "bar"
+            path = os.path.join(self.video_folder, f"{self._video_name}.mp4")
+            clip.write_videofile(path, logger=moviepy_logger)
+
+        self.recorded_frames = []
+        self.recording = False
+        self._video_name = None
+
+        if self.gc_trigger and self.gc_trigger(self.episode_id):
+            gc.collect()
+
+    def __del__(self):
+        """Warn the user in case last video wasn't saved."""
+        if len(self.recorded_frames) > 0:
+            logger.warn("Unable to save last video! Did you call close()?")

--- a/tests/wrappers/vector/test_record_video.py
+++ b/tests/wrappers/vector/test_record_video.py
@@ -1,0 +1,175 @@
+"""Test suite for RecordVideo wrapper."""
+
+import os
+import shutil
+
+import numpy as np
+import pytest
+
+import gymnasium as gym
+from gymnasium.wrappers.vector import RecordVideo
+
+
+def test_video_folder_and_filenames(
+    video_folder="custom_video_folder", name_prefix="video-prefix"
+):
+    def make_env():
+        return gym.make("CartPole-v1", render_mode="rgb_array")
+
+    n_envs = 10
+    env = gym.vector.SyncVectorEnv([make_env for _ in range(n_envs)])
+    env = RecordVideo(
+        env,
+        video_folder=video_folder,
+        name_prefix=name_prefix,
+        episode_trigger=lambda x: x in [1, 4],
+        step_trigger=lambda x: x in [0, 25],
+        aspect_ratio=(1, 1),
+    )
+
+    env.reset(seed=123)
+    env.action_space.seed(123)
+    for _ in range(100):
+        action = env.action_space.sample()
+        _, _, terminated, truncated, _ = env.step(action)
+        if np.any(terminated) or np.any(truncated):
+            env.reset()
+    env.close()
+
+    assert os.path.isdir(video_folder)
+    mp4_files = {file for file in os.listdir(video_folder) if file.endswith(".mp4")}
+    shutil.rmtree(video_folder)
+    assert mp4_files == {
+        "video-prefix-step-0.mp4",  # step triggers
+        "video-prefix-step-25.mp4",
+        "video-prefix-episode-1.mp4",  # episode triggers
+        "video-prefix-episode-4.mp4",
+    }
+
+
+@pytest.mark.parametrize("episodic_trigger", [None, lambda x: x in [0, 3, 5, 10, 12]])
+def test_episodic_trigger(episodic_trigger):
+    """Test RecordVideo using the default episode trigger."""
+
+    def make_env():
+        return gym.make("CartPole-v1", render_mode="rgb_array")
+
+    n_envs = 10
+    env = gym.vector.SyncVectorEnv([make_env for _ in range(n_envs)])
+    env = RecordVideo(
+        env,
+        "videos",
+        episode_trigger=episodic_trigger,
+        aspect_ratio=(1, 1),
+    )
+    env.reset()
+    episode_count = 0
+    for _ in range(199):
+        action = env.action_space.sample()
+        _, _, terminated, truncated, _ = env.step(action)
+        if np.any(terminated) or np.any(truncated):
+            env.reset()
+            episode_count += 1
+    env.close()
+
+    assert os.path.isdir("videos")
+    mp4_files = [file for file in os.listdir("videos") if file.endswith(".mp4")]
+    assert env.episode_trigger is not None
+    assert len(mp4_files) == sum(
+        env.episode_trigger(i) for i in range(episode_count + 1)
+    )
+    shutil.rmtree("videos")
+
+
+def test_step_trigger():
+    """Test RecordVideo defining step trigger function."""
+    n_envs = 10
+
+    def make_env():
+        return gym.make("CartPole-v1", render_mode="rgb_array")
+
+    env = gym.vector.SyncVectorEnv([make_env for _ in range(n_envs)])
+    env = RecordVideo(
+        env,
+        "videos",
+        step_trigger=lambda x: x % 100 == 0,
+        aspect_ratio=(1, 1),
+    )
+    env.reset()
+    for _ in range(199):
+        action = env.action_space.sample()
+        _, _, terminated, truncated, _ = env.step(action)
+        if np.any(terminated) or np.any(truncated):
+            env.reset()
+    env.close()
+    assert os.path.isdir("videos")
+    mp4_files = [file for file in os.listdir("videos") if file.endswith(".mp4")]
+    shutil.rmtree("videos")
+    assert len(mp4_files) == 2
+
+
+def test_both_episodic_and_step_trigger():
+    """Test RecordVideo defining both step and episode trigger functions."""
+    n_envs = 10
+
+    def make_env():
+        return gym.make("CartPole-v1", render_mode="rgb_array")
+
+    env = gym.vector.SyncVectorEnv([make_env for _ in range(n_envs)])
+    env = RecordVideo(
+        env,
+        "videos",
+        step_trigger=lambda x: x == 100,
+        episode_trigger=lambda x: x == 0 or x == 3,
+        aspect_ratio=(1, 1),
+    )
+
+    env.reset(seed=123)
+    env.action_space.seed(123)
+    for i in range(199):
+        action = env.action_space.sample()
+        _, _, terminated, truncated, _ = env.step(action)
+        if np.any(terminated) or np.any(truncated):
+            env.reset()
+    env.close()
+
+    assert os.path.isdir("videos")
+    mp4_files = [file for file in os.listdir("videos") if file.endswith(".mp4")]
+    shutil.rmtree("videos")
+    assert len(mp4_files) == 3
+
+
+def test_video_length(video_length: int = 10):
+    """Test if argument video_length of RecordVideo works properly."""
+    n_envs = 10
+
+    def make_env():
+        return gym.make("CartPole-v1", render_mode="rgb_array")
+
+    env = gym.vector.SyncVectorEnv([make_env for _ in range(n_envs)])
+    env = RecordVideo(
+        env,
+        "videos",
+        step_trigger=lambda x: x == 0,
+        video_length=video_length,
+        aspect_ratio=(1, 1),
+    )
+
+    env.reset(seed=123)
+    env.action_space.seed(123)
+    for _ in range(video_length):
+        _, _, terminated, truncated, _ = env.step(env.action_space.sample())
+        if np.any(terminated) or np.any(truncated):
+            break
+
+    # check that the environment is still recording then take a step to take the number of steps > video length
+    assert env.recording
+    env.step(env.action_space.sample())
+    assert not env.recording
+    env.close()
+
+    # check that only one video is recorded
+    assert os.path.isdir("videos")
+    mp4_files = [file for file in os.listdir("videos") if file.endswith(".mp4")]
+    assert len(mp4_files) == 1
+    shutil.rmtree("videos")


### PR DESCRIPTION
# Description

Vector RecordVideo wrapper. Related to [this issue](https://github.com/Farama-Foundation/Gymnasium/issues/1414#issuecomment-3084989093).
Docs of the new class has an example.

I copied the basic RecordVideo wrapper and changed `_capture_frame` to process tuples of frames (from VectorEnv). Then, there are two helper functions `_get_concat_frame_shape` and `_concat_frames` that concatenate these frames into a "big frame" depending on the aspect ratio passed by the user at `__init__`. 
It would be nice to have default `aspect_ratio=None` and use the same logic of Vector HumanRendering, but I am not sure how it works. 
I also made new tests that are the same as basic RecordVideo (except the one with RenderCollection since there is no Vector version of it).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes