### PR TITLE
[Bugfix] fixed `step()` function in `AsyncVectorEnv` from hanging forever

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -385,13 +385,7 @@ class AsyncVectorEnv(VectorEnv):
 
         Returns:
             Batch of (observations, rewards, terminations, truncations, infos)
-
-        Raises:
-            AssertionError: If the action is not in the action space.
         """
-        assert self.action_space.contains(
-            actions
-        ), f"Expected action to be in {self.action_space}, got {actions}"
         self.step_async(actions)
         return self.step_wait()
 
@@ -416,7 +410,7 @@ class AsyncVectorEnv(VectorEnv):
             )
 
         iter_actions = iterate(self.action_space, actions)
-        for pipe, action in zip(self.parent_pipes, iter_actions):
+        for pipe, action in zip(self.parent_pipes, iter_actions, strict=True):
             pipe.send(("step", action))
         self._state = AsyncState.WAITING_STEP
 

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -385,10 +385,13 @@ class AsyncVectorEnv(VectorEnv):
 
         Returns:
             Batch of (observations, rewards, terminations, truncations, infos)
+
+        Raises:
+            AssertionError: If the action is not in the action space.
         """
-        assert self.action_space.contains(actions), (
-            f"Expected action to be in {self.action_space}, got {actions}"
-        )
+        assert self.action_space.contains(
+            actions
+        ), f"Expected action to be in {self.action_space}, got {actions}"
         self.step_async(actions)
         return self.step_wait()
 

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -386,6 +386,9 @@ class AsyncVectorEnv(VectorEnv):
         Returns:
             Batch of (observations, rewards, terminations, truncations, infos)
         """
+        assert self.action_space.contains(actions), (
+            f"Expected action to be in {self.action_space}, got {actions}"
+        )
         self.step_async(actions)
         return self.step_wait()
 

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -243,25 +243,11 @@ class SyncVectorEnv(VectorEnv):
 
         Returns:
             The batched environment step results
-
-        Raises:
-            ValueError: If the number of actions does not match the number of environments.
         """
-        try:
-            actions = np.asarray(actions)
-            if actions.shape[0] != self.num_envs:
-                raise ValueError(
-                    f"Expected {self.num_envs} actions, got {actions.shape[0]}"
-                )
-        except Exception as e:
-            raise ValueError(
-                f"Actions must be convertible to a numpy array with shape ({self.num_envs}, ...), got {type(actions)} with error: {e}"
-            ) from e
-
         actions = iterate(self.action_space, actions)
 
         infos = {}
-        for i, action in enumerate(actions):
+        for i, (action, _) in enumerate(zip(actions, self.envs, strict=True)):
             if self.autoreset_mode == AutoresetMode.NEXT_STEP:
                 if self._autoreset_envs[i]:
                     self._env_obs[i], env_info = self.envs[i].reset()

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -243,7 +243,21 @@ class SyncVectorEnv(VectorEnv):
 
         Returns:
             The batched environment step results
+
+        Raises:
+            ValueError: If the number of actions does not match the number of environments.
         """
+        try:
+            actions = np.asarray(actions)
+            if actions.shape[0] != self.num_envs:
+                raise ValueError(
+                    f"Expected {self.num_envs} actions, got {actions.shape[0]}"
+                )
+        except Exception as e:
+            raise ValueError(
+                f"Actions must be convertible to a numpy array with shape ({self.num_envs}, ...), got {type(actions)} with error: {e}"
+            ) from e
+
         actions = iterate(self.action_space, actions)
 
         infos = {}


### PR DESCRIPTION
# Description

Added action space assertion in `AsyncVectorEnv` `step` method to ensure that the actions passed to the step method are validated against the action space, preventing `step_await` hangs forever.


Fixes #1417 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<img width="1154" height="458" alt="image" src="https://github.com/user-attachments/assets/56b957fc-7c8a-4669-99cf-f360c3ce2e94" />

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
