### PR TITLE
Change `box2d` requirements from `box2d-py` to `box2d`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 # Update dependencies in `all` if any are added or removed
 atari = ["ale_py >=0.9"]
-box2d = ["box2d-py ==2.3.5", "pygame >=2.1.3", "swig ==4.*"]
+box2d = ["box2d ==2.3.10", "pygame >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame >=2.1.3"]
 classic_control = ["pygame >=2.1.3"]  # kept for backward compatibility
 mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1", "packaging >=23.0"]
@@ -61,7 +61,7 @@ all = [
     # atari
     "ale_py >=0.9",
     # box2d
-    "box2d-py ==2.3.5",
+    "box2d ==2.3.10",
     "pygame >=2.1.3",
     "swig ==4.*",
     # classic-control


### PR DESCRIPTION
In response to this proposal: https://github.com/Farama-Foundation/Gymnasium/issues/1324

# Description

As pointed out here: https://github.com/Farama-Foundation/Gymnasium/issues/1324
It is currently not possible to install the `box2d` dependency. Doing what is written on the Gymnasium website (here: https://gymnasium.farama.org/environments/box2d/) doesn't work. Changing the requirement to `box2d==2.3.10` fixes this issue. I wanted to start using Gymnasium for my own research project, but the fact that trying to install `box2d-py` currently raises an error means I could not even run the basic `LunarLander-v3` example shown on the Gymnasium website (see: https://gymnasium.farama.org/). Modifying the `box2d` requirement fixes the issue in Python 3.13.9.

Fixes #1324 

## Type of change
I modified the requirements in `pyproject.toml` to `box2d==2.3.10` instead of `box2d-py==2.3.8`.