### PR TITLE
Clear markers after rendering for MuJoCo OffscreenViewers

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -316,6 +316,7 @@ class OffScreenViewer(BaseRender):
                         seg_ids[geom.segid + 1, 1] = geom.objid
                 rgb_img = seg_ids[seg_img]
 
+        self._markers.clear()
         # Return processed images based on render_mode
         if render_mode == "rgb_array":
             return rgb_img

--- a/tests/envs/mujoco/test_mujoco_rendering.py
+++ b/tests/envs/mujoco/test_mujoco_rendering.py
@@ -136,6 +136,7 @@ def test_add_markers(model: mujoco.MjModel, data: mujoco.MjData, render_mode: st
     args = tuple() if render_mode == "human" else (render_mode,)
     viewer.render(*args)  # We need to render to trigger the marker addition in MuJoCo
     # close viewer after usage
+    assert len(viewer._markers) == 0, "Markers should be cleared after rendering."
     viewer.close()
 
 


### PR DESCRIPTION
# Description

The current MuJoCo `WindowViewer` clears markers after each `render` calls, but the `OffscreenViewer` does not. This leads to unexpected behavior when continuously adding markers to the scene: The `human` render mode works as expected but `rgb_array` raises a MuJoCo error that the maximum number of geoms has been exceeded. This PR makes the behavior consistent across viewers and tests that markers are cleared after each render call.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Clear markers after rendering for MuJoCo OffscreenViewers