### PR TITLE
Fix typing errors and add missing annotations in `spaces.*`

### DIFF
--- a/gymnasium/spaces/box.py
+++ b/gymnasium/spaces/box.py
@@ -3,13 +3,38 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
-from typing import Any, SupportsFloat
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias, cast, overload
 
 import numpy as np
 from numpy.typing import NDArray
 
 import gymnasium as gym
 from gymnasium.spaces.space import Space
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeIs, TypeVar
+
+    _ScalarT_co = TypeVar(
+        "_ScalarT_co",
+        bound="_RealScalar",
+        default="_RealScalar",
+        covariant=True,
+    )
+else:
+    from typing import TypeVar
+
+    _ScalarT_co = TypeVar("_ScalarT_co", bound="_RealScalar", covariant=True)
+
+_RealScalar: TypeAlias = np.floating | np.integer
+_RealArrayLike: TypeAlias = int | float | _RealScalar | NDArray[_RealScalar]
+_ToSeed: TypeAlias = int | np.random.Generator
+_ToShape: TypeAlias = Sequence[int | np.integer]
+
+_ScalarT = TypeVar("_ScalarT", bound=_RealScalar)
+_FloatScalarT = TypeVar("_FloatScalarT", bound=np.floating)
+_IntScalarT = TypeVar("_IntScalarT", bound=np.integer)
+
+_ToDType: TypeAlias = type[_ScalarT] | np.dtype[_ScalarT]
 
 
 def array_short_repr(arr: NDArray[Any]) -> str:
@@ -29,14 +54,14 @@ def array_short_repr(arr: NDArray[Any]) -> str:
     return str(arr)
 
 
-def is_float_integer(var: Any) -> bool:
+def is_float_integer(var: object) -> TypeIs[float | np.floating | np.integer]:
     """Checks if a scalar variable is an integer or float (does not include bool)."""
     return isinstance(var, (int, float, np.integer, np.floating)) and not isinstance(
         var, bool
     )
 
 
-class Box(Space[NDArray[Any]]):
+class Box(Space[NDArray[_ScalarT_co]]):
     r"""A (possibly unbounded) box in :math:`\mathbb{R}^n`.
 
     Specifically, a Box represents the Cartesian product of n closed intervals.
@@ -56,14 +81,54 @@ class Box(Space[NDArray[Any]]):
         Box([-1. -2.], [2. 4.], (2,), float32)
     """
 
+    dtype: np.dtype[_ScalarT_co]
+    _shape: tuple[int, ...]
+
+    low: NDArray[_ScalarT_co]
+    high: NDArray[_ScalarT_co]
+
+    bounded_below: NDArray[np.bool]
+    bounded_above: NDArray[np.bool]
+
+    low_repr: str | None
+    high_repr: str | None
+
+    @overload
+    def __init__(
+        self: Box[np.float32],
+        low: _RealArrayLike,
+        high: _RealArrayLike,
+        shape: _ToShape | None = None,
+        dtype: _ToDType[np.float32] = np.float32,
+        seed: _ToSeed | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: Box[_ScalarT],
+        low: _RealArrayLike,
+        high: _RealArrayLike,
+        shape: _ToShape | None = None,
+        *,
+        dtype: _ToDType[_ScalarT],
+        seed: _ToSeed | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: Box[_ScalarT],
+        low: _RealArrayLike,
+        high: _RealArrayLike,
+        shape: _ToShape | None,
+        dtype: _ToDType[_ScalarT],
+        seed: _ToSeed | None = None,
+    ) -> None: ...
     def __init__(
         self,
-        low: SupportsFloat | NDArray[Any],
-        high: SupportsFloat | NDArray[Any],
-        shape: Sequence[int] | None = None,
-        dtype: type[np.floating[Any]] | type[np.integer[Any]] = np.float32,
-        seed: int | np.random.Generator | None = None,
-    ):
+        low: _RealArrayLike,
+        high: _RealArrayLike,
+        shape: _ToShape | None = None,
+        dtype: _ToDType[_ScalarT_co | np.float32] = np.float32,
+        seed: _ToSeed | None = None,
+    ) -> None:
         r"""Constructor of :class:`Box`.
 
         The argument ``low`` specifies the lower bound of each dimension and ``high`` specifies the upper bounds.
@@ -87,7 +152,7 @@ class Box(Space[NDArray[Any]]):
         # determine dtype
         if dtype is None:
             raise ValueError("Box dtype must be explicitly provided, cannot be None.")
-        self.dtype: np.dtype = np.dtype(dtype)
+        self.dtype = np.dtype(dtype)
 
         #  * check that dtype is an accepted dtype
         if self.dtype.kind not in ("i", "u", "f", "b"):
@@ -125,7 +190,7 @@ class Box(Space[NDArray[Any]]):
                 "Box shape is not specified, therefore inferred from low and high. Expected low and high to be np.ndarray, integer, or float."
                 f"Actual types low={type(low)}, high={type(high)}"
             )
-        self._shape: tuple[int, ...] = shape
+        self._shape = shape
 
         # Cast scalar values to `np.ndarray` and capture the boundedness information
         # disallowed cases
@@ -136,11 +201,11 @@ class Box(Space[NDArray[Any]]):
         if self.dtype.kind == "b":
             dtype_min, dtype_max = 0, 1
         elif self.dtype.kind == "f":
-            dtype_min = float(np.finfo(self.dtype).min)
-            dtype_max = float(np.finfo(self.dtype).max)
+            finfo = np.finfo(cast(np.dtype[np.floating], self.dtype))
+            dtype_min, dtype_max = float(finfo.min), float(finfo.max)
         else:
-            dtype_min = int(np.iinfo(self.dtype).min)
-            dtype_max = int(np.iinfo(self.dtype).max)
+            iinfo = np.iinfo(cast(np.dtype[np.integer], self.dtype))
+            dtype_min, dtype_max = int(iinfo.min), int(iinfo.max)
 
         # Cast `low` and `high` to ndarray for the dtype min and max for out of range tests
         self.low, self.bounded_below = self._cast_low(low, dtype_min)
@@ -167,7 +232,9 @@ class Box(Space[NDArray[Any]]):
 
         super().__init__(self.shape, self.dtype, seed)
 
-    def _cast_low(self, low, dtype_min) -> tuple[np.ndarray, np.ndarray]:
+    def _cast_low(
+        self, low: _RealArrayLike, dtype_min: float
+    ) -> tuple[NDArray[_ScalarT_co], NDArray[np.bool]]:
         """Casts the input Box low value to ndarray with provided dtype.
 
         Args:
@@ -223,17 +290,18 @@ class Box(Space[NDArray[Any]]):
                     f"Box low is out of bounds of the dtype range, low={low}, min dtype={dtype_min}"
                 )
 
