### PR TITLE
Fix GridWorld tutorial to use NumPy [row, col] convention

### DIFF
--- a/docs/introduction/create_custom_env.md
+++ b/docs/introduction/create_custom_env.md
@@ -113,10 +113,10 @@ class GridWorldEnv(gym.Env):
         # Map action numbers to actual movements on the grid
         # This makes the code more readable than using raw numbers
         self._action_to_direction = {
-            0: np.array([1, 0]),   # Move right (positive x)
-            1: np.array([0, 1]),   # Move up (positive y)
-            2: np.array([-1, 0]),  # Move left (negative x)
-            3: np.array([0, -1]),  # Move down (negative y)
+            0: np.array([0, 1]),   # Move right (column + 1)
+            1: np.array([-1, 0]),  # Move up (row - 1)
+            2: np.array([0, -1]),  # Move left (column - 1)
+            3: np.array([1, 0]),   # Move down (row + 1)
         }
 ```
 
@@ -408,12 +408,12 @@ def reset(self, seed=None, options=None):
     # super().reset(seed=seed)  # ❌ Missing this line
     # Results in: possibly incorrect seeding
 
-# Issue 2: Wrong action mapping
+# Issue 2: Mixing up coordinate conventions
+# Using Cartesian [x, y] instead of NumPy [row, col] causes visual confusion
+# when rendering, since row 0 is at the top of the screen:
 self._action_to_direction = {
-    0: np.array([1, 0]),   # right
-    1: np.array([0, 1]),   # up - but is this really "up" in your coordinate system?
-    2: np.array([-1, 0]),  # left
-    3: np.array([0, -1]),  # down
+    0: np.array([1, 0]),   # Intended as "right" but this changes row
+    1: np.array([0, 1]),   # Intended as "up" but this changes column
 }
 
 # Issue 3: Not handling boundaries properly

--- a/docs/tutorials/gymnasium_basics/environment_creation.py
+++ b/docs/tutorials/gymnasium_basics/environment_creation.py
@@ -173,12 +173,13 @@ class GridWorldEnv(gym.Env):
         The following dictionary maps abstract actions from `self.action_space` to
         the direction we will walk in if that action is taken.
         i.e. 0 corresponds to "right", 1 to "up" etc.
+        Uses NumPy [row, col] convention where row 0 is at the top.
         """
         self._action_to_direction = {
-            Actions.RIGHT.value: np.array([1, 0]),
-            Actions.UP.value: np.array([0, 1]),
-            Actions.LEFT.value: np.array([-1, 0]),
-            Actions.DOWN.value: np.array([0, -1]),
+            Actions.RIGHT.value: np.array([0, 1]),
+            Actions.UP.value: np.array([-1, 0]),
+            Actions.LEFT.value: np.array([0, -1]),
+            Actions.DOWN.value: np.array([1, 0]),
         }
 
         assert render_mode is None or render_mode in self.metadata["render_modes"]
@@ -332,11 +333,12 @@ class GridWorldEnv(gym.Env):
         )  # The size of a single grid square in pixels
 
         # First we draw the target
+        # Convert [row, col] to pygame (x, y) by reversing the coordinates
         pygame.draw.rect(
             canvas,
             (255, 0, 0),
             pygame.Rect(
-                pix_square_size * self._target_location,
+                pix_square_size * self._target_location[::-1],
                 (pix_square_size, pix_square_size),
             ),
         )
@@ -344,7 +346,7 @@ class GridWorldEnv(gym.Env):
         pygame.draw.circle(
             canvas,
             (0, 0, 255),
-            (self._agent_location + 0.5) * pix_square_size,
+            (self._agent_location[::-1] + 0.5) * pix_square_size,
             pix_square_size / 3,
         )
 


### PR DESCRIPTION
# Description

The GridWorld tutorial used Cartesian [x, y] coordinates for action mappings, which conflicts with NumPy's [row, col] convention. This caused visual confusion when rendering - "up" actually moved the agent down on screen because row 0 is at the top.

Changed action mappings to NumPy convention and updated rendering to convert [row, col] to pygame (x, y) coordinates.

Fixes #1395 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

### Screenshots

N/A - tutorial documentation change

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
