### PR TITLE
Add `RepeatAction` wrapper

### DIFF
--- a/docs/api/wrappers/action_wrappers.md
+++ b/docs/api/wrappers/action_wrappers.md
@@ -15,4 +15,5 @@
 .. autoclass:: gymnasium.wrappers.ClipAction
 .. autoclass:: gymnasium.wrappers.RescaleAction
 .. autoclass:: gymnasium.wrappers.StickyAction
+.. autoclass:: gymnasium.wrappers.RepeatAction
 ```

--- a/docs/api/wrappers/table.md
+++ b/docs/api/wrappers/table.md
@@ -68,6 +68,8 @@ wrapper in the page on the wrapper type
       - Reshapes Array based observations to a specified shape.
     * - :class:`ResizeObservation`
       - Resizes image observations using OpenCV to a specified shape.
+    * - :class:`RepeatAction`
+      - Repeats an action ``N`` times, returning the cumulative reward and last observation / info.
     * - :class:`StickyAction`
       - Adds a probability that the action is repeated for the same ``step`` function.
     * - :class:`TimeAwareObservation`

--- a/gymnasium/wrappers/__init__.py
+++ b/gymnasium/wrappers/__init__.py
@@ -65,7 +65,7 @@ from gymnasium.wrappers.rendering import (
     RecordVideo,
     RenderCollection,
 )
-from gymnasium.wrappers.stateful_action import StickyAction
+from gymnasium.wrappers.stateful_action import ActionRepeat, StickyAction
 from gymnasium.wrappers.stateful_observation import (
     DelayObservation,
     FrameStackObservation,
@@ -120,6 +120,7 @@ __all__ = [
     "RescaleAction",
     # "NanAction",
     "StickyAction",
+    "ActionRepeat",
     # --- Reward wrappers ---
     "ClipReward",
     "TransformReward",

--- a/gymnasium/wrappers/__init__.py
+++ b/gymnasium/wrappers/__init__.py
@@ -65,7 +65,7 @@ from gymnasium.wrappers.rendering import (
     RecordVideo,
     RenderCollection,
 )
-from gymnasium.wrappers.stateful_action import ActionRepeat, StickyAction
+from gymnasium.wrappers.stateful_action import RepeatAction, StickyAction
 from gymnasium.wrappers.stateful_observation import (
     DelayObservation,
     FrameStackObservation,
@@ -120,7 +120,7 @@ __all__ = [
     "RescaleAction",
     # "NanAction",
     "StickyAction",
-    "ActionRepeat",
+    "RepeatAction",
     # --- Reward wrappers ---
     "ClipReward",
     "TransformReward",

--- a/gymnasium/wrappers/stateful_action.py
+++ b/gymnasium/wrappers/stateful_action.py
@@ -1,4 +1,4 @@
-"""Stateful action wrappers - ``StickyAction`` and ``ActionRepeat``."""
+"""Stateful action wrappers - ``StickyAction`` and ``RepeatAction``."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ import gymnasium as gym
 from gymnasium.core import ActType, ObsType, WrapperActType, WrapperObsType
 from gymnasium.error import InvalidBound, InvalidProbability
 
-__all__ = ["StickyAction", "ActionRepeat"]
+__all__ = ["StickyAction", "RepeatAction"]
 
 
 class StickyAction(
@@ -135,7 +135,7 @@ class StickyAction(
         return action
 
 
-class ActionRepeat(
+class RepeatAction(
     gym.Wrapper[ObsType, ActType, ObsType, ActType], gym.utils.RecordConstructorArgs
 ):
     """Repeats the given action for ``num_repeats`` steps, accumulating the reward.
@@ -156,7 +156,7 @@ class ActionRepeat(
     Example:
         >>> import gymnasium as gym
         >>> env = gym.make("CartPole-v1")
-        >>> env = ActionRepeat(env, num_repeats=4)
+        >>> env = RepeatAction(env, num_repeats=4)
         >>> obs, info = env.reset(seed=123)
         >>> obs, reward, terminated, truncated, info = env.step(1)
         >>> reward  # sum of 4 inner-step rewards

--- a/gymnasium/wrappers/stateful_action.py
+++ b/gymnasium/wrappers/stateful_action.py
@@ -1,16 +1,16 @@
-"""``StickyAction`` wrapper - There is a probability that the action is taken again."""
+"""Stateful action wrappers - ``StickyAction`` and ``ActionRepeat``."""
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, SupportsFloat
 
 import numpy as np
 
 import gymnasium as gym
-from gymnasium.core import ActType, ObsType
+from gymnasium.core import ActType, ObsType, WrapperActType, WrapperObsType
 from gymnasium.error import InvalidBound, InvalidProbability
 
-__all__ = ["StickyAction"]
+__all__ = ["StickyAction", "ActionRepeat"]
 
 
 class StickyAction(
@@ -133,3 +133,81 @@ class StickyAction(
 
         self.last_action = action
         return action
+
+
+class ActionRepeat(
+    gym.Wrapper[ObsType, ActType, ObsType, ActType], gym.utils.RecordConstructorArgs
+):
+    """Repeats the given action for ``num_repeats`` steps, accumulating the reward.
+
+    This is useful for environments where the agent does not need to make
+    a decision at every time step. By repeating actions, the effective
+    decision frequency is reduced, which can speed up training and make
+    exploration more efficient.
+
+    Unlike :class:`StickyAction`, which *stochastically* replaces the agent's
+    action with the *previous* action, ``ActionRepeat`` *deterministically*
+    executes the *current* action multiple times and returns the accumulated
+    reward together with the final observation. If the episode terminates or
+    is truncated during repetition, the loop stops early.
+
+    No vector version of the wrapper exists.
+
+    Example:
+        >>> import gymnasium as gym
+        >>> env = gym.make("CartPole-v1")
+        >>> env = ActionRepeat(env, num_repeats=4)
+        >>> obs, info = env.reset(seed=123)
+        >>> obs, reward, terminated, truncated, info = env.step(1)
+        >>> reward  # sum of 4 inner-step rewards
+        4.0
+
+    Change logs:
+     * v1.3.0 - Initially added
+    """
+
+    def __init__(self, env: gym.Env[ObsType, ActType], num_repeats: int):
+        """Initialize ActionRepeat wrapper.
+
+        Args:
+            env (Env): The wrapped environment.
+            num_repeats (int): The number of times to repeat each action.
+        """
+        if not np.issubdtype(type(num_repeats), np.integer):
+            raise TypeError(
+                f"The num_repeats is expected to be an integer, actual type: {type(num_repeats)}"
+            )
+        if num_repeats < 1:
+            raise ValueError(
+                f"The num_repeats value needs to be equal or greater than one, actual value: {num_repeats}"
+            )
+
+        gym.utils.RecordConstructorArgs.__init__(self, num_repeats=num_repeats)
+        gym.Wrapper.__init__(self, env)
+
+        self.num_repeats = num_repeats
+
+    def step(
+        self, action: WrapperActType
+    ) -> tuple[WrapperObsType, SupportsFloat, bool, bool, dict[str, Any]]:
+        """Step the environment, repeating the action for ``num_repeats`` steps.
+
+        The reward returned is the sum of rewards from all inner steps.
+        If the episode terminates or is truncated during repetition,
+        the loop stops early.
+
+        Args:
+            action: The action to repeat.
+
+        Returns:
+            The last observation, accumulated reward, terminated, truncated, and info.
+        """
+        total_reward = 0.0
+        terminated = truncated = False
+        info: dict[str, Any] = {}
+        for _ in range(self.num_repeats):
+            obs, reward, terminated, truncated, info = self.env.step(action)
+            total_reward += float(reward)
+            if terminated or truncated:
+                break
+        return obs, total_reward, terminated, truncated, info

--- a/tests/wrappers/test_action_repeat.py
+++ b/tests/wrappers/test_action_repeat.py
@@ -1,0 +1,151 @@
+"""Test suite for ActionRepeat wrapper."""
+
+import numpy as np
+import pytest
+
+import gymnasium as gym
+from gymnasium.spaces import Discrete
+from gymnasium.wrappers.stateful_action import ActionRepeat
+from tests.testing_env import GenericTestEnv
+
+
+def _counting_step(self, action):
+    """Step function that returns an incrementing reward and the action as obs."""
+    self._step_count = getattr(self, "_step_count", 0) + 1
+    return action, float(self._step_count), False, False, {"step": self._step_count}
+
+
+def _terminating_step(self, action):
+    """Step function that terminates after 3 steps."""
+    self._step_count = getattr(self, "_step_count", 0) + 1
+    terminated = self._step_count >= 3
+    return action, 1.0, terminated, False, {"step": self._step_count}
+
+
+def test_action_repeat_exact_steps():
+    """Test that exactly num_repeats inner steps are taken using GenericTestEnv."""
+    env = ActionRepeat(
+        GenericTestEnv(
+            step_func=_counting_step,
+            action_space=Discrete(5),
+            observation_space=Discrete(5),
+        ),
+        num_repeats=3,
+    )
+    env.reset()
+    obs, reward, _, _, info = env.step(2)
+    # Rewards: 1.0 + 2.0 + 3.0 = 6.0 (proving exactly 3 inner steps)
+    assert reward == 6.0
+    assert info["step"] == 3  # info from last inner step
+    assert obs == 2  # action passed through as observation
+
+
+def test_action_repeat_reward_accumulation():
+    """Test that rewards from repeated steps are summed correctly."""
+    env = gym.make("CartPole-v1")
+
+    # Without wrapper: step 4 times manually
+    env.reset(seed=42)
+    total_reward_manual = 0.0
+    for _ in range(4):
+        obs_manual, reward, term, trunc, _ = env.step(1)
+        total_reward_manual += reward
+        if term or trunc:
+            break
+
+    # With wrapper: single step should accumulate 4 rewards
+    env2 = gym.make("CartPole-v1")
+    wrapped_env = ActionRepeat(env2, num_repeats=4)
+    wrapped_env.reset(seed=42)
+    obs_wrapped, reward_wrapped, _, _, _ = wrapped_env.step(1)
+
+    assert reward_wrapped == total_reward_manual
+    assert np.array_equal(obs_wrapped, obs_manual)
+
+
+def test_action_repeat_early_termination():
+    """Test that repetition stops early on termination."""
+    env = ActionRepeat(
+        GenericTestEnv(
+            step_func=_terminating_step,
+            action_space=Discrete(3),
+            observation_space=Discrete(3),
+        ),
+        num_repeats=10,
+    )
+    env.reset()
+    _, reward, terminated, _, info = env.step(0)
+    # Environment terminates at step 3, so only 3 inner steps taken
+    assert terminated is True
+    assert reward == 3.0  # 1.0 * 3 steps
+    assert info["step"] == 3
+
+
+def test_action_repeat_info_propagation():
+    """Test that info from the last inner step is returned."""
+    env = ActionRepeat(
+        GenericTestEnv(
+            step_func=_counting_step,
+            action_space=Discrete(5),
+            observation_space=Discrete(5),
+        ),
+        num_repeats=5,
+    )
+    env.reset()
+    _, _, _, _, info = env.step(0)
+    assert info["step"] == 5  # info from the 5th (last) inner step
+
+
+def test_action_repeat_num_repeats_one():
+    """Test that num_repeats=1 behaves identically to the unwrapped environment."""
+    env1 = gym.make("CartPole-v1")
+    env2 = gym.make("CartPole-v1")
+    wrapped_env = ActionRepeat(env2, num_repeats=1)
+
+    env1.reset(seed=42)
+    wrapped_env.reset(seed=42)
+
+    for _ in range(10):
+        action = env1.action_space.sample()
+        obs1, r1, term1, trunc1, _ = env1.step(action)
+        obs2, r2, term2, trunc2, _ = wrapped_env.step(action)
+        assert r1 == r2
+        assert term1 == term2
+        assert trunc1 == trunc2
+        assert np.array_equal(obs1, obs2)
+        if term1 or trunc1:
+            break
+
+
+def test_action_repeat_observation_space():
+    """Test that observation and action spaces are preserved."""
+    env = gym.make("CartPole-v1")
+    wrapped_env = ActionRepeat(env, num_repeats=4)
+
+    assert wrapped_env.observation_space == env.observation_space
+    assert wrapped_env.action_space == env.action_space
+
+    obs, _ = wrapped_env.reset(seed=123)
+    assert obs in wrapped_env.observation_space
+
+    for _ in range(5):
+        obs, _, term, trunc, _ = wrapped_env.step(wrapped_env.action_space.sample())
+        assert obs in wrapped_env.observation_space
+        if term or trunc:
+            obs, _ = wrapped_env.reset()
+
+
+@pytest.mark.parametrize("num_repeats", [2.5, 1.0, 3.14])
+def test_action_repeat_invalid_type(num_repeats):
+    """Test that non-integer num_repeats raises TypeError."""
+    env = gym.make("CartPole-v1")
+    with pytest.raises(TypeError, match="expected to be an integer"):
+        ActionRepeat(env, num_repeats=num_repeats)
+
+
+@pytest.mark.parametrize("num_repeats", [0, -1, -100])
+def test_action_repeat_invalid_value(num_repeats):
+    """Test that num_repeats < 1 raises ValueError."""
+    env = gym.make("CartPole-v1")
+    with pytest.raises(ValueError, match="equal or greater than one"):
+        ActionRepeat(env, num_repeats=num_repeats)

--- a/tests/wrappers/test_action_repeat.py
+++ b/tests/wrappers/test_action_repeat.py
@@ -5,7 +5,7 @@ import pytest
 
 import gymnasium as gym
 from gymnasium.spaces import Discrete
-from gymnasium.wrappers.stateful_action import ActionRepeat
+from gymnasium.wrappers.stateful_action import RepeatAction
 from tests.testing_env import GenericTestEnv
 
 
@@ -24,7 +24,7 @@ def _terminating_step(self, action):
 
 def test_action_repeat_exact_steps():
     """Test that exactly num_repeats inner steps are taken using GenericTestEnv."""
-    env = ActionRepeat(
+    env = RepeatAction(
         GenericTestEnv(
             step_func=_counting_step,
             action_space=Discrete(5),
@@ -55,7 +55,7 @@ def test_action_repeat_reward_accumulation():
 
     # With wrapper: single step should accumulate 4 rewards
     env2 = gym.make("CartPole-v1")
-    wrapped_env = ActionRepeat(env2, num_repeats=4)
+    wrapped_env = RepeatAction(env2, num_repeats=4)
     wrapped_env.reset(seed=42)
     obs_wrapped, reward_wrapped, _, _, _ = wrapped_env.step(1)
 
@@ -65,7 +65,7 @@ def test_action_repeat_reward_accumulation():
 
 def test_action_repeat_early_termination():
     """Test that repetition stops early on termination."""
-    env = ActionRepeat(
+    env = RepeatAction(
         GenericTestEnv(
             step_func=_terminating_step,
             action_space=Discrete(3),
@@ -83,7 +83,7 @@ def test_action_repeat_early_termination():
 
 def test_action_repeat_info_propagation():
     """Test that info from the last inner step is returned."""
-    env = ActionRepeat(
+    env = RepeatAction(
         GenericTestEnv(
             step_func=_counting_step,
             action_space=Discrete(5),
@@ -100,7 +100,7 @@ def test_action_repeat_num_repeats_one():
     """Test that num_repeats=1 behaves identically to the unwrapped environment."""
     env1 = gym.make("CartPole-v1")
     env2 = gym.make("CartPole-v1")
-    wrapped_env = ActionRepeat(env2, num_repeats=1)
+    wrapped_env = RepeatAction(env2, num_repeats=1)
 
     env1.reset(seed=42)
     wrapped_env.reset(seed=42)
@@ -120,7 +120,7 @@ def test_action_repeat_num_repeats_one():
 def test_action_repeat_observation_space():
     """Test that observation and action spaces are preserved."""
     env = gym.make("CartPole-v1")
-    wrapped_env = ActionRepeat(env, num_repeats=4)
+    wrapped_env = RepeatAction(env, num_repeats=4)
 
     assert wrapped_env.observation_space == env.observation_space
     assert wrapped_env.action_space == env.action_space
@@ -140,7 +140,7 @@ def test_action_repeat_invalid_type(num_repeats):
     """Test that non-integer num_repeats raises TypeError."""
     env = gym.make("CartPole-v1")
     with pytest.raises(TypeError, match="expected to be an integer"):
-        ActionRepeat(env, num_repeats=num_repeats)
+        RepeatAction(env, num_repeats=num_repeats)
 
 
 @pytest.mark.parametrize("num_repeats", [0, -1, -100])
@@ -148,4 +148,4 @@ def test_action_repeat_invalid_value(num_repeats):
     """Test that num_repeats < 1 raises ValueError."""
     env = gym.make("CartPole-v1")
     with pytest.raises(ValueError, match="equal or greater than one"):
-        ActionRepeat(env, num_repeats=num_repeats)
+        RepeatAction(env, num_repeats=num_repeats)


### PR DESCRIPTION
## Summary

Add a new `ActionRepeat` wrapper that deterministically repeats the given action for `num_repeats` steps, accumulating the reward. Closes #652.

**Key design decisions:**
- Extends `gym.Wrapper` (not `ActionWrapper`), since it changes `step()` semantics by calling the inner environment multiple times per wrapped step
- Follows the same pattern as `MaxAndSkipObservation` for multi-step execution, early termination, and reward accumulation
- Placed in `stateful_action.py` alongside `StickyAction`, with a clear docstring explaining the difference:
  - `StickyAction`: *stochastically* replaces the agent's action with the *previous* action
  - `ActionRepeat`: *deterministically* executes the *current* action N times, returning accumulated reward + final observation

**Files changed:**
- `gymnasium/wrappers/stateful_action.py` — New `ActionRepeat` class
- `gymnasium/wrappers/__init__.py` — Import and export
- `tests/wrappers/test_action_repeat.py` — 12 test cases

<details>
<summary>Before (ActionRepeat does not exist)</summary>

```
>>> from gymnasium.wrappers import ActionRepeat
Traceback (most recent call last):
  ...