-            if (
-                low.dtype.kind == "f"
-                and self.dtype.kind == "f"
-                and np.finfo(self.dtype).precision < np.finfo(low.dtype).precision
-            ):
-                gym.logger.warn(
-                    f"Box low's precision lowered by casting to {self.dtype}, current low.dtype={low.dtype}"
-                )
+            if low.dtype.kind == "f" and self.dtype.kind == "f":
+                dtype_self = cast("np.dtype[np.floating]", self.dtype)
+                dtype_low = cast("np.dtype[np.floating]", low.dtype)
+                if np.finfo(dtype_self).precision < np.finfo(dtype_low).precision:
+                    gym.logger.warn(
+                        f"Box low's precision lowered by casting to {self.dtype}, current low.dtype={low.dtype}"
+                    )
             return low.astype(self.dtype), bounded_below
 
-    def _cast_high(self, high, dtype_max) -> tuple[np.ndarray, np.ndarray]:
+    def _cast_high(
+        self, high: _RealArrayLike, dtype_max: float
+    ) -> tuple[NDArray[_ScalarT_co], NDArray[np.bool]]:
         """Casts the input Box high value to ndarray with provided dtype.
 
         Args:
@@ -289,14 +357,13 @@ class Box(Space[NDArray[Any]]):
                     f"Box high is out of bounds of the dtype range, high={high}, max dtype={dtype_max}"
                 )
 
-            if (
-                high.dtype.kind == "f"
-                and self.dtype.kind == "f"
-                and np.finfo(self.dtype).precision < np.finfo(high.dtype).precision
-            ):
-                gym.logger.warn(
-                    f"Box high's precision lowered by casting to {self.dtype}, current high.dtype={high.dtype}"
-                )
+            if high.dtype.kind == "f" and self.dtype.kind == "f":
+                dtype_self = cast("np.dtype[np.floating]", self.dtype)
+                dtype_high = cast("np.dtype[np.floating]", high.dtype)
+                if np.finfo(dtype_self).precision < np.finfo(dtype_high).precision:
+                    gym.logger.warn(
+                        f"Box high's precision lowered by casting to {self.dtype}, current high.dtype={high.dtype}"
+                    )
             return high.astype(self.dtype), bounded_above
 
     @property
@@ -305,11 +372,11 @@ class Box(Space[NDArray[Any]]):
         return self._shape
 
     @property
-    def is_np_flattenable(self):
+    def is_np_flattenable(self) -> Literal[True]:
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return True
 
-    def is_bounded(self, manner: str = "both") -> bool:
+    def is_bounded(self, manner: Literal["both", "below", "above"] = "both") -> bool:
         """Checks whether the box is bounded in some sense.
 
         Args:
@@ -334,7 +401,9 @@ class Box(Space[NDArray[Any]]):
                 f"manner is not in {{'below', 'above', 'both'}}, actual value: {manner}"
             )
 
-    def sample(self, mask: None = None, probability: None = None) -> NDArray[Any]:
+    def sample(
+        self, mask: None = None, probability: None = None
+    ) -> NDArray[_ScalarT_co]:
         r"""Generates a single random sample inside the Box.
 
         In creating a sample of the box, each coordinate is sampled (independently) from a distribution
@@ -391,13 +460,12 @@ class Box(Space[NDArray[Any]]):
             sample = np.floor(sample)
 
         # clip values that would underflow/overflow
-        if np.issubdtype(self.dtype, np.signedinteger):
-            dtype_min = np.iinfo(self.dtype).min + 2
-            dtype_max = np.iinfo(self.dtype).max - 2
-            sample = sample.clip(min=dtype_min, max=dtype_max)
-        elif np.issubdtype(self.dtype, np.unsignedinteger):
-            dtype_min = np.iinfo(self.dtype).min
-            dtype_max = np.iinfo(self.dtype).max
+        if np.issubdtype(self.dtype, np.integer):
+            iinfo = np.iinfo(cast("np.dtype[np.integer]", self.dtype))
+            dtype_min, dtype_max = iinfo.min, iinfo.max
+            if np.issubdtype(self.dtype, np.signedinteger):
+                dtype_min += 2
+                dtype_max -= 2
             sample = sample.clip(min=dtype_min, max=dtype_max)
 
         sample = sample.astype(self.dtype)
@@ -409,7 +477,7 @@ class Box(Space[NDArray[Any]]):
 
         return sample
 
-    def contains(self, x: Any) -> bool:
+    def contains(self, x: np.ndarray | Any) -> bool:
         """Return boolean specifying if x is a valid member of this space."""
         if not isinstance(x, np.ndarray):
             gym.logger.warn("Casting input x to numpy array.")
@@ -425,11 +493,13 @@ class Box(Space[NDArray[Any]]):
             and np.all(x <= self.high)
         )
 
-    def to_jsonable(self, sample_n: Sequence[NDArray[Any]]) -> list[list]:
+    def to_jsonable(self, sample_n: Iterable[np.ndarray]) -> list[list]:
         """Convert a batch of samples from this space to a JSONable data type."""
         return [sample.tolist() for sample in sample_n]
 
-    def from_jsonable(self, sample_n: Sequence[float | int]) -> list[NDArray[Any]]:
+    def from_jsonable(
+        self, sample_n: Iterable[float | list]
+    ) -> list[NDArray[_ScalarT_co]]:
         """Convert a JSONable data type to a batch of samples from this space."""
         return [np.asarray(sample, dtype=self.dtype) for sample in sample_n]
 
@@ -448,7 +518,7 @@ class Box(Space[NDArray[Any]]):
             self.high_repr = array_short_repr(self.high)
         return f"Box({self.low_repr}, {self.high_repr}, {self.shape}, {self.dtype})"
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object, /) -> bool:
         """Check whether `other` is equivalent to this instance. Doesn't check dtype equivalence."""
         return (
             isinstance(other, Box)
@@ -458,7 +528,9 @@ class Box(Space[NDArray[Any]]):
             and np.allclose(self.high, other.high)
         )
 
-    def __setstate__(self, state: Iterable[tuple[str, Any]] | Mapping[str, Any]):
+    def __setstate__(
+        self, state: Iterable[tuple[str, Any]] | Mapping[str, Any]
+    ) -> None:
         """Sets the state of the box for unpickling a box with legacy support."""
         super().__setstate__(state)
 

--- a/gymnasium/spaces/dict.py
+++ b/gymnasium/spaces/dict.py
@@ -5,15 +5,28 @@ from __future__ import annotations
 import collections.abc
 import typing
 from collections import OrderedDict
-from collections.abc import KeysView, Sequence
-from typing import Any
+from collections.abc import Iterable, Iterator, KeysView, Sequence
+from typing import TYPE_CHECKING, Any, Generic, cast
 
 import numpy as np
 
 from gymnasium.spaces.space import Space
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeVar
 
