### PR TITLE
Revise migration guide for TimeLimit wrapper changes

### DIFF
--- a/docs/introduction/migration_guide.md
+++ b/docs/introduction/migration_guide.md
@@ -256,7 +256,7 @@ if need_visualization:
 .. py:currentmodule:: gymnasium.wrappers
 
 The :class:`TimeLimit` wrapper behavior also changed to align with the new termination model.
-
+```
 **Old v0.21**: Added `TimeLimit.truncated` to info dict
 ```python
 obs, reward, done, info = env.step(action)


### PR DESCRIPTION
Update migration guide to add closing backticks in ReST block in TimeLimit wrapper behavior.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
