### PR TITLE
docs(RecordEpisodeStatistics(VectorWrapper)) removes reference to final_observation/info

### DIFF
--- a/gymnasium/wrappers/vector/common.py
+++ b/gymnasium/wrappers/vector/common.py
@@ -46,6 +46,7 @@ class RecordEpisodeStatistics(VectorWrapper):
     Example:
         >>> from pprint import pprint
         >>> import gymnasium as gym
+        >>> from gymnasium.wrappers.vector import RecordEpisodeStatistics
         >>> envs = gym.make_vec("CartPole-v1", num_envs=3)
         >>> envs = RecordEpisodeStatistics(envs)
         >>> obs, info = envs.reset(123)
@@ -58,14 +59,9 @@ class RecordEpisodeStatistics(VectorWrapper):
         >>> envs.close()
         >>> pprint(info) # doctest: +SKIP
         {'_episode': array([ True, False, False]),
-         '_final_info': array([ True, False, False]),
-         '_final_observation': array([ True, False, False]),
          'episode': {'l': array([11,  0,  0], dtype=int32),
                      'r': array([11.,  0.,  0.], dtype=float32),
                      't': array([0.007812, 0.      , 0.      ], dtype=float32)},
-         'final_info': array([{}, None, None], dtype=object),
-         'final_observation': array([array([ 0.11448676,  0.9416149 , -0.20946532, -1.7619033 ], dtype=float32),
-               None, None], dtype=object)}
     """
 
     def __init__(


### PR DESCRIPTION
# Description
Removes reference to `final_observation` and `final_info` from example section of doc strings for [vector RecordEpisodeStatistcs wrapper](https://gymnasium.farama.org/main/api/vector/wrappers/)
Fixes # (1504)

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

Before
<img width="893" height="568" alt="image" src="https://github.com/user-attachments/assets/48cfca94-73c1-4193-93c1-cc8003329f03" />
After
<img width="638" height="435" alt="image" src="https://github.com/user-attachments/assets/a3e20f7f-63c6-49ab-bc16-93e7774b8939" />

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