-class Dict(Space[dict[str, Any]], typing.Mapping[str, Space[Any]]):
+    _T_co = TypeVar("_T_co", covariant=True, default=Any)
+else:
+    from typing import TypeVar
+
+    _T_co = TypeVar("_T_co", covariant=True)
+
+
+class Dict(
+    Space[dict[str, Space[_T_co]]],
+    typing.Mapping[str, Space[_T_co]],
+    Generic[_T_co],
+):
     """A dictionary of :class:`Space` instances.
 
     Elements of this space are (ordered) dictionaries of elements from the constituent spaces.
@@ -51,12 +64,16 @@ class Dict(Space[dict[str, Any]], typing.Mapping[str, Space[Any]]):
     Similar wrappers can be implemented to deal with :class:`Dict` actions.
     """
 
+    spaces: dict[str, Space[_T_co]]
+
     def __init__(
         self,
-        spaces: None | dict[str, Space] | Sequence[tuple[str, Space]] = None,
+        spaces: (
+            dict[str, Space[_T_co]] | Sequence[tuple[str, Space[_T_co]]] | None
+        ) = None,
         seed: dict | int | np.random.Generator | None = None,
         **spaces_kwargs: Space,
-    ):
+    ) -> None:
         """Constructor of :class:`Dict` space.
 
         This space can be instantiated in one of two ways: Either you pass a dictionary
@@ -69,20 +86,20 @@ class Dict(Space[dict[str, Any]], typing.Mapping[str, Space[Any]]):
             **spaces_kwargs: If ``spaces`` is ``None``, you need to pass the constituent spaces as keyword arguments, as described above.
         """
         if isinstance(spaces, OrderedDict):
-            spaces = dict(spaces.items())
+            spaces_dict = dict(spaces.items())
         elif isinstance(spaces, collections.abc.Mapping):
             # for legacy reasons, we need to preserve the sorted dictionary items.
             # as this could matter for projects flatten the dictionary.
             try:
-                spaces = dict(sorted(spaces.items()))
+                spaces_dict = dict(sorted(spaces.items()))
             except TypeError:
                 # Incomparable types (e.g. `int` vs. `str`, or user-defined types) found.
                 # The keys remain in the insertion order.
-                spaces = dict(spaces.items())
+                spaces_dict = dict(spaces.items())
         elif isinstance(spaces, Sequence):
-            spaces = dict(spaces)
+            spaces_dict = dict(spaces)
         elif spaces is None:
-            spaces = dict()
+            spaces_dict = dict()
         else:
             raise TypeError(
                 f"Unexpected Dict space input, expecting dict, OrderedDict or Sequence, actual type: {type(spaces)}"
@@ -90,14 +107,14 @@ class Dict(Space[dict[str, Any]], typing.Mapping[str, Space[Any]]):
 
         # Add kwargs to spaces to allow both dictionary and keywords to be used
         for key, space in spaces_kwargs.items():
-            if key not in spaces:
-                spaces[key] = space
+            if key not in spaces_dict:
+                spaces_dict[key] = space
             else:
                 raise ValueError(
                     f"Dict space keyword '{key}' already exists in the spaces dictionary."
                 )
 
-        self.spaces: dict[str, Space[Any]] = spaces
+        self.spaces = cast("dict[str, Space[_T_co]]", spaces_dict)
         for key, space in self.spaces.items():
             assert isinstance(space, Space), (
                 f"Dict space element is not an instance of Space: key='{key}', space={space}"
@@ -107,7 +124,7 @@ class Dict(Space[dict[str, Any]], typing.Mapping[str, Space[Any]]):
         super().__init__(None, None, seed)  # type: ignore
 
     @property
-    def is_np_flattenable(self):
+    def is_np_flattenable(self) -> bool:
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return all(space.is_np_flattenable for space in self.spaces.values())
 
@@ -217,7 +234,7 @@ class Dict(Space[dict[str, Any]], typing.Mapping[str, Space[Any]]):
         )
         self.spaces[key] = value
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         """Iterator through the keys of the subspaces."""
         yield from self.spaces
 
@@ -239,7 +256,7 @@ class Dict(Space[dict[str, Any]], typing.Mapping[str, Space[Any]]):
             and self.spaces == other.spaces  # OrderedDict.__eq__
         )
 
-    def to_jsonable(self, sample_n: Sequence[dict[str, Any]]) -> dict[str, list[Any]]:
+    def to_jsonable(self, sample_n: Iterable[dict[str, Any]]) -> dict[str, list[Any]]:
         """Convert a batch of samples from this space to a JSONable data type."""
         # serialize as dict-repr of vectors
         return {
@@ -247,7 +264,7 @@ class Dict(Space[dict[str, Any]], typing.Mapping[str, Space[Any]]):
             for key, space in self.spaces.items()
         }
 
-    def from_jsonable(self, sample_n: dict[str, list[Any]]) -> list[dict[str, Any]]:
+    def from_jsonable(self, sample_n: dict[str, list[Any]]) -> list[dict[str, Any]]:  # ty:ignore[invalid-method-override]
         """Convert a JSONable data type to a batch of samples from this space."""
         dict_of_list: dict[str, list[Any]] = {
             key: space.from_jsonable(sample_n[key])

--- a/gymnasium/spaces/discrete.py
+++ b/gymnasium/spaces/discrete.py
@@ -2,17 +2,29 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
-from typing import Any, TypeVar
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING, Any, Generic, Literal, overload
 
 import numpy as np
 
 from gymnasium.spaces.space import MaskNDArray, Space
 
-IntType = TypeVar("IntType", bound=np.integer)
+if TYPE_CHECKING:
+    from typing_extensions import TypeVar
+
+    _IntegerT_co = TypeVar(
+        "_IntegerT_co",
+        bound=np.integer[Any],
+        covariant=True,
+        default=np.int64,
+    )
+else:
+    from typing import TypeVar
+
+    _IntegerT_co = TypeVar("_IntegerT_co", bound=np.integer[Any], covariant=True)
 
 
-class Discrete(Space[IntType]):
+class Discrete(Space[_IntegerT_co], Generic[_IntegerT_co]):
     r"""A space consisting of finitely many elements.
 
     This class represents a finite subset of integers, more specifically a set of the form :math:`\{ a, a+1, \dots, a+n-1 \}`.
@@ -36,13 +48,43 @@ class Discrete(Space[IntType]):
         np.int32(0)
     """
 
+    dtype: np.dtype[_IntegerT_co]
+    n: _IntegerT_co
+    start: _IntegerT_co
+
+    @overload
+    def __init__(
+        self,
+        n: int | np.integer[Any],
+        seed: int | np.random.Generator | None = None,
+        start: int | np.integer[Any] = 0,
+        *,
+        dtype: type[_IntegerT_co] | np.dtype[_IntegerT_co],
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: Discrete[Any],
+        n: int | np.integer[Any],
+        seed: int | np.random.Generator | None = None,
+        start: int | np.integer[Any] = 0,
+        *,
+        dtype: str,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: Discrete[np.int64],
+        n: int | np.integer[Any],
+        seed: int | np.random.Generator | None = None,
+        start: int | np.integer[Any] = 0,
+        dtype: type[np.int64] = np.int64,
+    ) -> None: ...
     def __init__(
         self,
         n: int | np.integer[Any],
         seed: int | np.random.Generator | None = None,
         start: int | np.integer[Any] = 0,
         dtype: str | type[np.integer[Any]] = np.int64,
-    ):
+    ) -> None:
         r"""Constructor of :class:`Discrete` space.
 
         This will construct the space :math:`\{\text{start}, ..., \text{start} + n - 1\}`.
@@ -77,13 +119,13 @@ class Discrete(Space[IntType]):
         super().__init__((), self.dtype, seed)
 
     @property
-    def is_np_flattenable(self):
+    def is_np_flattenable(self) -> Literal[True]:
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return True
 
     def sample(
         self, mask: MaskNDArray | None = None, probability: MaskNDArray | None = None
-    ) -> IntType:
+    ) -> _IntegerT_co:
         """Generates a single random sample from this space.
 
         A sample will be chosen uniformly at random with the mask if provided, or it will be chosen according to a specified probability distribution if the probability mask is provided.
