### PR TITLE
Add return type hint to close methods

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -190,7 +190,7 @@ class Env(Generic[ObsType, ActType]):
         """
         raise NotImplementedError
 
-    def close(self):
+    def close(self) -> None:
         """After the user has finished using the environment, close contains the code necessary to "clean up" the environment.
 
         This is critical for closing rendering windows, database or HTTP connections.
@@ -336,7 +336,7 @@ class Wrapper(
         """Uses the :meth:`render` of the :attr:`env` that can be overwritten to change the returned data."""
         return self.env.render()
 
-    def close(self):
+    def close(self) -> None:
         """Closes the wrapper and :attr:`env`."""
         return self.env.close()
 


### PR DESCRIPTION
# Description

`close` method has no type hints, so I added the return type of `None` as it's intended to be a void function.
Fixes #1339

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
