### PR TITLE
Fixes memory leak in recording

### DIFF
--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -417,7 +417,9 @@ class RecordVideo(
             moviepy_logger = None if self.disable_logger else "bar"
             path = os.path.join(self.video_folder, f"{self._video_name}.mp4")
             clip.write_videofile(path, logger=moviepy_logger)
+            del clip
 
+        del self.recorded_frames
         self.recorded_frames = []
         self.recording = False
         self._video_name = None


### PR DESCRIPTION
# Description

Fixes a memory leak in the recording script where `self.recorded_frames` stays in memory due to reference in the clip.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