@@ -190,7 +232,9 @@ class Discrete(Space[IntType]):
             and self.dtype == other.dtype
         )
 
-    def __setstate__(self, state: Iterable[tuple[str, Any]] | Mapping[str, Any]):
+    def __setstate__(
+        self, state: Iterable[tuple[str, Any]] | Mapping[str, Any]
+    ) -> None:
         """Used when loading a pickled space.
 
         This method has to be implemented explicitly to allow for loading of legacy states.
@@ -208,10 +252,10 @@ class Discrete(Space[IntType]):
 
         super().__setstate__(state)
 
-    def to_jsonable(self, sample_n: Sequence[IntType]) -> list[int]:
+    def to_jsonable(self, sample_n: Iterable[int | np.integer]) -> list[int]:
         """Converts a list of samples to a list of ints."""
         return [int(x) for x in sample_n]
 
-    def from_jsonable(self, sample_n: list[int]) -> list[IntType]:
+    def from_jsonable(self, sample_n: list[int]) -> list[_IntegerT_co]:
         """Converts a list of json samples to a list of numpy integer scalars."""
         return [self.dtype.type(x) for x in sample_n]

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any, NamedTuple
+from collections.abc import Iterable, Sequence
+from typing import Any, Literal, NamedTuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -48,12 +48,15 @@ class Graph(Space[GraphInstance]):
                [0, 2]], dtype=int32))
     """
 
+    node_space: Box | Discrete
+    edge_space: Box | Discrete | None
+
     def __init__(
         self,
         node_space: Box | Discrete,
-        edge_space: None | Box | Discrete,
+        edge_space: Box | Discrete | None,
         seed: int | np.random.Generator | None = None,
-    ):
+    ) -> None:
         r"""Constructor of :class:`Graph`.
 
         The argument ``node_space`` specifies the base space that each node feature will use.
@@ -81,7 +84,7 @@ class Graph(Space[GraphInstance]):
         super().__init__(None, None, seed)
 
     @property
-    def is_np_flattenable(self):
+    def is_np_flattenable(self) -> Literal[False]:
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return False
 
@@ -100,7 +103,7 @@ class Graph(Space[GraphInstance]):
                 seed=self.np_random,
             )
         elif isinstance(base_space, Discrete):
-            return MultiDiscrete(nvec=[base_space.n] * num, seed=self.np_random)
+            return MultiDiscrete(nvec=[int(base_space.n)] * num, seed=self.np_random)
         else:
             raise TypeError(
                 f"Expects base space to be Box and Discrete, actual space: {type(base_space)}."
@@ -178,20 +181,20 @@ class Graph(Space[GraphInstance]):
 
     def sample(
         self,
-        mask: None
-        | (
+        mask: (
             tuple[
                 NDArray[Any] | tuple[Any, ...] | None,
                 NDArray[Any] | tuple[Any, ...] | None,
             ]
-        ) = None,
-        probability: None
-        | (
+        )
+        | None = None,
+        probability: (
             tuple[
                 NDArray[Any] | tuple[Any, ...] | None,
                 NDArray[Any] | tuple[Any, ...] | None,
             ]
-        ) = None,
+        )
+        | None = None,
         num_nodes: int = 10,
         num_edges: int | None = None,
     ) -> GraphInstance:
@@ -231,7 +234,7 @@ class Graph(Space[GraphInstance]):
         if num_edges is None:
             if num_nodes > 1:
                 # maximal number of edges is `n*(n-1)` allowing self connections and two-way is allowed
-                num_edges = self.np_random.integers(num_nodes * (num_nodes - 1))
+                num_edges = int(self.np_random.integers(num_nodes * (num_nodes - 1)))
             else:
                 num_edges = 0
 
@@ -250,6 +253,10 @@ class Graph(Space[GraphInstance]):
         sampled_node_space = self._generate_sample_space(self.node_space, num_nodes)
         assert sampled_node_space is not None
         sampled_edge_space = self._generate_sample_space(self.edge_space, num_edges)
+
+        # ty can't infer typed dictionaries (yet?)
+        node_sample_kwargs: dict[str, Any]
+        edge_sample_kwargs: dict[str, Any]
 
         if mask_type is not None:
             node_sample_kwargs = {mask_type: node_space_mask}
@@ -316,8 +323,8 @@ class Graph(Space[GraphInstance]):
         )
 
     def to_jsonable(
-        self, sample_n: Sequence[GraphInstance]
-    ) -> list[dict[str, list[int | float]]]:
+        self, sample_n: Iterable[GraphInstance]
+    ) -> list[dict[str, list[float]]]:
         """Convert a batch of samples from this space to a JSONable data type."""
         ret_n = []
         for sample in sample_n:

--- a/gymnasium/spaces/multi_binary.py
+++ b/gymnasium/spaces/multi_binary.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from typing import Any
+from collections.abc import Iterable, Sequence
+from typing import Any, Literal
 
 import numpy as np
 from numpy.typing import NDArray
 
-from gymnasium.spaces.space import MaskNDArray, Space
+from gymnasium.spaces.space import Space
 
 
 class MultiBinary(Space[NDArray[np.int8]]):
@@ -28,11 +28,14 @@ class MultiBinary(Space[NDArray[np.int8]]):
                [1, 1]], dtype=int8)
     """
 
