### PR TITLE
Update Graph to accept arbitrary node and edge spaces

### DIFF
--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -145,6 +145,16 @@ class Graph(Space[GraphInstance]):
                 f"Expects `None`, int or tuple of ints, actual type: {type(seed)}"
             )
 
+    def _generate_sample_space(self, space: Space[Any], n: int) -> Space[Any] | None:
+        if n == 0 or space is None:
+            # There is nothing to batch
+            return
+
+        # TODO: remove this weird code that is just for advancing the node space RNG
+        _ = self.node_space.np_random.random()
+        batched_space = gym.vector.utils.batch_space(space, n)
+        return batched_space
+
     def sample(
         self,
         mask: (
@@ -219,18 +229,11 @@ class Graph(Space[GraphInstance]):
         sampled_node_space = None
         sampled_edge_space = None
 
-        if num_nodes != 0 and self.node_space is not None:
-            _ = self.node_space.np_random.random()
-            sampled_node_space = gym.vector.utils.batch_space(
-                self.node_space, num_nodes
-            )
-            assert sampled_node_space is not None
+        sampled_node_space = self._generate_sample_space(self.node_space, num_nodes)
+        assert sampled_node_space is not None
 
-        if num_edges != 0 and self.edge_space is not None:
-            _ = self.edge_space.np_random.random()
-            sampled_edge_space = gym.vector.utils.batch_space(
-                self.edge_space, num_edges
-            )
+        if self.edge_space is not None:
+            sampled_edge_space = self._generate_sample_space(self.edge_space, num_edges)
 
         # ty can't infer typed dictionaries (yet?)
         node_sample_kwargs: dict[str, Any]

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -9,22 +9,19 @@ import numpy as np
 from numpy.typing import NDArray
 
 import gymnasium as gym
-from gymnasium.spaces.box import Box
-from gymnasium.spaces.discrete import Discrete
-from gymnasium.spaces.multi_discrete import MultiDiscrete
 from gymnasium.spaces.space import Space
 
 
 class GraphInstance(NamedTuple):
     """A Graph space instance.
 
-    * nodes (np.ndarray): an (n x ...) sized array representing the features for n nodes, (...) must adhere to the shape of the node space.
-    * edges (Optional[np.ndarray]): an (m x ...) sized array representing the features for m edges, (...) must adhere to the shape of the edge space.
+    * nodes (Iterable): an (n x ...) sized array representing the features for n nodes, (...) must adhere to the shape of the node space.
+    * edges (Optional[Iterable]): an (m x ...) sized array representing the features for m edges, (...) must adhere to the shape of the edge space.
     * edge_links (Optional[np.ndarray]): an (m x 2) sized array of ints representing the indices of the two nodes that each edge connects.
     """
 
-    nodes: NDArray[Any]
-    edges: NDArray[Any] | None
+    nodes: Iterable[Any]
+    edges: Iterable[Any] | None
     edge_links: NDArray[Any] | None
 
 
@@ -53,34 +50,21 @@ class Graph(Space[GraphInstance]):
 
     def __init__(
         self,
-        node_space: Box | Discrete,
-        edge_space: Box | Discrete | None,
+        node_space: Space[Any],
+        edge_space: None | Space[Any],
         seed: int | np.random.Generator | None = None,
     ) -> None:
         r"""Constructor of :class:`Graph`.
 
         The argument ``node_space`` specifies the base space that each node feature will use.
-        This argument must be either a Box or Discrete instance.
 
         The argument ``edge_space`` specifies the base space that each edge feature will use.
-        This argument must be either a None, Box or Discrete instance.
 
         Args:
-            node_space (Union[Box, Discrete]): space of the node features.
-            edge_space (Union[None, Box, Discrete]): space of the edge features.
+            node_space (Space[Any]): space of the node features.
+            edge_space (None | Space[Any]): space of the edge features.
             seed: Optionally, you can use this argument to seed the RNG that is used to sample from the space.
         """
-        if not isinstance(node_space, (Box, Discrete)):
-            raise TypeError(
-                f"Values of the node_space should be instances of Box or Discrete, got {type(node_space)}"
-            )
-
-        if edge_space is not None:
-            if not isinstance(edge_space, (Box, Discrete)):
-                raise TypeError(
-                    f"Values of the edge_space should be instances of None, Box or Discrete, got {type(edge_space)}"
-                )
-
         self.node_space = node_space
         self.edge_space = edge_space
 
@@ -90,27 +74,6 @@ class Graph(Space[GraphInstance]):
     def is_np_flattenable(self) -> Literal[False]:
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return False
-
-    def _generate_sample_space(
-        self, base_space: None | Box | Discrete, num: int
-    ) -> Box | MultiDiscrete | None:
-        if num == 0 or base_space is None:
-            return None
-
-        if isinstance(base_space, Box):
-            return Box(
-                low=np.array(max(1, num) * [base_space.low]),
-                high=np.array(max(1, num) * [base_space.high]),
-                shape=(num,) + base_space.shape,
-                dtype=base_space.dtype,
-                seed=self.np_random,
-            )
-        elif isinstance(base_space, Discrete):
-            return MultiDiscrete(nvec=[int(base_space.n)] * num, seed=self.np_random)
-        else:
-            raise TypeError(
-                f"Expects base space to be Box and Discrete, actual space: {type(base_space)}."
-            )
 
     def seed(
         self, seed: int | tuple[int, int] | tuple[int, int, int] | None = None
@@ -204,10 +167,10 @@ class Graph(Space[GraphInstance]):
         """Generates a single sample graph with num_nodes between ``1`` and ``10`` sampled from the Graph.
 
         Args:
-            mask: An optional tuple of optional node and edge mask that is only possible with Discrete spaces
+            mask: An optional tuple of optional node and edge mask
                 (Box spaces don't support sample masks).
                 If no ``num_edges`` is provided then the ``edge_mask`` is multiplied by the number of edges
-            probability: An optional tuple of optional node and edge probability mask that is only possible with Discrete spaces
+            probability: An optional tuple of optional node and edge probability mask
                 (Box spaces don't support sample probability masks).
                 If no ``num_edges`` is provided then the ``edge_mask`` is multiplied by the number of edges
             num_nodes: The number of nodes that will be sampled, the default is `10` nodes
@@ -253,9 +216,21 @@ class Graph(Space[GraphInstance]):
             )
         assert num_edges is not None
 
-        sampled_node_space = self._generate_sample_space(self.node_space, num_nodes)
-        assert sampled_node_space is not None
-        sampled_edge_space = self._generate_sample_space(self.edge_space, num_edges)
+        sampled_node_space = None
+        sampled_edge_space = None
+
+        if num_nodes != 0 and self.node_space is not None:
+            _ = self.node_space.np_random.random()
+            sampled_node_space = gym.vector.utils.batch_space(
+                self.node_space, num_nodes
+            )
+            assert sampled_node_space is not None
+
+        if num_edges != 0 and self.edge_space is not None:
+            _ = self.edge_space.np_random.random()
+            sampled_edge_space = gym.vector.utils.batch_space(
+                self.edge_space, num_edges
+            )
 
         # ty can't infer typed dictionaries (yet?)
         node_sample_kwargs: dict[str, Any]
@@ -282,30 +257,40 @@ class Graph(Space[GraphInstance]):
 
     def contains(self, x: GraphInstance) -> bool:
         """Return boolean specifying if x is a valid member of this space."""
-        if isinstance(x, GraphInstance):
-            # Checks the nodes
-            if isinstance(x.nodes, np.ndarray):
-                if all(node in self.node_space for node in x.nodes):
-                    # Check the edges and edge links which are optional
-                    if isinstance(x.edges, np.ndarray) and isinstance(
-                        x.edge_links, np.ndarray
-                    ):
-                        assert x.edges is not None
-                        assert x.edge_links is not None
-                        if self.edge_space is not None:
-                            if all(edge in self.edge_space for edge in x.edges):
-                                if np.issubdtype(x.edge_links.dtype, np.integer):
-                                    if x.edge_links.shape == (len(x.edges), 2):
-                                        if np.all(
-                                            np.logical_and(
-                                                x.edge_links >= 0,
-                                                x.edge_links < len(x.nodes),
-                                            )
-                                        ):
-                                            return True
-                    else:
-                        return x.edges is None and x.edge_links is None
-        return False
+        if not isinstance(x, GraphInstance):
+            return False
+
+        if not isinstance(x.nodes, Iterable):
+            return False
+
+        if not all(node in self.node_space for node in x.nodes):
+            return False
+
+        # Check the edges and edge links which are optional
+        if isinstance(x.edges, Iterable) and isinstance(x.edge_links, np.ndarray):
+            if self.edge_space is None:
+                return False
+
+            if not all(edge in self.edge_space for edge in x.edges):
+                return False
+
+            if not np.issubdtype(x.edge_links.dtype, np.integer):
+                return False
+
+            if not x.edge_links.shape == (len(x.edges), 2):
+                return False
+
+            if not np.all(
+                np.logical_and(
+                    x.edge_links >= 0,
+                    x.edge_links < len(x.nodes),
+                )
+            ):
+                return False
+
+            return True
+
+        return x.edges is None and x.edge_links is None
 
     def __repr__(self) -> str:
         """A string representation of this space.

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -237,7 +237,8 @@ class Graph(Space[GraphInstance]):
         #   we need to get the updated np_random
         self.node_space.np_random.random()
 
-        if num_nodes > 1 and num_edges >= 1 and self.edge_space is not None:
+        # It is valid to sample one node and one edge (self loop)
+        if num_nodes >= 1 and num_edges >= 1 and self.edge_space is not None:
             sample_batch_edge_space = gym.vector.utils.batch_space(
                 self.edge_space, num_edges
             )
@@ -262,15 +263,17 @@ class Graph(Space[GraphInstance]):
             nodes = list(gym.vector.utils.iterate(self.batch_node_space, x.nodes))
             if all(node in self.node_space for node in nodes):
                 # Check the edges and edge links which are optional
-                if isinstance(x.edges, np.ndarray) and isinstance(
-                    x.edge_links, np.ndarray
-                ):
-                    assert x.edges is not None
-                    assert x.edge_links is not None
-                    if self.edge_space is not None:
-                        if all(edge in self.edge_space for edge in x.edges):
+                if x.edges is not None and x.edge_links is not None:
+                    if self.edge_space is not None and isinstance(
+                        x.edge_links, np.ndarray
+                    ):
+                        # Use iterate to handle all space types (Dict, Tuple, etc.)
+                        edges = list(
+                            gym.vector.utils.iterate(self.batch_edge_space, x.edges)
+                        )
+                        if all(edge in self.edge_space for edge in edges):
                             if np.issubdtype(x.edge_links.dtype, np.integer):
-                                if x.edge_links.shape == (len(x.edges), 2):
+                                if x.edge_links.shape == (len(edges), 2):
                                     if np.all(
                                         np.logical_and(
                                             x.edge_links >= 0, x.edge_links < len(nodes)

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -222,31 +222,30 @@ class Graph(Space[GraphInstance]):
             )
         assert num_edges is not None
 
-        sampled_node_space = gym.vector.utils.batch_space(self.node_space, num_nodes)
-        assert sampled_node_space is not None
-        if self.edge_space is not None and (num_nodes > 1 or num_edges == 1):
-            sampled_edge_space = gym.vector.utils.batch_space(
-                self.edge_space, num_edges
-            )
-        else:
-            sampled_edge_space = None
-
-        # ty can't infer typed dictionaries (yet?)
-        node_sample_kwargs: dict[str, Any]
-        edge_sample_kwargs: dict[str, Any]
-
         if mask_type is not None:
             node_sample_kwargs = {mask_type: node_space_mask}
             edge_sample_kwargs = {mask_type: edge_space_mask}
         else:
             node_sample_kwargs = edge_sample_kwargs = {}
 
-        sampled_nodes = sampled_node_space.sample(**node_sample_kwargs)
-        self.node_space.sample()
-        sampled_edges = None
-        if sampled_edge_space is not None:
-            sampled_edges = sampled_edge_space.sample(**edge_sample_kwargs)
-            self.edge_space.sample()
+        # We need to reconstruct the batch node space each time as the num_nodes will change each time.
+        sample_batch_node_space = gym.vector.utils.batch_space(
+            self.node_space, num_nodes
+        )
+        sampled_nodes = sample_batch_node_space.sample(**node_sample_kwargs)
+        # The batch_space function deepcopies the node_space's np_random therefore to avoid generating the same samples each time
+        #   we need to get the updated np_random
+        self.node_space.np_random.random()
+
+        if num_nodes > 1 and num_edges >= 1 and self.edge_space is not None:
+            sample_batch_edge_space = gym.vector.utils.batch_space(
+                self.edge_space, num_edges
+            )
+
+            sampled_edges = sample_batch_edge_space.sample(**edge_sample_kwargs)
+            self.edge_space.np_random.random()
+        else:
+            sampled_edges = None
 
         sampled_edge_links = None
         if sampled_edges is not None and num_edges > 0:

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -68,6 +68,12 @@ class Graph(Space[GraphInstance]):
         self.node_space = node_space
         self.edge_space = edge_space
 
+        self.batch_node_space = gym.vector.utils.batch_space(node_space, n=1)
+        if edge_space is not None:
+            self.batch_edge_space = gym.vector.utils.batch_space(edge_space, n=1)
+        else:
+            self.batch_edge_space = None
+
         super().__init__(None, None, seed)
 
     @property
@@ -145,16 +151,6 @@ class Graph(Space[GraphInstance]):
                 f"Expects `None`, int or tuple of ints, actual type: {type(seed)}"
             )
 
-    def _generate_sample_space(self, space: Space[Any], n: int) -> Space[Any] | None:
-        if n == 0 or space is None:
-            # There is nothing to batch
-            return
-
-        # TODO: remove this weird code that is just for advancing the node space RNG
-        _ = self.node_space.np_random.random()
-        batched_space = gym.vector.utils.batch_space(space, n)
-        return batched_space
-
     def sample(
         self,
         mask: (
@@ -226,14 +222,14 @@ class Graph(Space[GraphInstance]):
             )
         assert num_edges is not None
 
-        sampled_node_space = None
-        sampled_edge_space = None
-
-        sampled_node_space = self._generate_sample_space(self.node_space, num_nodes)
+        sampled_node_space = gym.vector.utils.batch_space(self.node_space, num_nodes)
         assert sampled_node_space is not None
-
-        if self.edge_space is not None:
-            sampled_edge_space = self._generate_sample_space(self.edge_space, num_edges)
+        if self.edge_space is not None and (num_nodes > 1 or num_edges == 1):
+            sampled_edge_space = gym.vector.utils.batch_space(
+                self.edge_space, num_edges
+            )
+        else:
+            sampled_edge_space = None
 
         # ty can't infer typed dictionaries (yet?)
         node_sample_kwargs: dict[str, Any]
@@ -246,9 +242,11 @@ class Graph(Space[GraphInstance]):
             node_sample_kwargs = edge_sample_kwargs = {}
 
         sampled_nodes = sampled_node_space.sample(**node_sample_kwargs)
+        self.node_space.sample()
         sampled_edges = None
         if sampled_edge_space is not None:
             sampled_edges = sampled_edge_space.sample(**edge_sample_kwargs)
+            self.edge_space.sample()
 
         sampled_edge_links = None
         if sampled_edges is not None and num_edges > 0:
@@ -260,40 +258,29 @@ class Graph(Space[GraphInstance]):
 
     def contains(self, x: GraphInstance) -> bool:
         """Return boolean specifying if x is a valid member of this space."""
-        if not isinstance(x, GraphInstance):
-            return False
-
-        if not isinstance(x.nodes, Iterable):
-            return False
-
-        if not all(node in self.node_space for node in x.nodes):
-            return False
-
-        # Check the edges and edge links which are optional
-        if isinstance(x.edges, Iterable) and isinstance(x.edge_links, np.ndarray):
-            if self.edge_space is None:
-                return False
-
-            if not all(edge in self.edge_space for edge in x.edges):
-                return False
-
-            if not np.issubdtype(x.edge_links.dtype, np.integer):
-                return False
-
-            if not x.edge_links.shape == (len(x.edges), 2):
-                return False
-
-            if not np.all(
-                np.logical_and(
-                    x.edge_links >= 0,
-                    x.edge_links < len(x.nodes),
-                )
-            ):
-                return False
-
-            return True
-
-        return x.edges is None and x.edge_links is None
+        if isinstance(x, GraphInstance) and x.nodes is not None:
+            # Checks the nodes
+            nodes = list(gym.vector.utils.iterate(self.batch_node_space, x.nodes))
+            if all(node in self.node_space for node in nodes):
+                # Check the edges and edge links which are optional
+                if isinstance(x.edges, np.ndarray) and isinstance(
+                    x.edge_links, np.ndarray
+                ):
+                    assert x.edges is not None
+                    assert x.edge_links is not None
+                    if self.edge_space is not None:
+                        if all(edge in self.edge_space for edge in x.edges):
+                            if np.issubdtype(x.edge_links.dtype, np.integer):
+                                if x.edge_links.shape == (len(x.edges), 2):
+                                    if np.all(
+                                        np.logical_and(
+                                            x.edge_links >= 0, x.edge_links < len(nodes)
+                                        )
+                                    ):
+                                        return True
+                else:
+                    return x.edges is None and x.edge_links is None
+        return False
 
     def __repr__(self) -> str:
         """A string representation of this space.
@@ -319,9 +306,9 @@ class Graph(Space[GraphInstance]):
         """Convert a batch of samples from this space to a JSONable data type."""
         ret_n = []
         for sample in sample_n:
-            ret = {"nodes": sample.nodes.tolist()}
+            ret = {"nodes": self.batch_node_space.to_jsonable([sample.nodes])}
             if sample.edges is not None and sample.edge_links is not None:
-                ret["edges"] = sample.edges.tolist()
+                ret["edges"] = self.batch_edge_space.to_jsonable([sample.edges])
                 ret["edge_links"] = sample.edge_links.tolist()
             ret_n.append(ret)
         return ret_n
@@ -335,13 +322,13 @@ class Graph(Space[GraphInstance]):
             if "edges" in sample:
                 assert self.edge_space is not None
                 ret_n = GraphInstance(
-                    np.asarray(sample["nodes"], dtype=self.node_space.dtype),
-                    np.asarray(sample["edges"], dtype=self.edge_space.dtype),
+                    self.batch_node_space.from_jsonable(sample["nodes"])[0],
+                    self.batch_edge_space.from_jsonable(sample["edges"])[0],
                     np.asarray(sample["edge_links"], dtype=np.int32),
                 )
             else:
                 ret_n = GraphInstance(
-                    np.asarray(sample["nodes"], dtype=self.node_space.dtype),
+                    self.batch_node_space.from_jsonable(sample["nodes"])[0],
                     None,
                     None,
                 )

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -9,6 +9,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 import gymnasium as gym
+from gymnasium.spaces import Box, Discrete
 from gymnasium.spaces.space import Space
 
 

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -32,17 +32,17 @@ class Graph(Space[GraphInstance]):
         >>> from gymnasium.spaces import Graph, Box, Discrete
         >>> observation_space = Graph(node_space=Box(low=-100, high=100, shape=(3,)), edge_space=Discrete(3), seed=123)
         >>> observation_space.sample(num_nodes=4, num_edges=8)
-        GraphInstance(nodes=array([[ 36.47037 , -89.235794, -55.928024],
-               [-63.125637, -64.81882 ,  62.4189  ],
-               [ 84.669   , -44.68512 ,  63.950912],
-               [ 77.97854 ,   2.594091, -51.00708 ]], dtype=float32), edges=array([2, 0, 2, 1, 2, 0, 2, 1]), edge_links=array([[3, 0],
-               [0, 0],
-               [0, 1],
-               [0, 2],
+        GraphInstance(nodes=array([[-50.143734, -89.37025 , -42.120003],
+               [ 31.519672, -96.5817  ,  85.16244 ],
+               [ 97.65833 ,  92.20077 ,  75.31062 ],
+               [-21.80443 , -73.790115,  39.97857 ]], dtype=float32), edges=array([1, 0, 2, 0, 2, 1, 1, 2]), edge_links=array([[0, 2],
+               [2, 0],
+               [3, 0],
                [1, 0],
                [1, 0],
-               [0, 1],
-               [0, 2]], dtype=int32))
+               [1, 3],
+               [1, 3],
+               [1, 1]], dtype=int32))
     """
 
     node_space: Box | Discrete

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -9,22 +9,19 @@ import numpy as np
 from numpy.typing import NDArray
 
 import gymnasium as gym
-from gymnasium.spaces.box import Box
-from gymnasium.spaces.discrete import Discrete
-from gymnasium.spaces.multi_discrete import MultiDiscrete
 from gymnasium.spaces.space import Space
 
 
 class GraphInstance(NamedTuple):
     """A Graph space instance.
 
-    * nodes (np.ndarray): an (n x ...) sized array representing the features for n nodes, (...) must adhere to the shape of the node space.
-    * edges (Optional[np.ndarray]): an (m x ...) sized array representing the features for m edges, (...) must adhere to the shape of the edge space.
+    * nodes (Iterable): an (n x ...) sized array representing the features for n nodes, (...) must adhere to the shape of the node space.
+    * edges (Optional[Iterable]): an (m x ...) sized array representing the features for m edges, (...) must adhere to the shape of the edge space.
     * edge_links (Optional[np.ndarray]): an (m x 2) sized array of ints representing the indices of the two nodes that each edge connects.
     """
 
-    nodes: NDArray[Any]
-    edges: NDArray[Any] | None
+    nodes: Iterable[Any]
+    edges: Iterable[Any] | None
     edge_links: NDArray[Any] | None
 
 
@@ -53,31 +50,21 @@ class Graph(Space[GraphInstance]):
 
     def __init__(
         self,
-        node_space: Box | Discrete,
-        edge_space: Box | Discrete | None,
+        node_space: Space[Any],
+        edge_space: None | Space[Any],
         seed: int | np.random.Generator | None = None,
     ) -> None:
         r"""Constructor of :class:`Graph`.
 
         The argument ``node_space`` specifies the base space that each node feature will use.
-        This argument must be either a Box or Discrete instance.
 
         The argument ``edge_space`` specifies the base space that each edge feature will use.
-        This argument must be either a None, Box or Discrete instance.
 
         Args:
-            node_space (Union[Box, Discrete]): space of the node features.
-            edge_space (Union[None, Box, Discrete]): space of the edge features.
+            node_space (Space[Any]): space of the node features.
+            edge_space (None | Space[Any]): space of the edge features.
             seed: Optionally, you can use this argument to seed the RNG that is used to sample from the space.
         """
-        assert isinstance(node_space, (Box, Discrete)), (
-            f"Values of the node_space should be instances of Box or Discrete, got {type(node_space)}"
-        )
-        if edge_space is not None:
-            assert isinstance(edge_space, (Box, Discrete)), (
-                f"Values of the edge_space should be instances of None Box or Discrete, got {type(edge_space)}"
-            )
-
         self.node_space = node_space
         self.edge_space = edge_space
 
@@ -87,27 +74,6 @@ class Graph(Space[GraphInstance]):
     def is_np_flattenable(self) -> Literal[False]:
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return False
-
-    def _generate_sample_space(
-        self, base_space: None | Box | Discrete, num: int
-    ) -> Box | MultiDiscrete | None:
-        if num == 0 or base_space is None:
-            return None
-
-        if isinstance(base_space, Box):
-            return Box(
-                low=np.array(max(1, num) * [base_space.low]),
-                high=np.array(max(1, num) * [base_space.high]),
-                shape=(num,) + base_space.shape,
-                dtype=base_space.dtype,
-                seed=self.np_random,
-            )
-        elif isinstance(base_space, Discrete):
-            return MultiDiscrete(nvec=[int(base_space.n)] * num, seed=self.np_random)
-        else:
-            raise TypeError(
-                f"Expects base space to be Box and Discrete, actual space: {type(base_space)}."
-            )
 
     def seed(
         self, seed: int | tuple[int, int] | tuple[int, int, int] | None = None
@@ -201,10 +167,10 @@ class Graph(Space[GraphInstance]):
         """Generates a single sample graph with num_nodes between ``1`` and ``10`` sampled from the Graph.
 
         Args:
-            mask: An optional tuple of optional node and edge mask that is only possible with Discrete spaces
+            mask: An optional tuple of optional node and edge mask
                 (Box spaces don't support sample masks).
                 If no ``num_edges`` is provided then the ``edge_mask`` is multiplied by the number of edges
-            probability: An optional tuple of optional node and edge probability mask that is only possible with Discrete spaces
+            probability: An optional tuple of optional node and edge probability mask
                 (Box spaces don't support sample probability masks).
                 If no ``num_edges`` is provided then the ``edge_mask`` is multiplied by the number of edges
             num_nodes: The number of nodes that will be sampled, the default is `10` nodes
@@ -250,9 +216,21 @@ class Graph(Space[GraphInstance]):
             )
         assert num_edges is not None
 
-        sampled_node_space = self._generate_sample_space(self.node_space, num_nodes)
-        assert sampled_node_space is not None
-        sampled_edge_space = self._generate_sample_space(self.edge_space, num_edges)
+        sampled_node_space = None
+        sampled_edge_space = None
+
+        if num_nodes != 0 and self.node_space is not None:
+            _ = self.node_space.np_random.random()
+            sampled_node_space = gym.vector.utils.batch_space(
+                self.node_space, num_nodes
+            )
+            assert sampled_node_space is not None
+
+        if num_edges != 0 and self.edge_space is not None:
+            _ = self.edge_space.np_random.random()
+            sampled_edge_space = gym.vector.utils.batch_space(
+                self.edge_space, num_edges
+            )
 
         # ty can't infer typed dictionaries (yet?)
         node_sample_kwargs: dict[str, Any]
@@ -279,30 +257,40 @@ class Graph(Space[GraphInstance]):
 
     def contains(self, x: GraphInstance) -> bool:
         """Return boolean specifying if x is a valid member of this space."""
-        if isinstance(x, GraphInstance):
-            # Checks the nodes
-            if isinstance(x.nodes, np.ndarray):
-                if all(node in self.node_space for node in x.nodes):
-                    # Check the edges and edge links which are optional
-                    if isinstance(x.edges, np.ndarray) and isinstance(
-                        x.edge_links, np.ndarray
-                    ):
-                        assert x.edges is not None
-                        assert x.edge_links is not None
-                        if self.edge_space is not None:
-                            if all(edge in self.edge_space for edge in x.edges):
-                                if np.issubdtype(x.edge_links.dtype, np.integer):
-                                    if x.edge_links.shape == (len(x.edges), 2):
-                                        if np.all(
-                                            np.logical_and(
-                                                x.edge_links >= 0,
-                                                x.edge_links < len(x.nodes),
-                                            )
-                                        ):
-                                            return True
-                    else:
-                        return x.edges is None and x.edge_links is None
-        return False
+        if not isinstance(x, GraphInstance):
+            return False
+
+        if not isinstance(x.nodes, Iterable):
+            return False
+
+        if not all(node in self.node_space for node in x.nodes):
+            return False
+
+        # Check the edges and edge links which are optional
+        if isinstance(x.edges, Iterable) and isinstance(x.edge_links, np.ndarray):
+            if self.edge_space is None:
+                return False
+
+            if not all(edge in self.edge_space for edge in x.edges):
+                return False
+
+            if not np.issubdtype(x.edge_links.dtype, np.integer):
+                return False
+
+            if not x.edge_links.shape == (len(x.edges), 2):
+                return False
+
+            if not np.all(
+                np.logical_and(
+                    x.edge_links >= 0,
+                    x.edge_links < len(x.nodes),
+                )
+            ):
+                return False
+
+            return True
+
+        return x.edges is None and x.edge_links is None
 
     def __repr__(self) -> str:
         """A string representation of this space.

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -96,9 +96,7 @@ def _flatdim_dict(space: Dict) -> int:
 
 @flatdim.register(Graph)
 def _flatdim_graph(space: Graph):
-    raise ValueError(
-        "Cannot get flattened size as the Graph Space in Gym has a dynamic size."
-    )
+    raise ValueError("Cannot get flattened size as the Graph Space has a dynamic size.")
 
 
 @flatdim.register(Text)
@@ -208,32 +206,36 @@ def _flatten_dict(space: Dict, x: dict[str, Any]) -> dict[str, Any] | NDArray[An
 
 @flatten.register(Graph)
 def _flatten_graph(space: Graph, x: GraphInstance) -> GraphInstance:
-    """We're not using ``.unflatten()`` for :class:`Box` and :class:`Discrete` because a graph is not a homogeneous space, see `.flatten` docstring."""
+    """The nodes and edges should be an instances of a batched of a flattened node/edge space."""
+    flat_node_space = flatten_space(space.node_space)
+    flattened_nodes = list(
+        flatten(space.node_space, node)
+        for node in gym.vector.utils.iterate(space.batch_node_space, x.nodes)
+    )
+    node_out = gym.vector.utils.create_empty_array(
+        flat_node_space, n=len(flattened_nodes)
+    )
+    concat_flat_nodes = gym.vector.utils.concatenate(
+        flat_node_space, flattened_nodes, node_out
+    )
 
-    def _graph_unflatten(
-        unflatten_space: Discrete | Box | None,
-        unflatten_x: NDArray[Any] | None,
-    ) -> NDArray[Any] | None:
-        ret = None
-        if unflatten_space is not None and unflatten_x is not None:
-            if isinstance(unflatten_space, Box):
-                ret = unflatten_x.reshape(unflatten_x.shape[0], -1)
-            else:
-                assert isinstance(unflatten_space, Discrete)
-                ret = np.zeros(
-                    (unflatten_x.shape[0], unflatten_space.n - unflatten_space.start),
-                    dtype=unflatten_space.dtype,
-                )
-                ret[
-                    np.arange(unflatten_x.shape[0]), unflatten_x - unflatten_space.start
-                ] = 1
-        return ret
+    if x.edges is not None:
+        assert space.edge_space is not None
+        flat_edge_space = flatten_space(space.edge_space)
+        flattened_edges = list(
+            flatten(space.edge_space, edge)
+            for edge in gym.vector.utils.iterate(space.batch_edge_space, x.edges)
+        )
+        edge_out = gym.vector.utils.create_empty_array(
+            flat_edge_space, n=len(flattened_edges)
+        )
+        concat_flat_edges = gym.vector.utils.concatenate(
+            flat_edge_space, flattened_edges, edge_out
+        )
+    else:
+        concat_flat_edges = None
 
-    nodes = _graph_unflatten(space.node_space, x.nodes)
-    assert nodes is not None
-    edges = _graph_unflatten(space.edge_space, x.edges)
-
-    return GraphInstance(nodes, edges, x.edge_links)
+    return GraphInstance(concat_flat_nodes, concat_flat_edges, x.edge_links)
 
 
 @flatten.register(Text)

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -391,20 +391,33 @@ def _unflatten_graph(space: Graph, x: GraphInstance) -> GraphInstance:
     The size of the outcome is actually not fixed, but determined based on the number of
     nodes and edges in the graph.
     """
+    flat_nodes = list(
+        gym.vector.utils.iterate(flatten_space(space.node_space), x.nodes)
+    )
+    unflat_nodes = [unflatten(space.node_space, flat_node) for flat_node in flat_nodes]
+    node_out = gym.vector.utils.create_empty_array(space.node_space, n=len(flat_nodes))
+    concat_unflat_nodes = gym.vector.utils.concatenate(
+        space.node_space, unflat_nodes, node_out
+    )
 
-    def _graph_unflatten(unflatten_space, unflatten_x):
-        result = None
-        if unflatten_space is not None and unflatten_x is not None:
-            if isinstance(unflatten_space, Box):
-                result = unflatten_x.reshape(-1, *unflatten_space.shape)
-            elif isinstance(unflatten_space, Discrete):
-                result = np.asarray(np.nonzero(unflatten_x))[-1, :]
-        return result
+    if x.edges is not None:
+        assert space.edge_space is not None
+        flat_edges = list(
+            gym.vector.utils.iterate(flatten_space(space.edge_space), x.edges)
+        )
+        unflat_edges = [
+            unflatten(space.edge_space, flat_node) for flat_node in flat_edges
+        ]
+        edge_out = gym.vector.utils.create_empty_array(
+            space.edge_space, n=len(unflat_edges)
+        )
+        concat_unflat_edges = gym.vector.utils.concatenate(
+            space.edge_space, unflat_edges, edge_out
+        )
+    else:
+        concat_unflat_edges = None
 
-    nodes = _graph_unflatten(space.node_space, x.nodes)
-    edges = _graph_unflatten(space.edge_space, x.edges)
-
-    return GraphInstance(nodes, edges, x.edge_links)
+    return GraphInstance(concat_unflat_nodes, concat_unflat_edges, x.edge_links)
 
 
 @unflatten.register(Text)

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import operator as op
 from functools import reduce, singledispatch
-from typing import Any, TypeVar
+from typing import Any, TypeAlias, TypeVar
 
 import numpy as np
 from numpy.typing import NDArray
@@ -110,7 +110,7 @@ def _flatdim_oneof(space: OneOf) -> int:
 
 
 T = TypeVar("T")
-FlatType = NDArray[Any] | dict[str, Any] | tuple[Any, ...] | GraphInstance
+FlatType: TypeAlias = NDArray[Any] | dict[str, Any] | tuple[Any, ...] | GraphInstance
 
 
 @singledispatch

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -480,8 +480,9 @@ def create_empty_array(
         >>> from gymnasium.spaces import Box, Dict
         >>> import numpy as np
         >>> space = Dict({
-        ... 'position': Box(low=0, high=1, shape=(3,), dtype=np.float32),
-        ... 'velocity': Box(low=0, high=1, shape=(2,), dtype=np.float32)})
+        ...     'position': Box(low=0, high=1, shape=(3,), dtype=np.float32),
+        ...     'velocity': Box(low=0, high=1, shape=(2,), dtype=np.float32),
+        ... })
         >>> create_empty_array(space, n=2, fn=np.zeros)
         {'position': array([[0., 0., 0.],
                [0., 0., 0.]], dtype=float32), 'velocity': array([[0., 0.],

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -510,27 +510,20 @@ def _create_empty_array_dict(
 def _create_empty_array_graph(
     space: Graph, n: int = 1, fn: Callable = np.zeros
 ) -> tuple[GraphInstance, ...]:
-    if space.edge_space is not None:
-        assert space.node_space.shape is not None
-        assert space.edge_space.shape is not None
-        return tuple(
-            GraphInstance(
-                nodes=fn((1,) + space.node_space.shape, dtype=space.node_space.dtype),
-                edges=fn((1,) + space.edge_space.shape, dtype=space.edge_space.dtype),
-                edge_links=fn((1, 2), dtype=np.int64),
-            )
-            for _ in range(n)
+    return tuple(
+        GraphInstance(
+            nodes=create_empty_array(space.node_space, n=1, fn=fn),
+            edges=(
+                create_empty_array(space.edge_space, n=1, fn=fn)
+                if space.edge_space is not None
+                else None
+            ),
+            edge_links=(
+                fn((1, 2), dtype=np.int64) if space.edge_space is not None else None
+            ),
         )
-    else:
-        assert space.node_space.shape is not None
-        return tuple(
-            GraphInstance(
-                nodes=fn((1,) + space.node_space.shape, dtype=space.node_space.dtype),
-                edges=None,
-                edge_links=None,
-            )
-            for _ in range(n)
-        )
+        for _ in range(n)
+    )
 
 
 @create_empty_array.register(Text)

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -525,27 +525,20 @@ def _create_empty_array_dict(
 def _create_empty_array_graph(
     space: Graph, n: int = 1, fn: Callable = np.zeros
 ) -> tuple[GraphInstance, ...]:
-    if space.edge_space is not None:
-        assert space.node_space.shape is not None
-        assert space.edge_space.shape is not None
-        return tuple(
-            GraphInstance(
-                nodes=fn((1,) + space.node_space.shape, dtype=space.node_space.dtype),
-                edges=fn((1,) + space.edge_space.shape, dtype=space.edge_space.dtype),
-                edge_links=fn((1, 2), dtype=np.int64),
-            )
-            for _ in range(n)
+    return tuple(
+        GraphInstance(
+            nodes=create_empty_array(space.node_space, n=1, fn=fn),
+            edges=(
+                create_empty_array(space.edge_space, n=1, fn=fn)
+                if space.edge_space is not None
+                else None
+            ),
+            edge_links=(
+                fn((1, 2), dtype=np.int64) if space.edge_space is not None else None
+            ),
         )
-    else:
-        assert space.node_space.shape is not None
-        return tuple(
-            GraphInstance(
-                nodes=fn((1,) + space.node_space.shape, dtype=space.node_space.dtype),
-                edges=None,
-                edge_links=None,
-            )
-            for _ in range(n)
-        )
+        for _ in range(n)
+    )
 
 
 @create_empty_array.register(Text)

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -465,8 +465,9 @@ def create_empty_array(
         >>> from gymnasium.spaces import Box, Dict
         >>> import numpy as np
         >>> space = Dict({
-        ... 'position': Box(low=0, high=1, shape=(3,), dtype=np.float32),
-        ... 'velocity': Box(low=0, high=1, shape=(2,), dtype=np.float32)})
+        ...     'position': Box(low=0, high=1, shape=(3,), dtype=np.float32),
+        ...     'velocity': Box(low=0, high=1, shape=(2,), dtype=np.float32),
+        ... })
         >>> create_empty_array(space, n=2, fn=np.zeros)
         {'position': array([[0., 0., 0.],
                [0., 0., 0.]], dtype=float32), 'velocity': array([[0., 0.],

--- a/gymnasium/wrappers/utils.py
+++ b/gymnasium/wrappers/utils.py
@@ -139,13 +139,24 @@ def _create_text_zero_array(space: Text):
     return "".join(space.characters[0] for _ in range(space.min_length))
 
 
+def expand_dims(sample, axis=0):
+    if isinstance(sample, (list, tuple)):
+        expanded_sample = [expand_dims(i) for i in sample]
+        return expanded_sample
+    elif isinstance(sample, dict):
+        expanded_sample = {k: expand_dims(v) for k, v in sample.items()}
+        return expanded_sample
+    else:
+        return np.expand_dims(sample, axis=axis)
+
+
 @create_zero_array.register(Graph)
 def _create_graph_zero_array(space: Graph):
-    nodes = np.expand_dims(create_zero_array(space.node_space), axis=0)
+    nodes = expand_dims(create_zero_array(space.node_space), axis=0)
     if space.edge_space is None:
         return GraphInstance(nodes=nodes, edges=None, edge_links=None)
     else:
-        edges = np.expand_dims(create_zero_array(space.edge_space), axis=0)
+        edges = expand_dims(create_zero_array(space.edge_space), axis=0)
         edge_links = np.zeros((1, 2), dtype=np.int64)
         return GraphInstance(nodes=nodes, edges=edges, edge_links=edge_links)
 

--- a/gymnasium/wrappers/utils.py
+++ b/gymnasium/wrappers/utils.py
@@ -8,6 +8,7 @@ from typing import TypeVar
 
 import numpy as np
 
+import gymnasium as gym
 from gymnasium import Space
 from gymnasium.error import CustomSpaceError
 from gymnasium.spaces import (
@@ -139,24 +140,14 @@ def _create_text_zero_array(space: Text):
     return "".join(space.characters[0] for _ in range(space.min_length))
 
 
-def expand_dims(sample, axis=0):
-    if isinstance(sample, (list, tuple)):
-        expanded_sample = [expand_dims(i) for i in sample]
-        return expanded_sample
-    elif isinstance(sample, dict):
-        expanded_sample = {k: expand_dims(v) for k, v in sample.items()}
-        return expanded_sample
-    else:
-        return np.expand_dims(sample, axis=axis)
-
-
 @create_zero_array.register(Graph)
 def _create_graph_zero_array(space: Graph):
-    nodes = expand_dims(create_zero_array(space.node_space), axis=0)
+    nodes = create_zero_array(gym.vector.utils.batch_space(space.node_space, 1))
+
     if space.edge_space is None:
         return GraphInstance(nodes=nodes, edges=None, edge_links=None)
     else:
-        edges = expand_dims(create_zero_array(space.edge_space), axis=0)
+        edges = create_zero_array(gym.vector.utils.batch_space(space.edge_space, 1))
         edge_links = np.zeros((1, 2), dtype=np.int64)
         return GraphInstance(nodes=nodes, edges=edges, edge_links=edge_links)
 

--- a/tests/spaces/test_graph.py
+++ b/tests/spaces/test_graph.py
@@ -34,6 +34,17 @@ def test_node_space_sample():
         sample = space.sample(num_edges=5)
         assert sample in space
 
+    # Change the node_space or edge_space to a non-Box or discrete space.
+    # This should not happen, test is primarily to increase coverage.
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            "The space provided to `batch_space` is not a gymnasium Space instance, type: <class 'str'>, abc"
+        ),
+    ):
+        space.node_space = "abc"
+        space.sample()
+
 
 def test_edge_space_sample():
     space = Graph(node_space=Discrete(3), edge_space=Discrete(3))

--- a/tests/spaces/test_graph.py
+++ b/tests/spaces/test_graph.py
@@ -34,17 +34,6 @@ def test_node_space_sample():
         sample = space.sample(num_edges=5)
         assert sample in space
 
-    # Change the node_space or edge_space to a non-Box or discrete space.
-    # This should not happen, test is primarily to increase coverage.
-    with pytest.raises(
-        TypeError,
-        match=re.escape(
-            "Expects base space to be Box and Discrete, actual space: <class 'str'>"
-        ),
-    ):
-        space.node_space = "abc"
-        space.sample()
-
 
 def test_edge_space_sample():
     space = Graph(node_space=Discrete(3), edge_space=Discrete(3))

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -155,7 +155,7 @@ def test_flatten_roundtripping(space):
 
     flattened_samples = [utils.flatten(space, sample) for sample in samples]
     unflattened_samples = [
-        utils.unflatten(space, sample) for sample in flattened_samples
+        utils.unflatten(space, flat_sample) for flat_sample in flattened_samples
     ]
 
     for original, roundtripped in zip(samples, unflattened_samples, strict=True):

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -61,6 +61,13 @@ TESTING_SPACES_EXPECTED_FLATDIMS = [
     None,
     None,
     None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
+    None,
     # Sequence
     None,
     None,

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -60,6 +60,7 @@ TESTING_SPACES_EXPECTED_FLATDIMS = [
     None,
     None,
     None,
+    None,
     # Sequence
     None,
     None,

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -68,6 +68,15 @@ TESTING_SPACES_EXPECTED_FLATDIMS = [
     None,
     None,
     None,
+    # Graph (non-functional subspaces)
+    # None,
+    # None,
+    # None,
+    # None,
+    # None,
+    # None,
+    # None,
+    # None,
     # Sequence
     None,
     None,

--- a/tests/spaces/utils.py
+++ b/tests/spaces/utils.py
@@ -104,6 +104,12 @@ TESTING_COMPOSITE_SPACES = [
     Graph(node_space=Box(low=-100, high=100, shape=(3, 4)), edge_space=Discrete(5)),
     Graph(node_space=Discrete(5), edge_space=Box(low=-100, high=100, shape=(3, 4))),
     Graph(node_space=Discrete(3), edge_space=Discrete(4)),
+    Graph(
+        node_space=Dict(
+            {"node_feature_1": Discrete(5), "node_feature_2": MultiBinary(5)}
+        ),
+        edge_space=Box(low=1, high=4),
+    ),
     # Sequence spaces
     Sequence(Discrete(4)),
     Sequence(Dict({"feature": Box(0, 1, (3,))})),

--- a/tests/spaces/utils.py
+++ b/tests/spaces/utils.py
@@ -110,6 +110,27 @@ TESTING_COMPOSITE_SPACES = [
         ),
         edge_space=Box(low=1, high=4),
     ),
+    # Graph spaces with arbitrary node/edge spaces
+    Graph(node_space=MultiBinary(4), edge_space=None),
+    Graph(node_space=MultiDiscrete([3, 4, 2]), edge_space=Discrete(3)),
+    Graph(node_space=Tuple((Box(-1, 1, shape=(2,)), Discrete(3))), edge_space=None),
+    Graph(
+        node_space=Discrete(4), edge_space=Tuple((Box(0, 1, shape=(2,)), Discrete(3)))
+    ),
+    Graph(
+        node_space=Discrete(3),
+        edge_space=Dict({"weight": Box(0, 1, shape=()), "type": Discrete(4)}),
+    ),
+    Graph(
+        node_space=Dict({"pos": Box(-10, 10, shape=(3,)), "label": Discrete(5)}),
+        edge_space=Dict({"weight": Box(0, 1, shape=()), "type": Discrete(3)}),
+    ),
+    Graph(
+        node_space=Tuple((Dict({"a": Discrete(3)}), MultiBinary(2))),
+        edge_space=Tuple((Discrete(4), Box(0, 1, shape=(2,)))),
+    ),
+    # Note: Text, Sequence, Graph, and OneOf as node/edge spaces have broken
+    # JSON serialization in Graph.to_jsonable/from_jsonable
     # Sequence spaces
     Sequence(Discrete(4)),
     Sequence(Dict({"feature": Box(0, 1, (3,))})),

--- a/tests/spaces/utils.py
+++ b/tests/spaces/utils.py
@@ -131,6 +131,21 @@ TESTING_COMPOSITE_SPACES = [
     ),
     # Note: Text, Sequence, Graph, and OneOf as node/edge spaces have broken
     # JSON serialization in Graph.to_jsonable/from_jsonable
+    # Graph(node_space=Sequence(Discrete(3)), edge_space=None),
+    # Graph(node_space=Discrete(3), edge_space=Sequence(Box(0, 1, shape=(2,)))),
+    # Graph(
+    #     node_space=Graph(node_space=Box(-1, 1, shape=(2,)), edge_space=None),
+    #     edge_space=None,
+    # ),
+    # Graph(
+    #     node_space=Discrete(3),
+    #     edge_space=Graph(node_space=Box(-1, 1, shape=(2,)), edge_space=None),
+    # ),
+    # Graph(node_space=OneOf([Discrete(3), Box(0, 1)]), edge_space=None),
+    # Graph(node_space=Discrete(3), edge_space=OneOf([Discrete(3), Box(0, 1)])),
+    # Graph(node_space=Text(6), edge_space=None),
+    # Graph(node_space=Discrete(3), edge_space=Text(6)),
+    #
     # Sequence spaces
     Sequence(Discrete(4)),
     Sequence(Dict({"feature": Box(0, 1, (3,))})),


### PR DESCRIPTION
# Description

Updated graph spaces to accept arbitrary node and edge spaces.  Motivation was to support heterogeneous graphs, or dictionaries of named features, or similar.

Now supports Dict and Tuple spaces for nodes and edges.  

Still needs more work to support Text, Sequence, Graph, and OneOf spaces for nodes/edges.  This seems to be pretty involved and I'm not ready to take that on right now.

Fixes #1501
Fixes #706 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
