### PR TITLE
Fix TransformObservation __init__()

### DIFF
--- a/gymnasium/wrappers/transform_observation.py
+++ b/gymnasium/wrappers/transform_observation.py
@@ -73,7 +73,7 @@ class TransformObservation(
         self,
         env: gym.Env[ObsType, ActType],
         func: Callable[[ObsType], Any],
-        observation_space: gym.Space[WrapperObsType] | None,
+        observation_space: gym.Space[WrapperObsType] = None,
     ):
         """Constructor for the transform observation wrapper.
 


### PR DESCRIPTION
Obviously, it was intended for `__init__()` here to not require observation_space to be provided, so I replaced the pipe symbol with "=", as the pipe before None means "or no type", not None as the default.

It broke my old code.