### PR TITLE
Fix `DictInfoToList` to support missing binary key

### DIFF
--- a/gymnasium/wrappers/vector/dict_info_to_list.py
+++ b/gymnasium/wrappers/vector/dict_info_to_list.py
@@ -117,17 +117,42 @@ class DictInfoToList(VectorWrapper):
             if key.startswith("_"):
                 continue
 
+            binary_key = f"_{key}"
             if isinstance(value, dict):
                 value_list_info = self._convert_info_to_list(value)
-                for env_num, (env_info, has_info) in enumerate(
-                    zip(value_list_info, vector_infos[f"_{key}"])
-                ):
-                    if has_info:
-                        list_info[env_num][key] = env_info
+                assert (
+                    len(value_list_info) == self.num_envs
+                ), f"Expects {value_list_info} to have length equal to the num-envs ({self.num_envs}), actual length is {len(value_list_info)}"
+
+                if binary_key in vector_infos:
+                    assert (
+                        len(vector_infos[binary_key]) == self.num_envs
+                    ), f"Expects {vector_infos[binary_key]} to have length equal to the num-envs ({self.num_envs}), actual length is {len(vector_infos[binary_key])}"
+
+                    for env_num, (env_info, has_info) in enumerate(
+                        zip(value_list_info, vector_infos[binary_key])
+                    ):
+                        if has_info:
+                            list_info[env_num][key] = env_info
+                else:
+                    for env_num, sub_value in enumerate(value_list_info):
+                        list_info[env_num][key] = sub_value
             else:
                 assert isinstance(value, np.ndarray)
-                for env_num, has_info in enumerate(vector_infos[f"_{key}"]):
-                    if has_info:
-                        list_info[env_num][key] = value[env_num]
+                assert (
+                    len(value) == self.num_envs
+                ), f"Expects {value} to have length equal to the num-envs ({self.num_envs}), actual length is {len(value)}"
+
+                if binary_key in vector_infos:
+                    assert (
+                        len(vector_infos[binary_key]) == self.num_envs
+                    ), f"Expects {vector_infos[binary_key]} to have length equal to the num-envs ({self.num_envs}), actual length is {len(vector_infos[binary_key])}"
+
+                    for env_num, has_info in enumerate(vector_infos[binary_key]):
+                        if has_info:
+                            list_info[env_num][key] = value[env_num]
+                else:
+                    for env_num, sub_value in enumerate(value):
+                        list_info[env_num][key] = sub_value
 
         return list_info


### PR DESCRIPTION
# Description

```python
import gymnasium

vec_env = gymnasium.make_vec("ale_py:ALE/Pong-v5", num_envs=2)
vec_env = gymnasium.wrappers.vector.DictInfoToList(vec_env)
vec_env.reset()
vec_env.step(vec_env.action_space.sample())
vec_env.close()
```
This code would error as the `DictInfoToList` assumed that the vector environment returns a binary array for each key. 
For the Gymnasium vectorizers this is implemented however for custom vector environments like Atari then this might not be implemented. 

This PR adds support for vector environments without the binary key and improved errors to explain to users where the info key value length is not equal to the number of environments 