+    dtype: np.dtype[np.int8]
+    n: int | tuple[int, ...]
+
     def __init__(
         self,
         n: NDArray[np.integer[Any]] | Sequence[int] | int,
         seed: int | np.random.Generator | None = None,
-    ):
+    ) -> None:
         """Constructor of :class:`MultiBinary` space.
 
         Args:
@@ -60,12 +63,14 @@ class MultiBinary(Space[NDArray[np.int8]]):
         return self._shape  # type: ignore
 
     @property
-    def is_np_flattenable(self):
+    def is_np_flattenable(self) -> Literal[True]:
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return True
 
     def sample(
-        self, mask: MaskNDArray | None = None, probability: MaskNDArray | None = None
+        self,
+        mask: NDArray[np.int8] | None = None,
+        probability: NDArray[np.int8] | None = None,
     ) -> NDArray[np.int8]:
         """Generates a single random sample from this space.
 
@@ -137,9 +142,9 @@ class MultiBinary(Space[NDArray[np.int8]]):
             and np.all(np.logical_or(x == 0, x == 1))
         )
 
-    def to_jsonable(self, sample_n: Sequence[NDArray[np.int8]]) -> list[Sequence[int]]:
+    def to_jsonable(self, sample_n: Iterable[NDArray[np.int8]]) -> list[Sequence[int]]:
         """Convert a batch of samples from this space to a JSONable data type."""
-        return np.array(sample_n).tolist()
+        return np.array(list(sample_n)).tolist()
 
     def from_jsonable(self, sample_n: list[Sequence[int]]) -> list[NDArray[np.int8]]:
         """Convert a JSONable data type to a batch of samples from this space."""
@@ -149,6 +154,6 @@ class MultiBinary(Space[NDArray[np.int8]]):
         """Gives a string representation of this space."""
         return f"MultiBinary({self.n})"
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object, /) -> bool:
         """Check whether `other` is equivalent to this instance."""
         return isinstance(other, MultiBinary) and self.n == other.n

--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
-from typing import Any
+from typing import TYPE_CHECKING, Any, Generic, Literal, overload
 
 import numpy as np
 from numpy.typing import NDArray
@@ -12,8 +12,22 @@ import gymnasium as gym
 from gymnasium.spaces.discrete import Discrete
 from gymnasium.spaces.space import MaskNDArray, Space
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeVar
 
-class MultiDiscrete(Space[NDArray[np.integer]]):
+    _IntegerT_co = TypeVar(
+        "_IntegerT_co",
+        bound=np.integer[Any],
+        covariant=True,
+        default=np.int64,
+    )
+else:
+    from typing import TypeVar
+
+    _IntegerT_co = TypeVar("_IntegerT_co", bound=np.integer[Any], covariant=True)
+
+
+class MultiDiscrete(Space[NDArray[_IntegerT_co]], Generic[_IntegerT_co]):
     """This represents the cartesian product of arbitrary :class:`Discrete` spaces.
 
     It is useful to represent game controllers or keyboards where each key can be represented as a discrete action space.
@@ -41,13 +55,41 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
                [2, 2]])
     """
 
+    dtype: np.dtype[_IntegerT_co]
+    nvec: NDArray[_IntegerT_co]
+    start: NDArray[_IntegerT_co]
+
+    @overload
+    def __init__(
+        self: MultiDiscrete[np.int64],
+        nvec: NDArray[np.integer[Any]] | list[int],
+        dtype: type[np.int64] = np.int64,
+        seed: int | np.random.Generator | None = None,
+        start: NDArray[np.integer[Any]] | list[int] | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        nvec: NDArray[np.integer[Any]] | list[int],
+        dtype: type[_IntegerT_co] | np.dtype[_IntegerT_co],
+        seed: int | np.random.Generator | None = None,
+        start: NDArray[np.integer[Any]] | list[int] | None = None,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self: MultiDiscrete[Any],
+        nvec: NDArray[np.integer[Any]] | list[int],
+        dtype: str,
+        seed: int | np.random.Generator | None = None,
+        start: NDArray[np.integer[Any]] | list[int] | None = None,
+    ) -> None: ...
     def __init__(
         self,
         nvec: NDArray[np.integer[Any]] | list[int],
         dtype: str | type[np.integer[Any]] = np.int64,
         seed: int | np.random.Generator | None = None,
         start: NDArray[np.integer[Any]] | list[int] | None = None,
-    ):
+    ) -> None:
         """Constructor of :class:`MultiDiscrete` space.
 
         The argument ``nvec`` will determine the number of values each categorical variable can take. If
@@ -92,7 +134,7 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
         return self._shape  # type: ignore
 
     @property
-    def is_np_flattenable(self):
+    def is_np_flattenable(self) -> Literal[True]:
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return True
 
@@ -100,7 +142,7 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
         self,
         mask: tuple[MaskNDArray, ...] | None = None,
         probability: tuple[MaskNDArray, ...] | None = None,
-    ) -> NDArray[np.integer[Any]]:
+    ) -> NDArray[_IntegerT_co]:
         """Generates a single random sample from this space.
 
         Args:
@@ -148,6 +190,7 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
             assert len(sub_mask) == len(sub_nvec), (
                 f"Expects the mask length to be equal to the number of actions, mask length: {len(sub_mask)}, nvec length: {len(sub_nvec)}"
             )
+            assert isinstance(sub_start, np.ndarray)
             return [
                 self._apply_mask(new_mask, new_nvec, new_start, mask_type)
                 for new_mask, new_nvec, new_start in zip(
@@ -217,14 +260,14 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
         )
 
     def to_jsonable(
-        self, sample_n: Sequence[NDArray[np.integer[Any]]]
+        self, sample_n: Iterable[NDArray[np.integer[Any]]]
     ) -> list[Sequence[int]]:
         """Convert a batch of samples from this space to a JSONable data type."""
         return [sample.tolist() for sample in sample_n]
 
     def from_jsonable(
         self, sample_n: list[Sequence[int]]
-    ) -> list[NDArray[np.integer[Any]]]:
+    ) -> list[NDArray[_IntegerT_co]]:
         """Convert a JSONable data type to a batch of samples from this space."""
         return [np.array(sample, dtype=self.dtype) for sample in sample_n]
 
@@ -234,10 +277,13 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
             return f"MultiDiscrete({self.nvec}, start={self.start})"
         return f"MultiDiscrete({self.nvec})"
 
-    def __getitem__(self, index: int | tuple[int, ...]):
+    def __getitem__(
+        self, index: int | tuple[int, ...]
+    ) -> Discrete[_IntegerT_co] | MultiDiscrete[_IntegerT_co]:
         """Extract a subspace from this ``MultiDiscrete`` space."""
         nvec = self.nvec[index]
         start = self.start[index]
+
         if nvec.ndim == 0:
             subspace = Discrete(nvec, start=start, dtype=self.dtype)
         else:
