### PR TITLE
Fix typing errors and add missing annotations in `utils`

### DIFF
--- a/gymnasium/utils/colorize.py
+++ b/gymnasium/utils/colorize.py
@@ -3,7 +3,11 @@
 These are not intended as API functions, and will not remain stable over time.
 """
 
-color2num = dict(
+from collections.abc import Mapping
+from typing import Final
+
+# We use `Mapping` instead of `dict` here because it's not intended to be modified
+color2num: Final[Mapping[str, int]] = dict(
     gray=30,
     red=31,
     green=32,

--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -16,6 +16,7 @@ These projects are covered by the MIT License.
 
 import inspect
 from copy import deepcopy
+from typing import Any
 
 import numpy as np
 
@@ -30,7 +31,7 @@ from gymnasium.utils.passive_env_checker import (
 )
 
 
-def data_equivalence(data_1, data_2, exact: bool = False) -> bool:
+def data_equivalence(data_1: Any, data_2: Any, exact: bool = False) -> bool:
     """Assert equality between data 1 and 2, i.e. observations, actions, info.
 
     Args:
@@ -61,16 +62,19 @@ def data_equivalence(data_1, data_2, exact: bool = False) -> bool:
                 )
             else:
                 if exact:
-                    return np.all(data_1 == data_2)
+                    # `np.all` returns `np.bool_`, which is incompatible with `bool`
+                    return bool(np.all(data_1 == data_2))
                 else:
                     return np.allclose(data_1, data_2, rtol=1e-5, atol=1e-5)
         else:
             return False
     else:
-        return data_1 == data_2
+        # `__eq__` doesn't always return `bool`; e.g. `np.int8() == np.int8()` returns
+        # a `np.bool_`, which is incompatible with `bool`
+        return bool(data_1 == data_2)
 
 
-def check_reset_seed_determinism(env: gym.Env):
+def check_reset_seed_determinism(env: gym.Env) -> None:
     """Check that the environment can be reset with a seed.
 
     Args:
@@ -163,7 +167,7 @@ def check_reset_seed_determinism(env: gym.Env):
         )
 
 
-def check_reset_options(env: gym.Env):
+def check_reset_options(env: gym.Env) -> None:
     """Check that the environment can be reset with options.
 
     Args:
@@ -191,7 +195,7 @@ def check_reset_options(env: gym.Env):
         )
 
 
-def check_step_determinism(env: gym.Env, seed=123):
+def check_step_determinism(env: gym.Env, seed: int = 123) -> None:
     """Check that the environment steps deterministically after reset.
 
     Note: This check assumes that seeded `reset()` is deterministic (it must have passed `check_reset_seed`) and that `step()` returns valid values (passed `env_step_passive_checker`).
@@ -209,15 +213,17 @@ def check_step_determinism(env: gym.Env, seed=123):
 
     env.reset(seed=seed)
     obs_0, rew_0, term_0, trunc_0, info_0 = env.step(action)
-    seeded_rng: np.random.Generator = deepcopy(env.unwrapped._np_random)
+
+    orig_rng = env.unwrapped._np_random
+    assert orig_rng is not None, "env.reset() should have initialized env._np_random"
+    seeded_rng: np.random.Generator = deepcopy(orig_rng)
 
     env.reset(seed=seed)
     obs_1, rew_1, term_1, trunc_1, info_1 = env.step(action)
 
-    assert (
-        env.unwrapped._np_random.bit_generator.state  # pyright: ignore [reportOptionalMemberAccess]
-        == seeded_rng.bit_generator.state
-    ), "The `.np_random` is not properly been updated after step."
+    assert orig_rng.bit_generator.state == seeded_rng.bit_generator.state, (
+        "The `.np_random` is not properly been updated after step."
+    )
 
     assert data_equivalence(obs_0, obs_1), (
         "Deterministic step observations are not equivalent for the same seed and action"
@@ -252,7 +258,7 @@ def check_step_determinism(env: gym.Env, seed=123):
         )
 
 
-def check_reset_return_info_deprecation(env: gym.Env):
+def check_reset_return_info_deprecation(env: gym.Env) -> None:
     """Makes sure support for deprecated `return_info` argument is dropped.
 
     Args:
