### PR TITLE
Fixed A2C critic regression against fixed target and bootstrapping.

### DIFF
--- a/docs/tutorials/training_agents/vector_a2c.py
+++ b/docs/tutorials/training_agents/vector_a2c.py
@@ -541,14 +541,8 @@ fig.suptitle(
 
 # episode return
 axs[0][0].set_title("Episode Returns")
-episode_returns_moving_average = (
-        np.convolve(
-            np.array(envs_wrapper.return_queue).flatten(),
-            np.ones(rolling_length),
-            mode="valid",
-        )
-        / rolling_length
-)
+episode_returns_moving_average = np.convolve(np.array(envs_wrapper.return_queue).flatten(), np.ones(rolling_length),
+                                             mode="valid") / rolling_length
 axs[0][0].plot(
     np.arange(len(episode_returns_moving_average)) / n_envs,
     episode_returns_moving_average,
@@ -557,30 +551,21 @@ axs[0][0].set_xlabel("Number of episodes")
 
 # entropy
 axs[1][0].set_title("Entropy")
-entropy_moving_average = (
-        np.convolve(np.array(entropies_list), np.ones(rolling_length), mode="valid")
-        / rolling_length
-)
+entropy_moving_average = np.convolve(np.array(entropies_list), np.ones(rolling_length), mode="valid") / rolling_length
 axs[1][0].plot(entropy_moving_average)
 axs[1][0].set_xlabel("Number of updates")
 
 # critic loss
 axs[0][1].set_title("Critic Loss")
-critic_losses_moving_average = (
-        np.convolve(
-            np.array(critic_losses).flatten(), np.ones(rolling_length), mode="valid"
-        )
-        / rolling_length
-)
+critic_losses_moving_average = np.convolve(np.array(critic_losses).flatten(), np.ones(rolling_length),
+                                           mode="valid") / rolling_length
 axs[0][1].plot(critic_losses_moving_average)
 axs[0][1].set_xlabel("Number of updates")
 
 # actor loss
 axs[1][1].set_title("Actor Loss")
-actor_losses_moving_average = (
-        np.convolve(np.array(actor_losses).flatten(), np.ones(rolling_length), mode="valid")
-        / rolling_length
-)
+actor_losses_moving_average = np.convolve(np.array(actor_losses).flatten(), np.ones(rolling_length),
+                                          mode="valid") / rolling_length
 axs[1][1].plot(actor_losses_moving_average)
 axs[1][1].set_xlabel("Number of updates")
 


### PR DESCRIPTION
# Description

Fixed A2C critic regression against fixed target and bootstrapping.
Advantages now shouldn't flow over between episode boundries.
Critic loss now regresses against a fixed target and not with regard to the GAE computation loop.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x] Documentation only change (no code changed)
- [x ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
