### PR TITLE
Fix `invalid-parameter-default` ty errors

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -118,7 +118,7 @@ class Env(Generic[ObsType, ActType]):
         *,
         seed: int | None = None,
         options: dict[str, Any] | None = None,
-    ) -> tuple[ObsType, dict[str, Any]]:  # type: ignore
+    ) -> tuple[ObsType, dict[str, Any]]:
         """Resets the environment to an initial internal state, returning an initial observation and info.
 
         This method generates a new starting state often with some randomness to ensure that the agent explores the

--- a/gymnasium/envs/mujoco/hopper_v5.py
+++ b/gymnasium/envs/mujoco/hopper_v5.py
@@ -164,7 +164,7 @@ class HopperEnv(MujocoEnv, utils.EzPickle):
         self,
         xml_file: str = "hopper.xml",
         frame_skip: int = 4,
-        default_camera_config: dict[str, float | int] = DEFAULT_CAMERA_CONFIG,
+        default_camera_config: dict[str, float | np.ndarray] = DEFAULT_CAMERA_CONFIG,
         forward_reward_weight: float = 1.0,
         ctrl_cost_weight: float = 1e-3,
         healthy_reward: float = 1.0,

--- a/gymnasium/envs/mujoco/humanoid_v5.py
+++ b/gymnasium/envs/mujoco/humanoid_v5.py
@@ -308,7 +308,7 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
         self,
         xml_file: str = "humanoid.xml",
         frame_skip: int = 5,
-        default_camera_config: dict[str, float | int] = DEFAULT_CAMERA_CONFIG,
+        default_camera_config: dict[str, float | np.ndarray] = DEFAULT_CAMERA_CONFIG,
         forward_reward_weight: float = 1.25,
         ctrl_cost_weight: float = 0.1,
         contact_cost_weight: float = 5e-7,

--- a/gymnasium/envs/mujoco/humanoidstandup_v5.py
+++ b/gymnasium/envs/mujoco/humanoidstandup_v5.py
@@ -287,7 +287,7 @@ class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
         self,
         xml_file: str = "humanoidstandup.xml",
         frame_skip: int = 5,
-        default_camera_config: dict[str, float | int] = DEFAULT_CAMERA_CONFIG,
+        default_camera_config: dict[str, float | np.ndarray] = DEFAULT_CAMERA_CONFIG,
         uph_cost_weight: float = 1,
         ctrl_cost_weight: float = 0.1,
         impact_cost_weight: float = 0.5e-6,

--- a/gymnasium/envs/mujoco/inverted_double_pendulum_v5.py
+++ b/gymnasium/envs/mujoco/inverted_double_pendulum_v5.py
@@ -146,7 +146,7 @@ class InvertedDoublePendulumEnv(MujocoEnv, utils.EzPickle):
         self,
         xml_file: str = "inverted_double_pendulum.xml",
         frame_skip: int = 5,
-        default_camera_config: dict[str, float | int] = None,
+        default_camera_config: dict[str, float | np.ndarray] | None = None,
         healthy_reward: float = 10.0,
         reset_noise_scale: float = 0.1,
         **kwargs,

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -45,7 +45,7 @@ class MujocoEnv(gym.Env):
         height: int = DEFAULT_SIZE,
         camera_id: int | None = None,
         camera_name: str | None = None,
-        default_camera_config: dict[str, float | int] | None = None,
+        default_camera_config: dict[str, float] | None = None,
         max_geom: int = 1000,
         visual_options: dict[int, bool] | None = None,
     ):

--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -47,7 +47,7 @@ class BaseRender:
         width: int,
         height: int,
         max_geom: int = 1000,
-        visual_options: dict[int, bool] = None,
+        visual_options: dict[int, bool] | None = None,
     ):
         """Render context superclass for offscreen and window rendering."""
         self.model = model
@@ -180,7 +180,7 @@ class OffScreenViewer(BaseRender):
         width: int,
         height: int,
         max_geom: int = 1000,
-        visual_options: dict[int, bool] = None,
+        visual_options: dict[int, bool] | None = None,
     ):
         # We must make GLContext before MjrContext
         self._get_opengl_backend(width, height)
@@ -341,7 +341,7 @@ class WindowViewer(BaseRender):
         width: int | None = None,
         height: int | None = None,
         max_geom: int = 1000,
-        visual_options: dict[int, bool] = None,
+        visual_options: dict[int, bool] | None = None,
     ):
         glfw.init()
 

--- a/gymnasium/envs/mujoco/swimmer_v5.py
+++ b/gymnasium/envs/mujoco/swimmer_v5.py
@@ -154,7 +154,7 @@ class SwimmerEnv(MujocoEnv, utils.EzPickle):
         self,
         xml_file: str = "swimmer.xml",
         frame_skip: int = 4,
-        default_camera_config: dict[str, float | int] = None,
+        default_camera_config: dict[str, float] | None = None,
         forward_reward_weight: float = 1.0,
         ctrl_cost_weight: float = 1e-4,
         reset_noise_scale: float = 0.1,

--- a/gymnasium/envs/mujoco/walker2d_v5.py
+++ b/gymnasium/envs/mujoco/walker2d_v5.py
@@ -173,7 +173,7 @@ class Walker2dEnv(MujocoEnv, utils.EzPickle):
         self,
         xml_file: str = "walker2d_v5.xml",
         frame_skip: int = 4,
-        default_camera_config: dict[str, float | int] = DEFAULT_CAMERA_CONFIG,
+        default_camera_config: dict[str, float | np.ndarray] = DEFAULT_CAMERA_CONFIG,
         forward_reward_weight: float = 1.0,
         ctrl_cost_weight: float = 1e-3,
         healthy_reward: float = 1.0,

--- a/gymnasium/envs/phys2d/cartpole.py
+++ b/gymnasium/envs/phys2d/cartpole.py
@@ -51,7 +51,9 @@ class CartPoleFunctional(
     action_space = gym.spaces.Discrete(2)
 
     def initial(
-        self, rng: PRNGKeyType, params: CartPoleParams = CartPoleParams
+        self,
+        rng: PRNGKeyType,
+        params: CartPoleParams | type[CartPoleParams] = CartPoleParams,
     ) -> StateType:
         """Initial state generation."""
         return jax.random.uniform(
@@ -63,7 +65,7 @@ class CartPoleFunctional(
         state: StateType,
         action: int | jax.Array,
         rng: None = None,
-        params: CartPoleParams = CartPoleParams,
+        params: CartPoleParams | type[CartPoleParams] = CartPoleParams,
     ) -> StateType:
         """Cartpole transition."""
         x, x_dot, theta, theta_dot = state
@@ -92,13 +94,19 @@ class CartPoleFunctional(
         return state
 
     def observation(
-        self, state: StateType, rng: Any, params: CartPoleParams = CartPoleParams
+        self,
+        state: StateType,
+        rng: Any,
+        params: CartPoleParams | type[CartPoleParams] = CartPoleParams,
     ) -> jax.Array:
         """Cartpole observation."""
         return state
 
     def terminal(
-        self, state: StateType, rng: Any, params: CartPoleParams = CartPoleParams
+        self,
+        state: StateType,
+        rng: Any,
+        params: CartPoleParams | type[CartPoleParams] = CartPoleParams,
     ) -> jax.Array:
         """Checks if the state is terminal."""
         x, _, theta, _ = state
@@ -118,7 +126,7 @@ class CartPoleFunctional(
         action: ActType,
         next_state: StateType,
         rng: Any,
-        params: CartPoleParams = CartPoleParams,
+        params: CartPoleParams | type[CartPoleParams] = CartPoleParams,
     ) -> jax.Array:
         """Computes the reward for the state transition using the action."""
         x, _, theta, _ = state
@@ -142,7 +150,7 @@ class CartPoleFunctional(
         self,
         state: StateType,
         render_state: RenderStateType,
-        params: CartPoleParams = CartPoleParams,
+        params: CartPoleParams | type[CartPoleParams] = CartPoleParams,
     ) -> tuple[RenderStateType, np.ndarray]:
         """Renders an image of the state using the render state."""
         try:
@@ -216,7 +224,7 @@ class CartPoleFunctional(
 
     def render_init(
         self,
-        params: CartPoleParams = CartPoleParams,
+        params: CartPoleParams | type[CartPoleParams] = CartPoleParams,
         screen_width: int = 600,
         screen_height: int = 400,
     ) -> RenderStateType:
@@ -235,7 +243,9 @@ class CartPoleFunctional(
         return screen, clock
 
     def render_close(
-        self, render_state: RenderStateType, params: CartPoleParams = CartPoleParams
+        self,
+        render_state: RenderStateType,
+        params: CartPoleParams | type[CartPoleParams] = CartPoleParams,
     ) -> None:
         """Closes the render state."""
         try:

--- a/gymnasium/envs/phys2d/pendulum.py
+++ b/gymnasium/envs/phys2d/pendulum.py
@@ -47,7 +47,9 @@ class PendulumFunctional(
     action_space = gym.spaces.Box(-max_torque, max_torque, shape=(1,), dtype=np.float32)
 
     def initial(
-        self, rng: PRNGKeyType, params: PendulumParams = PendulumParams
+        self,
+        rng: PRNGKeyType,
+        params: PendulumParams | type[PendulumParams] = PendulumParams,
     ) -> StateType:
         """Initial state generation."""
         high = jnp.array([params.high_x, params.high_y])
@@ -58,7 +60,7 @@ class PendulumFunctional(
         state: StateType,
         action: int | jax.Array,
         rng: None = None,
-        params: PendulumParams = PendulumParams,
+        params: PendulumParams | type[PendulumParams] = PendulumParams,
     ) -> StateType:
         """Pendulum transition."""
         th, thdot = state  # th := theta
@@ -79,7 +81,10 @@ class PendulumFunctional(
         return new_state
 
     def observation(
-        self, state: StateType, rng: Any, params: PendulumParams = PendulumParams
+        self,
+        state: StateType,
+        rng: Any,
+        params: PendulumParams | type[PendulumParams] = PendulumParams,
     ) -> jax.Array:
         """Generates an observation based on the state."""
         theta, thetadot = state
@@ -91,7 +96,7 @@ class PendulumFunctional(
         action: ActType,
         next_state: StateType,
         rng: Any,
-        params: PendulumParams = PendulumParams,
+        params: PendulumParams | type[PendulumParams] = PendulumParams,
     ) -> float:
         """Generates the reward based on the state, action and next state."""
         th, thdot = state  # th := theta
@@ -105,7 +110,10 @@ class PendulumFunctional(
         return -costs
 
     def terminal(
-        self, state: StateType, rng: Any, params: PendulumParams = PendulumParams
+        self,
+        state: StateType,
+        rng: Any,
+        params: PendulumParams | type[PendulumParams] = PendulumParams,
     ) -> bool:
         """Determines if the state is a terminal state."""
         return False
@@ -114,7 +122,7 @@ class PendulumFunctional(
         self,
         state: StateType,
         render_state: RenderStateType,
-        params: PendulumParams = PendulumParams,
+        params: PendulumParams | type[PendulumParams] = PendulumParams,
     ) -> tuple[RenderStateType, np.ndarray]:
         """Renders an RGB image."""
         try:
@@ -189,7 +197,7 @@ class PendulumFunctional(
         self,
         screen_width: int = 600,
         screen_height: int = 400,
-        params: PendulumParams = PendulumParams,
+        params: PendulumParams | type[PendulumParams] = PendulumParams,
     ) -> RenderStateType:
         """Initialises the render state."""
         try:
@@ -208,7 +216,7 @@ class PendulumFunctional(
     def render_close(
         self,
         render_state: RenderStateType,
-        params: PendulumParams = PendulumParams,
+        params: PendulumParams | type[PendulumParams] = PendulumParams,
     ):
         """Closes the render state."""
         try:

--- a/gymnasium/envs/tabular/blackjack.py
+++ b/gymnasium/envs/tabular/blackjack.py
@@ -247,7 +247,7 @@ class BlackjackFunctional(
         state: EnvState,
         action: int | jax.Array,
         key: PRNGKeyType,
-        params: BlackJackParams = BlackJackParams,
+        params: BlackJackParams | type[BlackJackParams] = BlackJackParams,
     ) -> EnvState:
         """The blackjack environment's state transition function."""
         env_state = jax.lax.cond(action, take, notake, (state, key))
