### PR TITLE
fix incorrect `TypeVar` use in `core` for `RenderFrame`

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Generic, SupportsFloat, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, SupportsFloat, TypeAlias, TypeVar
 
 import numpy as np
 
@@ -16,7 +16,8 @@ if TYPE_CHECKING:
 
 ObsType = TypeVar("ObsType")
 ActType = TypeVar("ActType")
-RenderFrame = TypeVar("RenderFrame")
+
+RenderFrame: TypeAlias = str | np.ndarray | tuple[np.ndarray, np.ndarray]
 
 
 class Env(Generic[ObsType, ActType]):
@@ -302,7 +303,7 @@ class Wrapper(
         If you inherit from :class:`Wrapper`, don't forget to call ``super().__init__(env)``
     """
 
-    def __init__(self, env: Env[ObsType, ActType]):
+    def __init__(self, env: Env[WrapperObsType, WrapperActType]):
         """Wraps an environment to allow a modular transformation of the :meth:`step` and :meth:`reset` methods.
 
         Args:

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -33,7 +33,7 @@ __all__ = [
 
 class RenderCollection(
     gym.Wrapper[ObsType, ActType, ObsType, ActType],
-    Generic[ObsType, ActType, RenderFrame],
+    Generic[ObsType, ActType],
     gym.utils.RecordConstructorArgs,
 ):
     """Collect rendered frames of an environment such ``render`` returns a ``list[RenderedFrame]``.
@@ -161,7 +161,7 @@ class RenderCollection(
 
 class RecordVideo(
     gym.Wrapper[ObsType, ActType, ObsType, ActType],
-    Generic[ObsType, ActType, RenderFrame],
+    Generic[ObsType, ActType],
     gym.utils.RecordConstructorArgs,
 ):
     """Records videos of environment episodes using the environment's render function.


### PR DESCRIPTION
# Description

I noticed that the `RenderFrame` type variable was being used as return type, even though wasn't bound to anything, i.e. as a free type variable. As far as I'm aware, most type-checkers would interpret that as `Any`, and I'm guessing that this wasn't the intention here. 

To fix this, I changed it to a type alias instead. Judging by how it was being used in practice, I went with `str | np.ndarray | tuple[np.ndarray, np.ndarray]`, which I believe should cover all intended use-cases. 

This change resolved some `ty` warning in the relevant methods. 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation only change (no code changed)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Please attach before and after screenshots of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
