### PR TITLE
During autoreset use numpy types

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -754,7 +754,7 @@ def _async_worker(
                 if autoreset_mode == AutoresetMode.NEXT_STEP:
                     if autoreset:
                         observation, info = env.reset()
-                        reward, terminated, truncated = 0, False, False
+                        reward, terminated, truncated = np.array([0.0]), np.array([False]), np.array([False])
                     else:
                         (
                             observation,


### PR DESCRIPTION
Set reward, truncation, and termination returns to numpy types during autoreset

# Description

When autoreset happens during AsyncVectorEnv step, the pipe returns a non numpy type. This causes a ValueError where the requested array has an inhomogeneous shape, when some of the environments return numpy array types and the environment index that autoreset returns python primitives.

Fixes #1445 

During auto reset reward, truncated, and terminated should return numpy types.