@@ -269,7 +275,7 @@ def check_reset_return_info_deprecation(env: gym.Env):
         )
 
 
-def check_seed_deprecation(env: gym.Env):
+def check_seed_deprecation(env: gym.Env) -> None:
     """Makes sure support for deprecated function `seed` is dropped.
 
     Args:
@@ -285,7 +291,7 @@ def check_seed_deprecation(env: gym.Env):
         )
 
 
-def check_reset_return_type(env: gym.Env):
+def check_reset_return_type(env: gym.Env) -> None:
     """Checks that :meth:`reset` correctly returns a tuple of the form `(obs , info)`.
 
     Args:
@@ -310,7 +316,7 @@ def check_reset_return_type(env: gym.Env):
     )
 
 
-def check_space_limit(space, space_type: str):
+def check_space_limit(space: spaces.Space[object], space_type: str) -> None:
     """Check the space limit for only the Box space as a test that only runs as part of `check_env`."""
     if isinstance(space, spaces.Box):
         if np.any(np.equal(space.low, -np.inf)):
@@ -350,10 +356,10 @@ def check_space_limit(space, space_type: str):
 
 def check_env(
     env: gym.Env,
-    warn: bool = None,
+    warn: bool | None = None,
     skip_render_check: bool = False,
     skip_close_check: bool = False,
-):
+) -> None:
     """Check that an environment follows Gymnasium's API.
 
     .. py:currentmodule:: gymnasium.Env

--- a/gymnasium/utils/env_match.py
+++ b/gymnasium/utils/env_match.py
@@ -1,5 +1,7 @@
 """A set of tests to help the designer of gymnasium environments verify that they work correctly."""
 
+import numpy as np
+
 import gymnasium as gym
 from gymnasium.utils.env_checker import data_equivalence
 
@@ -15,7 +17,7 @@ def check_environments_match(
     skip_truncated: bool = False,
     skip_render: bool = False,
     info_comparison: str = "equivalence",
-):
+) -> None:
     """Checks if the environments `env_a` & `env_b` are identical.
 
     Args:
@@ -79,7 +81,7 @@ def check_environments_match(
         )
 
     if not skip_render:
-        assert (env_a.render() == env_b.render()).all(), (
+        assert np.all(env_a.render() == env_b.render()), (
             "resetting render is not equivalent"
         )
 
@@ -117,7 +119,7 @@ def check_environments_match(
                 f"stepping info keys are not a superset in step = {step}, keys not present in info_b are: {info_b.keys() - info_a.keys()}"
             )
         if not skip_render:
-            assert (env_a.render() == env_b.render()).all(), (
+            assert np.all(env_a.render() == env_b.render()), (
                 "stepping render is not equivalent in step = {step}"
             )
 
@@ -145,6 +147,6 @@ def check_environments_match(
                     f"resetting info keys are not a superset in step = {step}, keys not present in info_b are: {info_b.keys() - info_a.keys()}"
                 )
             if not skip_render:
-                assert (env_a.render() == env_b.render()).all(), (
+                assert np.all(env_a.render() == env_b.render()), (
                     "resetting render is not equivalent in step = {step}"
                 )

--- a/gymnasium/utils/ezpickle.py
+++ b/gymnasium/utils/ezpickle.py
@@ -19,19 +19,19 @@ class EzPickle:
     This is generally needed only for environments which wrap C/C++ code, such as MuJoCo and Atari.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any):
+    def __init__(self, *args: object, **kwargs: object) -> None:
         """Uses the ``args`` and ``kwargs`` from the object's constructor for pickling."""
         self._ezpickle_args = args
         self._ezpickle_kwargs = kwargs
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         """Returns the object pickle state with args and kwargs."""
         return {
             "_ezpickle_args": self._ezpickle_args,
             "_ezpickle_kwargs": self._ezpickle_kwargs,
         }
 
-    def __setstate__(self, d):
+    def __setstate__(self, d: dict[str, Any]) -> None:
         """Sets the object pickle state using d."""
         out = type(self)(*d["_ezpickle_args"], **d["_ezpickle_kwargs"])
         self.__dict__.update(out.__dict__)

--- a/gymnasium/utils/passive_env_checker.py
+++ b/gymnasium/utils/passive_env_checker.py
@@ -3,10 +3,12 @@
 import inspect
 from collections.abc import Callable
 from functools import partial
+from typing import Any, SupportsFloat, TypeVar, cast, overload
 
 import numpy as np
 
-from gymnasium import Space, error, logger, spaces
+from gymnasium import Env, Space, error, logger, spaces
+from gymnasium.core import RenderFrame
 
 __all__ = [
     "env_render_passive_checker",
@@ -16,8 +18,11 @@ __all__ = [
     "check_observation_space",
 ]
 
+_ObsT = TypeVar("_ObsT")
+_ActT = TypeVar("_ActT")
 
-def _check_box_observation_space(observation_space: spaces.Box):
+
+def _check_box_observation_space(observation_space: spaces.Box) -> None:
     """Checks that a :class:`Box` observation space is defined in a sensible way.
 
     Args:
@@ -36,7 +41,7 @@ def _check_box_observation_space(observation_space: spaces.Box):
         logger.warn("A Box observation space low value is greater than a high value.")
 
 
-def _check_box_action_space(action_space: spaces.Box):
+def _check_box_action_space(action_space: spaces.Box) -> None:
     """Checks that a :class:`Box` action space is defined in a sensible way.
 
     Args:
@@ -55,7 +60,7 @@ def _check_box_action_space(action_space: spaces.Box):
 
 def check_space(
     space: Space, space_type: str, check_box_space_fn: Callable[[spaces.Box], None]
-):
+) -> None:
     """A passive check of the environment action space that should not affect the environment."""
     if not isinstance(space, spaces.Space):
         if str(space.__class__.__base__) == "<class 'gym.spaces.space.Space'>":
@@ -101,17 +106,29 @@ def check_space(
             check_space(subspace, space_type, check_box_space_fn)
 
 
-check_observation_space = partial(
+check_observation_space: Callable[[Space], None] = partial(
     check_space,
     space_type="observation",
     check_box_space_fn=_check_box_observation_space,
 )
-check_action_space = partial(
+check_action_space: Callable[[Space], None] = partial(
     check_space, space_type="action", check_box_space_fn=_check_box_action_space
 )
 
 
-def check_obs(obs, observation_space: spaces.Space, method_name: str):
+@overload
+def check_obs(
+    obs: int | np.int64, observation_space: spaces.Discrete, method_name: str
+) -> None: ...
+@overload
+def check_obs(
+    obs: np.generic | np.ndarray, observation_space: spaces.Box, method_name: str
+) -> None: ...
+@overload
+def check_obs(
+    obs: _ObsT, observation_space: spaces.Space[_ObsT], method_name: str
+) -> None: ...
+def check_obs(obs: Any, observation_space: spaces.Space[Any], method_name: str) -> None:
     """Check that the observation returned by the environment correspond to the declared one.
 
     Args:
@@ -159,7 +176,9 @@ def check_obs(obs, observation_space: spaces.Space, method_name: str):
         logger.warn(f"{pre} is not within the observation space with exception: {e}")
 
 
-def env_reset_passive_checker(env, **kwargs):
+def env_reset_passive_checker(
+    env: Env[_ObsT, Any], **kwargs: Any
+) -> tuple[_ObsT, dict[str, Any]]:
     """A passive check of the `Env.reset` function investigating the returning reset information and returning the data unchanged."""
     signature = inspect.signature(env.reset)
     if "seed" not in signature.parameters and "kwargs" not in signature.parameters:
@@ -200,7 +219,9 @@ def env_reset_passive_checker(env, **kwargs):
     return result
 
 
-def env_step_passive_checker(env, action):
+def env_step_passive_checker(
+    env: Env[_ObsT, _ActT], action: _ActT
+) -> tuple[_ObsT, SupportsFloat, bool, bool, dict[str, Any]]:
     """A passive check for the environment step, investigating the returning data then returning the data unchanged."""
     # We don't check the action as for some environments then out-of-bounds values can be given
     result = env.step(action)
@@ -245,6 +266,7 @@ def env_step_passive_checker(env, action):
             f"The reward returned by `step()` must be a float, int, np.integer or np.floating, actual type: {type(reward)}"
         )
     else:
+        reward = cast("float | np.integer | np.floating", reward)
         if np.isnan(reward):
             logger.warn("The reward is a NaN value.")
         if np.isinf(reward):
@@ -309,7 +331,7 @@ def _check_render_return(render_mode, render_return):
                 )  # Check that each item of the list matches the base render mode
 
 
-def env_render_passive_checker(env):
+def env_render_passive_checker(env: Env) -> RenderFrame | list[RenderFrame] | None:
     """A passive check of the `Env.render` that the declared render modes/fps in the metadata of the environment is declared."""
     render_modes = env.metadata.get("render_modes")
     if render_modes is None:

--- a/gymnasium/utils/performance.py
+++ b/gymnasium/utils/performance.py
@@ -6,7 +6,9 @@ from collections.abc import Callable
 import gymnasium
 
 
-def benchmark_step(env: gymnasium.Env, target_duration: int = 5, seed=None) -> float:
+def benchmark_step(
+    env: gymnasium.Env, target_duration: int = 5, seed: int | None = None
+) -> float:
     """A benchmark to measure the runtime performance of step for an environment.
 
     example usage:
@@ -50,7 +52,9 @@ def benchmark_step(env: gymnasium.Env, target_duration: int = 5, seed=None) -> f
 
 
 def benchmark_init(
-    env_lambda: Callable[[], gymnasium.Env], target_duration: int = 5, seed=None
+    env_lambda: Callable[[], gymnasium.Env],
+    target_duration: int = 5,
+    seed: int | None = None,
 ) -> float:
     """A benchmark to measure the initialization time and first reset.
 

--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -3,19 +3,22 @@
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import Callable
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 import numpy as np
 
 import gymnasium as gym
 from gymnasium import Env, logger
-from gymnasium.core import ActType, ObsType
+from gymnasium.core import ActType
 from gymnasium.error import DependencyNotInstalled
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
-
+    from matplotlib.collections import PathCollection
+    from matplotlib.figure import Figure
+    from pygame import Surface
+    from pygame.event import Event
 
 try:
     import pygame
@@ -36,6 +39,11 @@ except ImportError:
     matplotlib, plt = None, None
 
 
+_ObsT_contra = TypeVar("_ObsT_contra", contravariant=True)
+_ActT_contra = TypeVar("_ActT_contra", contravariant=True)
+_ActionKey = TypeVar("_ActionKey", bound=tuple[str | int, ...] | str | int)
+
+
 class MissingKeysToAction(Exception):
     """Raised when the environment does not have a default ``keys_to_action`` mapping."""
 
@@ -43,12 +51,19 @@ class MissingKeysToAction(Exception):
 class PlayableGame:
     """Wraps an environment allowing keyboard inputs to interact with the environment."""
 
+    env: Env
+    relevant_keys: set[int]
+    video_size: tuple[int, int]
+    screen: Surface
+    pressed_keys: list[int]
+    running: bool
+
     def __init__(
         self,
         env: Env,
         keys_to_action: dict[tuple[int, ...], int] | None = None,
         zoom: float | None = None,
-    ):
+    ) -> None:
         """Wraps an environment with a dictionary of keyboard buttons to action and if to zoom in on the environment.
 
         Args:
@@ -72,8 +87,8 @@ class PlayableGame:
         self.running = True
 
     def _get_relevant_keys(
-        self, keys_to_action: dict[tuple[int], int] | None = None
-    ) -> set:
+        self, keys_to_action: dict[tuple[int, ...], int] | None = None
+    ) -> set[int]:
         if keys_to_action is None:
             if self.env.has_wrapper_attr("get_keys_to_action"):
                 keys_to_action = self.env.get_wrapper_attr("get_keys_to_action")()
@@ -99,7 +114,7 @@ class PlayableGame:
 
         return video_size
 
-    def process_event(self, event: Event):
+    def process_event(self, event: Event) -> None:
         """Processes a PyGame event.
 
         In particular, this function is used to keep track of which buttons are currently pressed
@@ -127,8 +142,11 @@ class PlayableGame:
 
 
 def display_arr(
-    screen: Surface, arr: np.ndarray, video_size: tuple[int, int], transpose: bool
-):
+    screen: Surface,
+    arr: np.typing.NDArray[np.uint8],
+    video_size: tuple[int, int],
+    transpose: bool | None,
+) -> None:
     """Displays a numpy array on screen.
 
     Args:
@@ -149,16 +167,17 @@ def display_arr(
 
 
 def play(
-    env: Env,
+    env: Env[Any, ActType],
     transpose: bool | None = True,
     fps: int | None = None,
     zoom: float | None = None,
     callback: Callable | None = None,
-    keys_to_action: dict[tuple[str | int, ...] | str | int, ActType] | None = None,
+    # `dict` is invariant so we use a type variable as key type
+    keys_to_action: dict[_ActionKey, ActType] | None = None,
     seed: int | None = None,
-    noop: ActType = 0,
+    noop: ActType | int = 0,
     wait_on_player: bool = False,
-):
+) -> None:
     """Allows the user to play the environment using a keyboard.
 
     If playing in a turn-based environment, set wait_on_player to True.
@@ -274,7 +293,7 @@ def play(
         if isinstance(key_combination, int):
             key_combination = (key_combination,)
         key_code = tuple(
-            sorted(ord(key) if isinstance(key, str) else key for key in key_combination)
+            sorted(ord(key) if isinstance(key, str) else key for key in key_combination)  # ty:ignore[not-iterable]
         )
         key_code_to_action[key_code] = action
 
@@ -282,6 +301,7 @@ def play(
 
     if fps is None:
         fps = env.metadata.get("render_fps", 30)
+        assert isinstance(fps, int)
 
     done, obs = True, None
     clock = pygame.time.Clock()
@@ -301,7 +321,7 @@ def play(
             rendered = env.render()
             if isinstance(rendered, list):
                 rendered = rendered[-1]
-            assert rendered is not None and isinstance(rendered, np.ndarray)
+            assert isinstance(rendered, np.ndarray)
             display_arr(
                 game.screen, rendered, transpose=transpose, video_size=game.video_size
             )
@@ -315,7 +335,7 @@ def play(
     pygame.quit()
 
 
-class PlayPlot:
+class PlayPlot(Generic[_ObsT_contra, _ActT_contra]):
     """Provides a callback to create live plots of arbitrary metrics when using :func:`play`.
 
     This class is instantiated with a function that accepts information about a single environment transition:
@@ -343,9 +363,27 @@ class PlayPlot:
         >>> play(your_env, callback=plotter.callback)                                                # doctest: +SKIP
     """
 
+    data_callback: Callable[
+        [_ObsT_contra, _ObsT_contra, _ActT_contra, float, bool, bool, dict],
+        Iterable[float],
+    ]
+    horizon_timesteps: int
+    plot_names: list[str]
+    fig: Figure
+    ax: list[Axes]
+    t: int
+    cur_plot: list[PathCollection | None]
+    data: list[deque[float]]
+
     def __init__(
-        self, callback: Callable, horizon_timesteps: int, plot_names: list[str]
-    ):
+        self,
+        callback: Callable[
+            [_ObsT_contra, _ObsT_contra, _ActT_contra, float, bool, bool, dict],
+            Iterable[Any],
+        ],
+        horizon_timesteps: int,
+        plot_names: list[str],
+    ) -> None:
         """Constructor of :class:`PlayPlot`.
 
         The function ``callback`` that is passed to this constructor should return
@@ -369,25 +407,27 @@ class PlayPlot:
             )
 
         num_plots = len(self.plot_names)
-        self.fig, self.ax = plt.subplots(num_plots)
+        self.fig, ax = plt.subplots(num_plots)
         if num_plots == 1:
-            self.ax = [self.ax]
+            self.ax = [ax]
+        else:
+            self.ax = ax
         for axis, name in zip(self.ax, plot_names, strict=True):
             axis.set_title(name)
         self.t = 0
-        self.cur_plot: list[Axes | None] = [None for _ in range(num_plots)]
+        self.cur_plot = [None for _ in range(num_plots)]
         self.data = [deque(maxlen=horizon_timesteps) for _ in range(num_plots)]
 
     def callback(
         self,
-        obs_t: ObsType,
-        obs_tp1: ObsType,
-        action: ActType,
+        obs_t: _ObsT_contra,
+        obs_tp1: _ObsT_contra,
+        action: _ActT_contra,
         rew: float,
         terminated: bool,
         truncated: bool,
         info: dict,
-    ):
+    ) -> None:
         """The callback that calls the provided data callback and adds the data to the plots.
 
         Args:

--- a/gymnasium/utils/save_video.py
+++ b/gymnasium/utils/save_video.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable
+from typing import Any
 
 import gymnasium as gym
 from gymnasium import logger
@@ -36,15 +37,15 @@ def capped_cubic_video_schedule(episode_id: int) -> bool:
 def save_video(
     frames: list,
     video_folder: str,
-    episode_trigger: Callable[[int], bool] = None,
-    step_trigger: Callable[[int], bool] = None,
+    episode_trigger: Callable[[int], bool] | None = None,
+    step_trigger: Callable[[int], bool] | None = None,
     video_length: int | None = None,
     name_prefix: str = "rl-video",
     episode_index: int = 0,
     step_starting_index: int = 0,
     save_logger: str | None = None,
-    **kwargs,
-):
+    **kwargs: Any,
+) -> None:
     """Save videos from rendering frames.
 
     This function extract video from a list of render frame episodes.

--- a/gymnasium/utils/step_api_compatibility.py
+++ b/gymnasium/utils/step_api_compatibility.py
@@ -25,7 +25,8 @@ TerminatedTruncatedStepType = tuple[
 
 
 def convert_to_terminated_truncated_step_api(
-    step_returns: DoneStepType | TerminatedTruncatedStepType, is_vector_env=False
+    step_returns: DoneStepType | TerminatedTruncatedStepType,
+    is_vector_env: bool = False,
 ) -> TerminatedTruncatedStepType:
     """Function to transform step returns to new step API irrespective of input API.
 


### PR DESCRIPTION
# Description

This fixes 11 typing errors (`ty` warnings) in `gymnasium.utils` and increases the type coverage of this subpackage to 100% by filling in all missing annotations.

There are still some typing errors that I didn't solve in parts of code where I wasn't sure of the intentions. For example in `utils.step_api_compatibility.convert_to_terminated_truncated_step_api` looks like it some of the errors could be solved by adding overloads, but I couldn't really figure out what those overloads should actually look like. 

I confirmed that `gymnasium.utils` now indeed has 100% type-coverage using `uvx typestats check gymnasium` ([typestats docs](https://jorenham.github.io/typestats/guides/getting-started/)). The total type `gymnasium` coverage increased with almost 2% to ~59.2%.

Related to #1566, #1567, and #1568.

## Type of change

Static typing fixes and improvements

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