@@ -248,7 +294,7 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
 
         return subspace
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Gives the ``len`` of samples from this space."""
         if self.nvec.ndim >= 2:
             gym.logger.warn(
@@ -266,7 +312,9 @@ class MultiDiscrete(Space[NDArray[np.integer]]):
             and np.all(self.start == other.start)
         )
 
-    def __setstate__(self, state: Iterable[tuple[str, Any]] | Mapping[str, Any]):
+    def __setstate__(
+        self, state: Iterable[tuple[str, Any]] | Mapping[str, Any]
+    ) -> None:
         """Used when loading a pickled space.
 
         This method has to be implemented explicitly to allow for loading of legacy states.

--- a/gymnasium/spaces/oneof.py
+++ b/gymnasium/spaces/oneof.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-import typing
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Generic, TypeVar
 
 import numpy as np
 
 from gymnasium.spaces.space import Space
 
+_T_co = TypeVar("_T_co", covariant=True)
 
-class OneOf(Space[Any]):
+
+class OneOf(Space[tuple[int, _T_co]], Generic[_T_co]):
     """An exclusive tuple (more precisely: the direct sum) of :class:`Space` instances.
 
     Elements of this space are elements of one of the constituent spaces.
@@ -31,11 +32,13 @@ class OneOf(Space[Any]):
         2
     """
 
+    spaces: tuple[Space[_T_co], ...]
+
     def __init__(
         self,
-        spaces: Iterable[Space[Any]],
-        seed: int | typing.Sequence[int] | np.random.Generator | None = None,
-    ):
+        spaces: Iterable[Space[_T_co]],
+        seed: int | np.random.Generator | None = None,
+    ) -> None:
         r"""Constructor of :class:`OneOf` space.
 
         The generated instance will represent the cartesian product :math:`\text{spaces}[0] \times ... \times \text{spaces}[-1]`.
@@ -54,7 +57,7 @@ class OneOf(Space[Any]):
         super().__init__(None, None, seed)
 
     @property
-    def is_np_flattenable(self):
+    def is_np_flattenable(self) -> bool:
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return all(space.is_np_flattenable for space in self.spaces)
 
@@ -106,7 +109,7 @@ class OneOf(Space[Any]):
         self,
         mask: tuple[Any | None, ...] | None = None,
         probability: tuple[Any | None, ...] | None = None,
-    ) -> tuple[int, Any]:
+    ) -> tuple[int, _T_co]:
         """Generates a single random sample inside this space.
 
         This method draws independent samples from the subspaces.
@@ -120,7 +123,7 @@ class OneOf(Space[Any]):
         Returns:
             Tuple of the subspace's samples
         """
-        subspace_idx = self.np_random.integers(0, len(self.spaces), dtype=np.int64)
+        subspace_idx = int(self.np_random.integers(0, len(self.spaces), dtype=np.int64))
         subspace = self.spaces[subspace_idx]
 
         if mask is not None and probability is not None:
@@ -166,9 +169,7 @@ class OneOf(Space[Any]):
         """Gives a string representation of this space."""
         return "OneOf(" + ", ".join([str(s) for s in self.spaces]) + ")"
 
-    def to_jsonable(
-        self, sample_n: typing.Sequence[tuple[int, Any]]
-    ) -> list[list[Any]]:
+    def to_jsonable(self, sample_n: Iterable[tuple[int, Any]]) -> list[list[Any]]:
         """Convert a batch of samples from this space to a JSONable data type."""
         return [
             [int(i), self.spaces[i].to_jsonable([subsample])[0]]
@@ -185,7 +186,7 @@ class OneOf(Space[Any]):
             for space_idx, jsonable_sample in sample_n
         ]
 
-    def __getitem__(self, index: int) -> Space[Any]:
+    def __getitem__(self, index: int) -> Space[_T_co]:
         """Get the subspace at specific `index`."""
         return self.spaces[index]
 
@@ -193,6 +194,6 @@ class OneOf(Space[Any]):
         """Get the number of subspaces that are involved in the cartesian product."""
         return len(self.spaces)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object, /) -> bool:
         """Check whether ``other`` is equivalent to this instance."""
         return isinstance(other, OneOf) and self.spaces == other.spaces

--- a/gymnasium/spaces/oneof.py
+++ b/gymnasium/spaces/oneof.py
@@ -123,7 +123,7 @@ class OneOf(Space[tuple[int, _T_co]], Generic[_T_co]):
         Returns:
             Tuple of the subspace's samples
         """
-        subspace_idx = int(self.np_random.integers(0, len(self.spaces), dtype=np.int64))
+        subspace_idx: int = self.np_random.integers(0, len(self.spaces), dtype=np.int64)  # ty:ignore[invalid-assignment]
         subspace = self.spaces[subspace_idx]
 
         if mask is not None and probability is not None:

--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import typing
-from typing import Any
+from collections.abc import Iterable
+from typing import Any, Literal
 
 import numpy as np
 from numpy.typing import NDArray
@@ -34,12 +34,16 @@ class Sequence(Space[tuple[Any, ...] | Any]):
                [0.19049619]], dtype=float32)
     """
 
+    feature_space: Space[Any]
+    stack: bool
+    stacked_feature_space: Space[Any]
+
     def __init__(
         self,
         space: Space[Any],
         seed: int | np.random.Generator | None = None,
         stack: bool = False,
-    ):
+    ) -> None:
         """Constructor of the :class:`Sequence` space.
 
         Args:
@@ -53,7 +57,7 @@ class Sequence(Space[tuple[Any, ...] | Any]):
         self.feature_space = space
         self.stack = stack
         if self.stack:
-            self.stacked_feature_space: Space = gym.vector.utils.batch_space(
+            self.stacked_feature_space = gym.vector.utils.batch_space(
                 self.feature_space, 1
             )
 
@@ -95,27 +99,15 @@ class Sequence(Space[tuple[Any, ...] | Any]):
             )
 
     @property
