### PR TITLE
Replace pygame with pygame-ce to enable Python 3.14 support for some envs

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         numpy-version: ['>=1.21,<2.0', '>=2.1']
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]


### PR DESCRIPTION
# Description

Many of our environments depend on the basic functionality of PyGame. However, the main PyGame repo stopped being actively maintained and lacks a wheel release for Python 3.14. In order to support Python 3.14, this PR replaces pygame with PyGame community edition (pygame-ce), which is a drop-in replacement that receives frequent updates.

Fixes # (issue)

## Type of change

- [x] Compatibility fix

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] (NA)I have commented my code, particularly in hard-to-understand areas
- [x] (NA) I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] (NA) I have added tests that prove my fix is effective or that my feature works
- [x] (NA) New and existing unit tests pass locally with my changes
