### PR TITLE
Return type annotations for the `logger` functions

### DIFF
--- a/gymnasium/logger.py
+++ b/gymnasium/logger.py
@@ -19,7 +19,7 @@ def warn(
     *args: object,
     category: type[Warning] | None = None,
     stacklevel: int = 1,
-):
+) -> None:
     """Raises a warning to the user if the min_level <= WARN.
 
     Args:
@@ -36,12 +36,12 @@ def warn(
         )
 
 
-def deprecation(msg: str, *args: object):
+def deprecation(msg: str, *args: object) -> None:
     """Logs a deprecation warning to users."""
     warn(msg, *args, category=DeprecationWarning, stacklevel=2)
 
 
-def error(msg: str, *args: object):
+def error(msg: str, *args: object) -> None:
     """Logs an error message if min_level <= ERROR in red on the sys.stderr."""
     if min_level <= ERROR:
         warnings.warn(colorize(f"ERROR: {msg % args}", "red"), stacklevel=3)


### PR DESCRIPTION
# Description

The `gymnasium.logger` functions were missing return annotations. And even though you might think that type-checkers would then assume it returns `None`, they actually tend to infer `Any` in cases like these. So it helps to to be explicit about these things and spell out the `-> None`.

Related to #1566 and #1567.

## Type of change

Static typing improvements

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