-    def is_np_flattenable(self):
+    def is_np_flattenable(self) -> Literal[False]:
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return False
 
     def sample(
         self,
-        mask: None
-        | (
-            tuple[
-                None | int | NDArray[np.integer],
-                Any,
-            ]
-        ) = None,
-        probability: None
-        | (
-            tuple[
-                None | int | NDArray[np.integer],
-                Any,
-            ]
-        ) = None,
-    ) -> tuple[Any] | Any:
+        mask: tuple[None | int | NDArray[np.integer], Any] | None = None,
+        probability: tuple[None | int | NDArray[np.integer], Any] | None = None,
+    ) -> tuple[Any, ...] | Any:
         """Generates a single random sample from this space.
 
         Args:
@@ -213,9 +205,7 @@ class Sequence(Space[tuple[Any, ...] | Any]):
         """Gives a string representation of this space."""
         return f"Sequence({self.feature_space}, stack={self.stack})"
 
-    def to_jsonable(
-        self, sample_n: typing.Sequence[tuple[Any, ...] | Any]
-    ) -> list[list[Any]]:
+    def to_jsonable(self, sample_n: Iterable[tuple[Any, ...] | Any]) -> list[list[Any]]:
         """Convert a batch of samples from this space to a JSONable data type."""
         if self.stack:
             return self.stacked_feature_space.to_jsonable(sample_n)
@@ -231,7 +221,7 @@ class Sequence(Space[tuple[Any, ...] | Any]):
                 tuple(self.feature_space.from_jsonable(sample)) for sample in sample_n
             ]
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object, /) -> bool:
         """Check whether ``other`` is equivalent to this instance."""
         return (
             isinstance(other, Sequence)

--- a/gymnasium/spaces/space.py
+++ b/gymnasium/spaces/space.py
@@ -10,13 +10,12 @@ import numpy.typing as npt
 
 from gymnasium.utils import seeding
 
-T_cov = TypeVar("T_cov", covariant=True)
-
+_T_co = TypeVar("_T_co", covariant=True)
 
 MaskNDArray: TypeAlias = npt.NDArray[np.int8]
 
 
-class Space(Generic[T_cov]):
+class Space(Generic[_T_co]):
     """Superclass that is used to define observation and action spaces.
 
     Spaces are crucially used in Gym to define the format of valid actions and observations.
@@ -42,6 +41,10 @@ class Space(Generic[T_cov]):
         not handle custom spaces properly. Use custom spaces with care.
     """
 
+    dtype: np.dtype | None
+    _shape: tuple[int, ...] | None
+    _np_random: np.random.Generator
+
     def __init__(
         self,
         shape: Sequence[int] | None = None,
@@ -57,7 +60,6 @@ class Space(Generic[T_cov]):
         """
         self._shape = None if shape is None else tuple(shape)
         self.dtype = None if dtype is None else np.dtype(dtype)
-        self._np_random = None
         if seed is not None:
             if isinstance(seed, np.random.Generator):
                 self._np_random = seed
@@ -90,7 +92,7 @@ class Space(Generic[T_cov]):
         """Checks whether this space can be flattened to a :class:`gymnasium.spaces.Box`."""
         raise NotImplementedError
 
-    def sample(self, mask: Any | None = None, probability: Any | None = None) -> T_cov:
+    def sample(self, mask: Any | None = None, probability: Any | None = None) -> _T_co:
         """Randomly sample an element of this space.
 
         Can be uniform or non-uniform sampling based on boundedness of space.
@@ -106,7 +108,7 @@ class Space(Generic[T_cov]):
         """
         raise NotImplementedError
 
-    def seed(self, seed: int | None = None) -> int | list[int] | dict[str, int]:
+    def seed(self, seed: int | None = None) -> int | Any:
         """Seed the pseudorandom number generator (PRNG) of this space and, if applicable, the PRNGs of subspaces.
 
         Args:
@@ -126,7 +128,9 @@ class Space(Generic[T_cov]):
         """Return boolean specifying if x is a valid member of this space."""
         return self.contains(x)
 
-    def __setstate__(self, state: Iterable[tuple[str, Any]] | Mapping[str, Any]):
+    def __setstate__(
+        self, state: Iterable[tuple[str, Any]] | Mapping[str, Any]
+    ) -> None:
         """Used when loading a pickled space.
 
         This method was implemented explicitly to allow for loading of legacy states.
@@ -152,12 +156,12 @@ class Space(Generic[T_cov]):
         # Update our state
         self.__dict__.update(state)
 
-    def to_jsonable(self, sample_n: Sequence[T_cov]) -> list[Any]:
+    def to_jsonable(self, sample_n: Iterable[_T_co]) -> list[Any] | Any:
         """Convert a batch of samples from this space to a JSONable data type."""
         # By default, assume identity is JSONable
         return list(sample_n)
 
-    def from_jsonable(self, sample_n: list[Any]) -> list[T_cov]:
+    def from_jsonable(self, sample_n: list[Any]) -> list[Any]:
         """Convert a JSONable data type to a batch of samples from this space."""
         # By default, assume identity is JSONable
         return sample_n

--- a/gymnasium/spaces/space.py
+++ b/gymnasium/spaces/space.py
@@ -60,6 +60,7 @@ class Space(Generic[_T_co]):
         """
         self._shape = None if shape is None else tuple(shape)
         self.dtype = None if dtype is None else np.dtype(dtype)
+        self._np_random = None  # ty:ignore[invalid-assignment]
         if seed is not None:
             if isinstance(seed, np.random.Generator):
                 self._np_random = seed

--- a/gymnasium/spaces/text.py
+++ b/gymnasium/spaces/text.py
@@ -37,7 +37,7 @@ class Text(Space[str]):
         min_length: int = 1,
         charset: frozenset[str] | str = alphanumeric,
         seed: int | np.random.Generator | None = None,
-    ):
+    ) -> None:
         r"""Constructor of :class:`Text` space.
 
         Both bounds for text length are inclusive.
@@ -148,7 +148,7 @@ class Text(Space[str]):
     def _validate_mask(
         self,
         mask: tuple[int | None, NDArray[np.int8] | NDArray[np.float64] | None],
-        expected_dtype: np.dtype,
+        expected_dtype: np.dtype | type[np.generic],
         mask_type: str,
     ) -> tuple[int | None, NDArray[np.int8] | NDArray[np.float64] | None]:
         assert isinstance(mask, tuple), (
@@ -190,7 +190,7 @@ class Text(Space[str]):
         """Gives a string representation of this space."""
         return f"Text({self.min_length}, {self.max_length}, charset={self.characters})"
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object, /) -> bool:
         """Check whether ``other`` is equivalent to this instance."""
         return (
             isinstance(other, Text)

--- a/gymnasium/spaces/tuple.py
+++ b/gymnasium/spaces/tuple.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 import typing
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, TypeVar, overload
 
 import numpy as np
 
 from gymnasium.spaces.space import Space
 
+_T_co = TypeVar("_T_co", covariant=True)
 
-class Tuple(Space[tuple[Any, ...]], typing.Sequence[Any]):
+
+class Tuple(Space[tuple[_T_co, ...]], typing.Sequence[_T_co]):
     """A tuple (more precisely: the cartesian product) of :class:`Space` instances.
 
     Elements of this space are tuples of elements of the constituent spaces.
@@ -23,11 +25,13 @@ class Tuple(Space[tuple[Any, ...]], typing.Sequence[Any]):
         (np.int64(0), array([-0.3991573 ,  0.21649833], dtype=float32))
     """
 
+    spaces: tuple[Space[_T_co], ...]
+
     def __init__(
         self,
-        spaces: Iterable[Space[Any]],
-        seed: int | typing.Sequence[int] | np.random.Generator | None = None,
-    ):
+        spaces: Iterable[Space[_T_co]],
+        seed: int | np.random.Generator | None = None,
+    ) -> None:
         r"""Constructor of :class:`Tuple` space.
 
         The generated instance will represent the cartesian product :math:`\text{spaces}[0] \times ... \times \text{spaces}[-1]`.
@@ -41,10 +45,10 @@ class Tuple(Space[tuple[Any, ...]], typing.Sequence[Any]):
             assert isinstance(space, Space), (
                 f"{space} does not inherit from `gymnasium.Space`. Actual Type: {type(space)}"
             )
-        super().__init__(None, None, seed)  # type: ignore
+        super().__init__(None, None, seed)
 
     @property
-    def is_np_flattenable(self):
+    def is_np_flattenable(self) -> bool:
         """Checks whether this space can be flattened to a :class:`spaces.Box`."""
         return all(space.is_np_flattenable for space in self.spaces)
 
@@ -93,7 +97,7 @@ class Tuple(Space[tuple[Any, ...]], typing.Sequence[Any]):
         self,
         mask: tuple[Any | None, ...] | None = None,
         probability: tuple[Any | None, ...] | None = None,
-    ) -> tuple[Any, ...]:
+    ) -> tuple[_T_co, ...]:
         """Generates a single random sample inside this space.
 
         This method draws independent samples from the subspaces.
