### PR TITLE
Annotate the attributes of the `error` classes

### DIFF
--- a/gymnasium/error.py
+++ b/gymnasium/error.py
@@ -72,6 +72,8 @@ class DeprecatedWrapper(ImportError):
 class AlreadyPendingCallError(Exception):
     """Raised when `reset`, or `step` is called asynchronously (e.g. with `reset_async`, or `step_async` respectively), and `reset_async`, or `step_async` (respectively) is called again (without a complete call to `reset_wait`, or `step_wait` respectively)."""
 
+    name: str
+
     def __init__(self, message: str, name: str):
         """Initialises the exception with name attributes."""
         super().__init__(message)
@@ -80,6 +82,8 @@ class AlreadyPendingCallError(Exception):
 
 class NoAsyncCallError(Exception):
     """Raised when an asynchronous `reset`, or `step` is not running, but `reset_wait`, or `step_wait` (respectively) is called."""
+
+    name: str
 
     def __init__(self, message: str, name: str):
         """Initialises the exception with name attributes."""


### PR DESCRIPTION
# Description

Same story as #1566, but for `gymnasium.error`.

## Type of change

Static typing improvements

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
