### PR TITLE
Enforce and fix four `ty` rules

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -1032,7 +1032,7 @@ def pprint_registry(
     """
     # Defaultdict to store environment ids according to namespace.
     namespace_envs: dict[str, list[str]] = defaultdict(list)
-    max_justify = float("-inf")
+    max_justify = 0
 
     # Find the namespace associated with each environment spec
     for env_spec in print_registry.values():

--- a/gymnasium/envs/tabular/cliffwalking.py
+++ b/gymnasium/envs/tabular/cliffwalking.py
@@ -47,7 +47,7 @@ class EnvState(NamedTuple):
 
     player_position: jax.Array
     last_action: int
-    fallen: bool
+    fallen: bool | jax.Array
 
 
 PRNGKeyType: TypeAlias = jax.Array
@@ -144,7 +144,7 @@ class CliffWalkingFunctional(
     def transition(
         self,
         state: EnvState,
-        action: int | jax.Array,
+        action: jax.Array,
         key: PRNGKeyType,
         params: None = None,
     ) -> EnvState:
@@ -209,6 +209,9 @@ class CliffWalkingFunctional(
     ) -> jax.Array:
         """Calculates reward from a state."""
         state = next_state
+        assert not isinstance(state.fallen, bool), (
+            "state.fallen should be a jax array, not a bool"
+        )
         reward = -1 + (-99 * state.fallen[0])
         return jax.lax.convert_element_type(reward, jnp.float32)
 

--- a/gymnasium/spaces/box.py
+++ b/gymnasium/spaces/box.py
@@ -87,7 +87,7 @@ class Box(Space[NDArray[Any]]):
         # determine dtype
         if dtype is None:
             raise ValueError("Box dtype must be explicitly provided, cannot be None.")
-        self.dtype = np.dtype(dtype)
+        self.dtype: np.dtype = np.dtype(dtype)
 
         #  * check that dtype is an accepted dtype
         if self.dtype.kind not in ("i", "u", "f", "b"):

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -169,7 +169,7 @@ class Graph(Space[GraphInstance]):
                 return (
                     super().seed(seed[0]),
                     self.node_space.seed(seed[1]),
-                    self.edge_space.seed(seed[2]),
+                    self.edge_space.seed(seed[2]),  # ty:ignore[index-out-of-bounds]
                 )
         else:
             raise TypeError(

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -267,7 +267,7 @@ def _flatten_sequence(
 def _flatten_oneof(space: OneOf, x: tuple[int, Any]) -> NDArray[Any]:
     idx, sample = x
     sub_space = space.spaces[idx]
-    flat_sample = flatten(sub_space, sample)
+    flat_sample: np.ndarray = flatten(sub_space, sample)
 
     max_flatdim = flatdim(space) - 1  # Don't include the index
     if flat_sample.size < max_flatdim:
@@ -361,6 +361,9 @@ def _unflatten_tuple(
 @unflatten.register(Dict)
 def _unflatten_dict(space: Dict, x: NDArray[Any] | dict[str, Any]) -> dict[str, Any]:
     if space.is_np_flattenable:
+        assert isinstance(x, np.ndarray), (
+            "x must be a numpy array when unflattening a numpy-flattenable space"
+        )
         dims = np.asarray([flatdim(s) for s in space.spaces.values()], dtype=np.int_)
         list_flattened = np.split(x, np.cumsum(dims[:-1]))
         return {

--- a/gymnasium/utils/step_api_compatibility.py
+++ b/gymnasium/utils/step_api_compatibility.py
@@ -43,7 +43,7 @@ def convert_to_terminated_truncated_step_api(
 
         # Cases to handle - info single env /  info vector env (list) / info vector env (dict)
         if is_vector_env is False:
-            truncated = infos.pop("TimeLimit.truncated", False)  # ty:ignore[too-many-positional-arguments]
+            truncated = infos.pop("TimeLimit.truncated", False)  # ty:ignore[no-matching-overload,too-many-positional-arguments]
             return (
                 observations,
                 rewards,

--- a/gymnasium/utils/step_api_compatibility.py
+++ b/gymnasium/utils/step_api_compatibility.py
@@ -43,7 +43,7 @@ def convert_to_terminated_truncated_step_api(
 
         # Cases to handle - info single env /  info vector env (list) / info vector env (dict)
         if is_vector_env is False:
-            truncated = infos.pop("TimeLimit.truncated", False)
+            truncated = infos.pop("TimeLimit.truncated", False)  # ty:ignore[too-many-positional-arguments]
             return (
                 observations,
                 rewards,

--- a/gymnasium/vector/utils/shared_memory.py
+++ b/gymnasium/vector/utils/shared_memory.py
@@ -66,6 +66,7 @@ def _create_base_shared_memory(
     space: Box | Discrete | MultiDiscrete | MultiBinary, n: int = 1, ctx=mp
 ):
     assert space.dtype is not None
+    assert space.shape is not None
     dtype = space.dtype.char
     if dtype in "?":
         dtype = c_bool
@@ -243,6 +244,7 @@ def _write_base_to_shared_memory(
     value,
     shared_memory,
 ):
+    assert space.shape is not None
     size = int(np.prod(space.shape))
     destination = np.frombuffer(shared_memory.get_obj(), dtype=space.dtype)
     np.copyto(

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -141,7 +141,7 @@ def _batch_space_custom(space: Graph | Text | Sequence | OneOf, n: int = 1):
         tuple(deepcopy(space) for _ in range(n)), seed=deepcopy(space.np_random)
     )
     space_rng = deepcopy(space.np_random)
-    new_seeds = list(map(int, space_rng.integers(0, 1e8, n)))
+    new_seeds = list(map(int, space_rng.integers(0, int(1e8), n)))
     batched_space.seed(new_seeds)
     return batched_space
 
@@ -402,7 +402,7 @@ def _concatenate_base(
     items: Iterable,
     out: np.ndarray,
 ) -> np.ndarray:
-    return np.stack(items, axis=0, out=out)
+    return np.stack(list(items), axis=0, out=out)
 
 
 @concatenate.register(Tuple)

--- a/gymnasium/wrappers/vector/rendering.py
+++ b/gymnasium/wrappers/vector/rendering.py
@@ -134,8 +134,8 @@ class HumanRendering(VectorWrapper, gym.utils.RecordConstructorArgs):
                 num_cols * subenv_size[0] * scaling_factor == self.screen_size[0]
             ) or (num_rows * subenv_size[1] * scaling_factor == self.screen_size[1])
 
-            self.num_rows = num_rows
-            self.num_cols = num_cols
+            self.num_rows: int = num_rows
+            self.num_cols: int = num_cols
             self.scaled_subenv_size = (
                 int(subenv_size[0] * scaling_factor),
                 int(subenv_size[1] * scaling_factor),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,6 @@ invalid-assignment = "warn"               # TODO remove
 invalid-method-override = "warn"          # TODO remove
 invalid-parameter-default = "warn"        # TODO remove
 invalid-return-type = "warn"              # TODO remove
-no-matching-overload = "warn"             # TODO remove
 missing-argument = "warn"                 # TODO remove
 unresolved-attribute = "warn"             # TODO remove
 unresolved-import = "warn"                # TODO remove

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,6 @@ python-platform = "all"
 extra-paths = []
 
 [tool.ty.rules]
-index-out-of-bounds = "warn"              # TODO remove
 invalid-argument-type = "warn"            # TODO remove
 invalid-assignment = "warn"               # TODO remove
 invalid-method-override = "warn"          # TODO remove

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,6 @@ invalid-parameter-default = "warn"        # TODO remove
 invalid-return-type = "warn"              # TODO remove
 no-matching-overload = "warn"             # TODO remove
 missing-argument = "warn"                 # TODO remove
-too-many-positional-arguments = "warn"    # TODO remove
 unresolved-attribute = "warn"             # TODO remove
 unresolved-import = "warn"                # TODO remove
 unsupported-operator = "warn"             # TODO remove

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,6 @@ invalid-parameter-default = "warn"        # TODO remove
 invalid-return-type = "warn"              # TODO remove
 no-matching-overload = "warn"             # TODO remove
 missing-argument = "warn"                 # TODO remove
-not-subscriptable = "warn"                # TODO remove
 too-many-positional-arguments = "warn"    # TODO remove
 unresolved-attribute = "warn"             # TODO remove
 unresolved-import = "warn"                # TODO remove


### PR DESCRIPTION
# Description

This sets four `ty` rules to `"error"` (the default) and fixes  the corresponding typing issues (or works around false positives in `ty`)

- `index-out-of-bounds`
- `not-subscriptable`
- `too-many-positional-arguments`
- `no-matching-overloads`

Ref: https://github.com/Farama-Foundation/Gymnasium/pull/1566#pullrequestreview-4184505707

## Type of change

Static typing fixes.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
