### PR TITLE
Fix docstring typo in gymnasium/wrappers/vector/stateful_observation.py

### DIFF
--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -34,7 +34,7 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         The normalization depends on past trajectories and observations will not be normalized correctly if the wrapper was
         newly instantiated or the policy was changed recently.
 
-    Example without the normalize reward wrapper:
+    Example without the normalize observation wrapper:
         >>> import gymnasium as gym
         >>> envs = gym.make_vec("CartPole-v1", num_envs=3, vectorization_mode="sync")
         >>> obs, info = envs.reset(seed=123)
@@ -47,7 +47,7 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         np.float32(0.62259156)
         >>> envs.close()
 
-    Example with the normalize reward wrapper:
+    Example with the normalize observation wrapper:
         >>> import gymnasium as gym
         >>> envs = gym.make_vec("CartPole-v1", num_envs=3, vectorization_mode="sync")
         >>> envs = NormalizeObservation(envs)


### PR DESCRIPTION
# Description

Fix docstring typo for NormalizeObservation class in gymnasium/wrappers/vector/stateful_observation.py. The examples should refer to the normalise observation wrapper, not the normalise reward wrapper.

Fixes # (issue)

## Type of change

- [x] Documentation only change (no code changed)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

