### PR TITLE
Add reset_bounds info to CartPole reset() info dict

### DIFF
--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -243,7 +243,9 @@ class CartPoleEnv(gym.Env[np.ndarray, int | np.ndarray]):
 
         if self.render_mode == "human":
             self.render()
-        return np.array(self.state, dtype=np.float32), {}
+        #returning some useful data instead of an empty dictonary in every case
+        return np.array(self.state, dtype=np.float32), {"reset_bounds": (low, high)}
+
 
     def render(self):
         if self.render_mode is None:


### PR DESCRIPTION
# Description

The env.reset() method was returning an empty dictionary along with the state so I added some information in that.

Fixes # (issue)
Not originated from an issue.

## good first issue

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

able.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