@@ -273,7 +273,9 @@ class BlackjackFunctional(
         return new_state
 
     def initial(
-        self, rng: PRNGKeyType, params: BlackJackParams = BlackJackParams
+        self,
+        rng: PRNGKeyType,
+        params: BlackJackParams | type[BlackJackParams] = BlackJackParams,
     ) -> EnvState:
         """Blackjack initial observataion function."""
         player_hand = jnp.zeros(21)
@@ -297,7 +299,7 @@ class BlackjackFunctional(
         self,
         state: EnvState,
         rng: PRNGKeyType,
-        params: BlackJackParams = BlackJackParams,
+        params: BlackJackParams | type[BlackJackParams] = BlackJackParams,
     ) -> jax.Array:
         """Blackjack observation."""
         return jnp.array(
@@ -313,7 +315,7 @@ class BlackjackFunctional(
         self,
         state: EnvState,
         rng: PRNGKeyType,
-        params: BlackJackParams = BlackJackParams,
+        params: BlackJackParams | type[BlackJackParams] = BlackJackParams,
     ) -> jax.Array:
         """Determines if a particular Blackjack observation is terminal."""
         return (state.done) > 0
@@ -324,7 +326,7 @@ class BlackjackFunctional(
         action: ActType,
         next_state: EnvState,
         rng: PRNGKeyType,
-        params: BlackJackParams = BlackJackParams,
+        params: BlackJackParams | type[BlackJackParams] = BlackJackParams,
     ) -> jax.Array:
         """Calculates reward from a state."""
         state = next_state
@@ -379,7 +381,7 @@ class BlackjackFunctional(
         self,
         state: StateType,
         render_state: RenderStateType,
-        params: BlackJackParams = BlackJackParams,
+        params: BlackJackParams | type[BlackJackParams] = BlackJackParams,
     ) -> tuple[RenderStateType, np.ndarray]:
         """Renders an image from a state."""
         try:
@@ -487,7 +489,9 @@ class BlackjackFunctional(
         )
 
     def render_close(
-        self, render_state: RenderStateType, params: BlackJackParams = BlackJackParams
+        self,
+        render_state: RenderStateType,
+        params: BlackJackParams | type[BlackJackParams] = BlackJackParams,
     ) -> None:
         """Closes the render state."""
         try:

--- a/gymnasium/envs/toy_text/frozen_lake.py
+++ b/gymnasium/envs/toy_text/frozen_lake.py
@@ -232,7 +232,7 @@ class FrozenLakeEnv(Env):
     def __init__(
         self,
         render_mode: str | None = None,
-        desc: list[str] = None,
+        desc: list[str] | None = None,
         map_name: str = "4x4",
         is_slippery: bool = True,
         success_rate: float = 1.0 / 3.0,
@@ -242,7 +242,8 @@ class FrozenLakeEnv(Env):
             desc = generate_random_map()
         elif desc is None:
             desc = MAPS[map_name]
-        self.desc = desc = np.asarray(desc, dtype="c")
+        desc: np.typing.NDArray[np.bytes_] = np.asarray(desc, dtype="c")
+        self.desc = desc
         self.nrow, self.ncol = nrow, ncol = desc.shape
         self.reward_range = (min(reward_schedule), max(reward_schedule))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,7 +173,6 @@ extra-paths = []
 invalid-argument-type = "warn"            # TODO remove
 invalid-assignment = "warn"               # TODO remove
 invalid-method-override = "warn"          # TODO remove
-invalid-parameter-default = "warn"        # TODO remove
 invalid-return-type = "warn"              # TODO remove
 missing-argument = "warn"                 # TODO remove
 unresolved-attribute = "warn"             # TODO remove


### PR DESCRIPTION
# Description

With this, we're now down to 368 `ty` warnings.

Ref: https://github.com/Farama-Foundation/Gymnasium/pull/1570#issuecomment-4331323979

## Type of change

Static typing fixes

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