@@ -159,9 +163,7 @@ class Tuple(Space[tuple[Any, ...]], typing.Sequence[Any]):
         """Gives a string representation of this space."""
         return "Tuple(" + ", ".join([str(s) for s in self.spaces]) + ")"
 
-    def to_jsonable(
-        self, sample_n: typing.Sequence[tuple[Any, ...]]
-    ) -> list[list[Any]]:
+    def to_jsonable(self, sample_n: Iterable[tuple[Any, ...]]) -> list[list[Any]]:
         """Convert a batch of samples from this space to a JSONable data type."""
         # serialize as list-repr of tuple of vectors
         return [
@@ -182,7 +184,13 @@ class Tuple(Space[tuple[Any, ...]], typing.Sequence[Any]):
             )
         ]
 
-    def __getitem__(self, index: int) -> Space[Any]:
+    @overload
+    def __getitem__(self, index: int) -> Space[_T_co]: ...
+    @overload
+    def __getitem__(self, index: slice) -> tuple[Space[_T_co], ...]: ...
+    def __getitem__(
+        self, index: int | slice
+    ) -> Space[_T_co] | tuple[Space[_T_co], ...]:
         """Get the subspace at specific `index`."""
         return self.spaces[index]
 
@@ -190,6 +198,6 @@ class Tuple(Space[tuple[Any, ...]], typing.Sequence[Any]):
         """Get the number of subspaces that are involved in the cartesian product."""
         return len(self.spaces)
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object, /) -> bool:
         """Check whether ``other`` is equivalent to this instance."""
         return isinstance(other, Tuple) and self.spaces == other.spaces

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -28,7 +28,8 @@ from gymnasium.spaces import (
     Text,
     Tuple,
 )
-from gymnasium.spaces.discrete import IntType
+
+_IntegerT = TypeVar("_IntegerT", bound=np.integer)
 
 
 @singledispatch
@@ -166,7 +167,7 @@ def _flatten_box_multibinary(space: Box | MultiBinary, x: NDArray[Any]) -> NDArr
 
 
 @flatten.register(Discrete)
-def _flatten_discrete(space: Discrete, x: IntType) -> NDArray[IntType]:
+def _flatten_discrete(space: Discrete, x: _IntegerT) -> NDArray[_IntegerT]:
     onehot = np.zeros(space.n, dtype=space.dtype)
     onehot[x - space.start] = 1
     return onehot
@@ -308,7 +309,9 @@ def _unflatten_box_multibinary(
 
 
 @unflatten.register(Discrete)
-def _unflatten_discrete(space: Discrete, x: NDArray[IntType | np.float64]) -> IntType:
+def _unflatten_discrete(
+    space: Discrete, x: NDArray[_IntegerT | np.float64]
+) -> _IntegerT:
     nonzero = np.nonzero(x)
     if len(nonzero[0]) == 0:
         raise ValueError(
@@ -513,6 +516,7 @@ def _flatten_space_box(space: Box) -> Box:
 @flatten_space.register(MultiBinary)
 @flatten_space.register(MultiDiscrete)
 def _flatten_space_binary(space: Discrete | MultiBinary | MultiDiscrete) -> Box:
+    assert space.dtype is not None
     return Box(low=0, high=1, shape=(flatdim(space),), dtype=space.dtype)
 
 

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -13,7 +13,7 @@ import typing
 from collections.abc import Callable, Iterable, Iterator
 from copy import deepcopy
 from functools import singledispatch
-from typing import Any
+from typing import Any, TypeVar
 
 import numpy as np
 
@@ -32,7 +32,6 @@ from gymnasium.spaces import (
     Text,
     Tuple,
 )
-from gymnasium.spaces.space import T_cov
 
 __all__ = [
     "batch_space",
@@ -41,6 +40,8 @@ __all__ = [
     "concatenate",
     "create_empty_array",
 ]
+
+_T = TypeVar("_T")
 
 
 @singledispatch
@@ -275,7 +276,7 @@ def _batch_spaces_undefined(spaces: list[Graph | Text | Sequence | OneOf]):
 
 
 @singledispatch
-def iterate(space: Space[T_cov], items: T_cov) -> Iterator:
+def iterate(space: Space[_T], items: _T) -> Iterator:
     """Iterate over the elements of a (batched) space.
 
     Args:

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -165,6 +165,8 @@ class TimeAwareObservation(
      * v1.0.0 - Remove vector environment support, add ``flatten`` and ``normalize_time`` parameters
     """
 
+    max_timesteps: int
+
     def __init__(
         self,
         env: gym.Env[ObsType, ActType],

--- a/gymnasium/wrappers/utils.py
+++ b/gymnasium/wrappers/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import singledispatch
+from typing import TypeVar
 
 import numpy as np
 
@@ -22,9 +23,10 @@ from gymnasium.spaces import (
     Text,
     Tuple,
 )
-from gymnasium.spaces.space import T_cov
 
 __all__ = ["RunningMeanStd", "update_mean_var_count_from_moments", "create_zero_array"]
+
+_T = TypeVar("_T")
 
 
 class RunningMeanStd:
@@ -69,7 +71,7 @@ def update_mean_var_count_from_moments(
 
 
 @singledispatch
-def create_zero_array(space: Space[T_cov]) -> T_cov:
+def create_zero_array(space: Space[_T]) -> _T:
     """Creates a zero-based array of a space, this is similar to ``create_empty_array`` except all arrays are valid samples from the space.
 
     As some ``Box`` cases have ``high`` or ``low`` that don't contain zero then the ``create_empty_array`` would in case


### PR DESCRIPTION
# Description

Here's another batch of static typing improvements and fixes, this time for `gymnasium.spaces.*`. 

## Type of change

Static typing fixes and improvements.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