ImportError: cannot import name 'ActionRepeat' from 'gymnasium.wrappers'
```

</details>

<details>
<summary>After (full test output)</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0

tests/wrappers/test_action_repeat.py::test_action_repeat_exact_steps PASSED [  1%]
tests/wrappers/test_action_repeat.py::test_action_repeat_reward_accumulation PASSED [  2%]
tests/wrappers/test_action_repeat.py::test_action_repeat_early_termination PASSED [  4%]
tests/wrappers/test_action_repeat.py::test_action_repeat_info_propagation PASSED [  5%]
tests/wrappers/test_action_repeat.py::test_action_repeat_num_repeats_one PASSED [  7%]
tests/wrappers/test_action_repeat.py::test_action_repeat_observation_space PASSED [  8%]
tests/wrappers/test_action_repeat.py::test_action_repeat_invalid_type[2.5] PASSED [  9%]
tests/wrappers/test_action_repeat.py::test_action_repeat_invalid_type[1.0] PASSED [ 11%]
tests/wrappers/test_action_repeat.py::test_action_repeat_invalid_type[3.14] PASSED [ 12%]
tests/wrappers/test_action_repeat.py::test_action_repeat_invalid_value[0] PASSED [ 14%]
tests/wrappers/test_action_repeat.py::test_action_repeat_invalid_value[-1] PASSED [ 15%]
tests/wrappers/test_action_repeat.py::test_action_repeat_invalid_value[-100] PASSED [ 16%]
tests/wrappers/test_sticky_action.py::test_sticky_action[0.25-1-actions0-expected_action0] PASSED [ 18%]
tests/wrappers/test_sticky_action.py::test_sticky_action[0.25-2-actions1-expected_action1] PASSED [ 19%]
tests/wrappers/test_sticky_action.py::test_sticky_action[0.25-repeat_action_duration2-actions2-expected_action2] PASSED [ 21%]
tests/wrappers/test_sticky_action.py::test_sticky_action_raise_probability[-1] PASSED [ 22%]
tests/wrappers/test_sticky_action.py::test_sticky_action_raise_probability[1] PASSED [ 23%]
tests/wrappers/test_sticky_action.py::test_sticky_action_raise_probability[1.5] PASSED [ 25%]
tests/wrappers/test_sticky_action.py::test_sticky_action_raise_duration[-4] PASSED [ 26%]
tests/wrappers/test_sticky_action.py::test_sticky_action_raise_duration[0] PASSED [ 28%]
tests/wrappers/test_sticky_action.py::test_sticky_action_raise_duration[repeat_action_duration2] PASSED [ 29%]
tests/wrappers/test_sticky_action.py::test_sticky_action_raise_duration[repeat_action_duration3] PASSED [ 30%]
tests/wrappers/test_sticky_action.py::test_sticky_action_raise_duration[repeat_action_duration4] PASSED [ 32%]
tests/wrappers/test_import_wrappers.py::test_import_wrappers PASSED      [ 33%]
tests/wrappers/test_import_wrappers.py::test_all_wrappers_shortened[ActionRepeat] PASSED [ 66%]
gymnasium/wrappers/stateful_action.py::gymnasium.wrappers.stateful_action.ActionRepeat PASSED [ 98%]
gymnasium/wrappers/stateful_action.py::gymnasium.wrappers.stateful_action.StickyAction PASSED [100%]

======================== 68 passed, 3 skipped in 0.22s =========================
```

</details>

## Test plan
- [x] 12 unit tests covering: exact step count, reward accumulation, early termination, info propagation, identity (num_repeats=1), observation space preservation, invalid type/value errors
- [x] All 12 `test_action_repeat.py` tests pass
- [x] All 11 existing `test_sticky_action.py` tests pass (no regression)
- [x] All 45 `test_import_wrappers.py` tests pass (ActionRepeat correctly exported)
- [x] Both doctests in `stateful_action.py` pass (StickyAction + ActionRepeat)
- [x] All pre-commit hooks pass (ruff check, ruff format, ty check, codespell)