### PR TITLE
Fill in the missing type annotations in `core`

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -12,6 +12,8 @@ from gymnasium import spaces
 from gymnasium.utils import RecordConstructorArgs, seeding
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from gymnasium.envs.registration import EnvSpec, WrapperSpec
 
 ObsType = TypeVar("ObsType")
@@ -255,11 +257,11 @@ class Env(Generic[ObsType, ActType]):
         else:
             return f"<{type(self).__name__}<{self.spec.id}>>"
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         """Support with-statement for the environment."""
         return self
 
-    def __exit__(self, *args: Any):
+    def __exit__(self, *args: Any) -> bool:
         """Support with-statement for the environment and closes the environment."""
         self.close()
         # propagate exception
@@ -302,6 +304,8 @@ class Wrapper(
     Note:
         If you inherit from :class:`Wrapper`, don't forget to call ``super().__init__(env)``
     """
+
+    env: Env[WrapperObsType, WrapperActType]
 
     def __init__(self, env: Env[WrapperObsType, WrapperActType]):
         """Wraps an environment to allow a modular transformation of the :meth:`step` and :meth:`reset` methods.


### PR DESCRIPTION
# Description

On the typestats dashboard ([url](https://jorenham.github.io/typestats/dashboard/report/#gymnasium)) I saw that there were a couple of missing annotations in `gymnasium.core`, so I figured I'd fill them in.

Fixes # (issue)

## Type of change

Static typing improvements

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
