### PR TITLE
Fix typing errors and add missing annotations in `vector.**`

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -6,18 +6,19 @@ import multiprocessing
 import sys
 import time
 import traceback
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from copy import deepcopy
 from enum import Enum
 from multiprocessing import Queue
 from multiprocessing.connection import Connection
 from multiprocessing.sharedctypes import SynchronizedArray
-from typing import Any
+from typing import Any, TypeAlias
 
 import numpy as np
+import numpy.typing as npt
 
 from gymnasium import Space, logger
-from gymnasium.core import ActType, Env, ObsType, RenderFrame
+from gymnasium.core import Env, RenderFrame
 from gymnasium.error import (
     AlreadyPendingCallError,
     ClosedEnvironmentError,
@@ -37,9 +38,17 @@ from gymnasium.vector.utils import (
     read_from_shared_memory,
     write_to_shared_memory,
 )
-from gymnasium.vector.vector_env import ArrayType, AutoresetMode, VectorEnv
+from gymnasium.vector.vector_env import AutoresetMode, VectorEnv
 
 __all__ = ["AsyncVectorEnv", "AsyncState"]
+
+_StepResult: TypeAlias = tuple[
+    np.ndarray,
+    npt.NDArray[np.float64],
+    npt.NDArray[np.bool_],
+    npt.NDArray[np.bool_],
+    dict[str, Any],
+]
 
 
 class AsyncState(Enum):
@@ -88,6 +97,34 @@ class AsyncVectorEnv(VectorEnv):
         {}
     """
 
+    env_fns: Sequence[Callable[[], Env]]
+    shared_memory: bool
+    copy: bool
+    context: str | None
+    daemon: bool
+    worker: (
+        Callable[
+            [int, Callable[[], Env], Connection, Connection, bool, Queue],
+            None,
+        ]
+        | None
+    )
+    observation_mode: str | Space
+    autoreset_mode: AutoresetMode
+    num_envs: int
+    metadata: dict[str, Any]
+    render_mode: str | None
+
+    single_action_space: Space
+    action_space: Space
+    single_observation_space: Space
+    observation_space: Space
+    observations: np.ndarray
+
+    parent_pipes: list[Connection]
+    processes: list[multiprocessing.Process]
+    error_queue: Queue
+
     def __init__(
         self,
         env_fns: Sequence[Callable[[], Env]],
@@ -103,7 +140,7 @@ class AsyncVectorEnv(VectorEnv):
         ) = None,
         observation_mode: str | Space = "same",
         autoreset_mode: str | AutoresetMode = AutoresetMode.NEXT_STEP,
-    ):
+    ) -> None:
         """Vectorized environment that runs multiple environments in parallel.
 
         Args:
@@ -194,7 +231,7 @@ class AsyncVectorEnv(VectorEnv):
                 _obs_buffer = create_shared_memory(
                     self.single_observation_space, n=self.num_envs, ctx=ctx
                 )
-                self.observations = read_from_shared_memory(
+                self.observations = read_from_shared_memory(  # ty:ignore[invalid-assignment]
                     self.single_observation_space, _obs_buffer, n=self.num_envs
                 )
             except CustomSpaceError as e:
@@ -203,7 +240,7 @@ class AsyncVectorEnv(VectorEnv):
                 ) from e
         else:
             _obs_buffer = None
-            self.observations = create_empty_array(
+            self.observations = create_empty_array(  # ty:ignore[invalid-assignment]
                 self.single_observation_space, n=self.num_envs, fn=np.zeros
             )
 
@@ -213,7 +250,7 @@ class AsyncVectorEnv(VectorEnv):
         with clear_mpi_env_vars():
             for idx, env_fn in enumerate(self.env_fns):
                 parent_pipe, child_pipe = ctx.Pipe()
-                process = ctx.Process(
+                process = ctx.Process(  # ty:ignore[unresolved-attribute]
                     target=target,
                     name=f"Worker<{type(self).__name__}>-{idx}",
                     args=(
@@ -252,7 +289,7 @@ class AsyncVectorEnv(VectorEnv):
         *,
         seed: int | list[int | None] | None = None,
         options: dict[str, Any] | None = None,
-    ) -> tuple[ObsType, dict[str, Any]]:
+    ) -> tuple[np.ndarray, dict[str, Any]]:
         """Resets all sub-environments in parallel and return a batch of concatenated observations and info.
 
         Args:
@@ -268,8 +305,8 @@ class AsyncVectorEnv(VectorEnv):
     def reset_async(
         self,
         seed: int | list[int | None] | None = None,
-        options: dict | None = None,
-    ):
+        options: dict[str, Any] | None = None,
+    ) -> None:
         """Send calls to the :obj:`reset` methods of the sub-environments.
 
         To get the results of these calls, you may invoke :meth:`reset_wait`.
@@ -332,8 +369,8 @@ class AsyncVectorEnv(VectorEnv):
 
     def reset_wait(
         self,
-        timeout: int | float | None = None,
-    ) -> tuple[ObsType, dict[str, Any]]:
+        timeout: float | None = None,
+    ) -> tuple[np.ndarray, dict[str, Any]]:
         """Waits for the calls triggered by :meth:`reset_async` to finish and returns the results.
 
         Args:
@@ -371,16 +408,14 @@ class AsyncVectorEnv(VectorEnv):
             infos = self._add_info(infos, info, i)
 
         if not self.shared_memory:
-            self.observations = concatenate(
+            self.observations = concatenate(  # ty:ignore[invalid-assignment]
                 self.single_observation_space, results, self.observations
             )
 
         self._state = AsyncState.DEFAULT
         return (deepcopy(self.observations) if self.copy else self.observations), infos
 
-    def step(
-        self, actions: ActType
-    ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, dict[str, Any]]:
+    def step(self, actions: np.ndarray) -> _StepResult:
         """Take an action for each parallel environment.
 
         Args:
@@ -392,7 +427,7 @@ class AsyncVectorEnv(VectorEnv):
         self.step_async(actions)
         return self.step_wait()
 
-    def step_async(self, actions: np.ndarray):
+    def step_async(self, actions: np.ndarray) -> None:
         """Send the calls to :meth:`Env.step` to each sub-environment.
 
         Args:
@@ -417,9 +452,7 @@ class AsyncVectorEnv(VectorEnv):
             pipe.send(("step", action))
         self._state = AsyncState.WAITING_STEP
 
-    def step_wait(
-        self, timeout: int | float | None = None
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict]:
+    def step_wait(self, timeout: float | None = None) -> _StepResult:
         """Wait for the calls to :obj:`step` in each sub-environment to finish.
 
         Args:
@@ -462,7 +495,7 @@ class AsyncVectorEnv(VectorEnv):
         self._raise_if_errors(successes)
 
         if not self.shared_memory:
-            self.observations = concatenate(
+            self.observations = concatenate(  # ty:ignore[invalid-assignment]
                 self.single_observation_space,
                 observations,
                 self.observations,
@@ -495,7 +528,7 @@ class AsyncVectorEnv(VectorEnv):
         """Returns a list of rendered frames from the environments."""
         return self.call("render")
 
-    def call_async(self, name: str, *args, **kwargs):
+    def call_async(self, name: str, /, *args: object, **kwargs: object) -> None:
         """Calls the method with name asynchronously and apply args and kwargs to the method.
 
         Args:
@@ -518,7 +551,7 @@ class AsyncVectorEnv(VectorEnv):
             pipe.send(("_call", (name, args, kwargs)))
         self._state = AsyncState.WAITING_CALL
 
-    def call_wait(self, timeout: int | float | None = None) -> tuple[Any, ...]:
+    def call_wait(self, timeout: float | None = None) -> tuple[Any, ...]:
         """Calls all parent pipes and waits for the results.
 
         Args:
@@ -564,7 +597,7 @@ class AsyncVectorEnv(VectorEnv):
         """
         return self.call(name)
 
-    def set_attr(self, name: str, values: list[Any] | tuple[Any] | object):
+    def set_attr(self, name: str, values: list[Any] | tuple[Any] | object) -> None:
         """Sets an attribute of the sub-environments.
 
         Args:
@@ -597,7 +630,9 @@ class AsyncVectorEnv(VectorEnv):
         _, successes = zip(*[pipe.recv() for pipe in self.parent_pipes], strict=True)
         self._raise_if_errors(successes)
 
-    def close_extras(self, timeout: int | float | None = None, terminate: bool = False):
+    def close_extras(
+        self, timeout: float | None = None, terminate: bool = False
+    ) -> None:
         """Close the environments & clean up the extra resources (processes and pipes).
 
         Args:
@@ -638,7 +673,7 @@ class AsyncVectorEnv(VectorEnv):
         for process in self.processes:
             process.join()
 
-    def _poll_pipe_envs(self, timeout: int | None = None):
+    def _poll_pipe_envs(self, timeout: float | None = None) -> bool:
         self._assert_is_running()
 
         if timeout is None:
@@ -691,13 +726,13 @@ class AsyncVectorEnv(VectorEnv):
                 "In order to batch actions, the action spaces from all environments must be equal."
             )
 
-    def _assert_is_running(self):
+    def _assert_is_running(self) -> None:
         if self.closed:
             raise ClosedEnvironmentError(
                 f"Trying to operate on `{type(self).__name__}`, after a call to `close()`."
             )
 
-    def _raise_if_errors(self, successes: list[bool] | tuple[bool]):
+    def _raise_if_errors(self, successes: Iterable[bool]) -> None:
         if all(successes):
             return
 
@@ -719,7 +754,7 @@ class AsyncVectorEnv(VectorEnv):
                 self._state = AsyncState.DEFAULT
                 raise exctype(value)
 
-    def __del__(self):
+    def __del__(self) -> None:
         """On deleting the object, checks that the vector environment is closed."""
         if not getattr(self, "closed", True) and hasattr(self, "_state"):
             self.close(terminate=True)
@@ -733,7 +768,7 @@ def _async_worker(
     shared_memory: SynchronizedArray | dict[str, Any] | tuple[Any, ...],
     error_queue: Queue,
     autoreset_mode: AutoresetMode,
-):
+) -> None:
     env = env_fn()
     observation_space = env.observation_space
     action_space = env.action_space

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Sequence
 from copy import deepcopy
 from typing import Any
 
@@ -60,13 +60,26 @@ class SyncVectorEnv(VectorEnv):
         >>> envs.close()
     """
 
+    env_fns: Sequence[Callable[[], Env]]
+    copy: bool
+    observation_mode: str | tuple[Space, Space]
+    autoreset_mode: AutoresetMode
+    envs: list[Env]
+    num_envs: int
+    metadata: dict[str, Any]
+    render_mode: str | None
+    single_action_space: Space
+    action_space: Space
+    single_observation_space: Space
+    observation_space: Space
+
     def __init__(
         self,
-        env_fns: Iterator[Callable[[], Env]] | Sequence[Callable[[], Env]],
+        env_fns: Sequence[Callable[[], Env]],
         copy: bool = True,
-        observation_mode: str | Space = "same",
+        observation_mode: str | tuple[Space, Space] = "same",
         autoreset_mode: str | AutoresetMode = AutoresetMode.NEXT_STEP,
-    ):
+    ) -> None:
         """Vectorized environment that serially runs multiple environments.
 
         Args:
@@ -310,7 +323,7 @@ class SyncVectorEnv(VectorEnv):
             infos,
         )
 
-    def render(self) -> tuple[RenderFrame, ...] | None:
+    def render(self) -> tuple[RenderFrame, ...]:
         """Returns the rendered frames from the environments."""
         return tuple(env.render() for env in self.envs)
 
@@ -347,7 +360,7 @@ class SyncVectorEnv(VectorEnv):
         """
         return self.call(name)
 
-    def set_attr(self, name: str, values: list[Any] | tuple[Any, ...] | Any):
+    def set_attr(self, name: str, values: list[Any] | tuple[Any, ...] | Any) -> None:
         """Sets an attribute of the sub-environments.
 
         Args:
@@ -371,7 +384,7 @@ class SyncVectorEnv(VectorEnv):
         for env, value in zip(self.envs, values, strict=True):
             env.set_wrapper_attr(name, value)
 
-    def close_extras(self, **kwargs: Any):
+    def close_extras(self, **kwargs: Any) -> None:
         """Close the environments."""
         if hasattr(self, "envs"):
             [env.close() for env in self.envs]

--- a/gymnasium/vector/utils/misc.py
+++ b/gymnasium/vector/utils/misc.py
@@ -4,39 +4,51 @@ from __future__ import annotations
 
 import contextlib
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+from typing import TYPE_CHECKING, Generic
 
 from gymnasium.core import Env
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeVar
+
+    _EnvT_co = TypeVar("_EnvT_co", bound=Env, covariant=True, default=Env)
+else:
+    from typing import TypeVar
+
+    _EnvT_co = TypeVar("_EnvT_co", bound=Env, covariant=True)
 
 __all__ = ["CloudpickleWrapper", "clear_mpi_env_vars"]
 
 
-class CloudpickleWrapper:
+class CloudpickleWrapper(Generic[_EnvT_co]):
     """Wrapper that uses cloudpickle to pickle and unpickle the result."""
 
-    def __init__(self, fn: Callable[[], Env]):
+    fn: Callable[[], _EnvT_co]
+
+    def __init__(self, fn: Callable[[], _EnvT_co]) -> None:
         """Cloudpickle wrapper for a function."""
         self.fn = fn
 
-    def __getstate__(self):
+    def __getstate__(self) -> bytes:
         """Get the state using `cloudpickle.dumps(self.fn)`."""
         import cloudpickle
 
         return cloudpickle.dumps(self.fn)
 
-    def __setstate__(self, ob):
+    def __setstate__(self, ob: bytes) -> None:
         """Sets the state with obs."""
         import pickle
 
         self.fn = pickle.loads(ob)
 
-    def __call__(self):
+    def __call__(self) -> _EnvT_co:
         """Calls the function `self.fn` with no arguments."""
         return self.fn()
 
 
 @contextlib.contextmanager
-def clear_mpi_env_vars():
+def clear_mpi_env_vars() -> Generator[None, None, None]:
     """Clears the MPI of environment variables.
 
     ``from mpi4py import MPI`` will call ``MPI_Init`` by default.

--- a/gymnasium/vector/utils/shared_memory.py
+++ b/gymnasium/vector/utils/shared_memory.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import multiprocessing as mp
-from ctypes import c_bool
+from collections.abc import Mapping
+from ctypes import c_bool, c_int32, c_int64
 from functools import singledispatch
 from multiprocessing.sharedctypes import SynchronizedArray
-from typing import Any
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import numpy as np
 
@@ -26,13 +28,23 @@ from gymnasium.spaces import (
     flatten,
 )
 
+if TYPE_CHECKING:
+    from typing_extensions import Never, Unpack
+
 __all__ = ["create_shared_memory", "read_from_shared_memory", "write_to_shared_memory"]
+
+
+_SharedMemory: TypeAlias = dict[str, Any] | tuple[Any, ...] | SynchronizedArray[Any]
+_SharedMemoryOneOf: TypeAlias = tuple[
+    SynchronizedArray[c_int64],
+    Unpack[tuple[SynchronizedArray[Any], ...]],
+]
 
 
 @singledispatch
 def create_shared_memory(
-    space: Space[Any], n: int = 1, ctx=mp
-) -> dict[str, Any] | tuple[Any, ...] | SynchronizedArray:
+    space: Space[Any], n: int = 1, ctx: ModuleType = mp
+) -> _SharedMemory:
     """Create a shared memory object, to be shared across processes.
 
     This eventually contains the observations from the vectorized environment.
@@ -63,8 +75,10 @@ def create_shared_memory(
 @create_shared_memory.register(MultiDiscrete)
 @create_shared_memory.register(MultiBinary)
 def _create_base_shared_memory(
-    space: Box | Discrete | MultiDiscrete | MultiBinary, n: int = 1, ctx=mp
-):
+    space: Box | Discrete | MultiDiscrete | MultiBinary,
+    n: int = 1,
+    ctx: ModuleType = mp,
+) -> SynchronizedArray[Any]:
     assert space.dtype is not None
     assert space.shape is not None
     dtype = space.dtype.char
@@ -74,14 +88,18 @@ def _create_base_shared_memory(
 
 
 @create_shared_memory.register(Tuple)
-def _create_tuple_shared_memory(space: Tuple, n: int = 1, ctx=mp):
+def _create_tuple_shared_memory(
+    space: Tuple, n: int = 1, ctx: ModuleType = mp
+) -> tuple[Any, ...]:
     return tuple(
         create_shared_memory(subspace, n=n, ctx=ctx) for subspace in space.spaces
     )
 
 
 @create_shared_memory.register(Dict)
-def _create_dict_shared_memory(space: Dict, n: int = 1, ctx=mp):
+def _create_dict_shared_memory(
+    space: Dict, n: int = 1, ctx: ModuleType = mp
+) -> dict[str, Any]:
     return {
         key: create_shared_memory(subspace, n=n, ctx=ctx)
         for (key, subspace) in space.spaces.items()
@@ -89,12 +107,16 @@ def _create_dict_shared_memory(space: Dict, n: int = 1, ctx=mp):
 
 
 @create_shared_memory.register(Text)
-def _create_text_shared_memory(space: Text, n: int = 1, ctx=mp):
+def _create_text_shared_memory(
+    space: Text, n: int = 1, ctx: ModuleType = mp
+) -> SynchronizedArray[c_int32]:
     return ctx.Array(np.dtype(np.int32).char, n * space.max_length)
 
 
 @create_shared_memory.register(OneOf)
-def _create_oneof_shared_memory(space: OneOf, n: int = 1, ctx=mp):
+def _create_oneof_shared_memory(
+    space: OneOf, n: int = 1, ctx: ModuleType = mp
+) -> _SharedMemoryOneOf:
     return (ctx.Array(np.dtype(np.int64).char, n),) + tuple(
         create_shared_memory(subspace, n=n, ctx=ctx) for subspace in space.spaces
     )
@@ -102,7 +124,9 @@ def _create_oneof_shared_memory(space: OneOf, n: int = 1, ctx=mp):
 
 @create_shared_memory.register(Graph)
 @create_shared_memory.register(Sequence)
-def _create_dynamic_shared_memory(space: Graph | Sequence, n: int = 1, ctx=mp):
+def _create_dynamic_shared_memory(
+    space: Graph | Sequence, n: int = 1, ctx: ModuleType = mp
+) -> Never:
     raise TypeError(
         f"As {space} has a dynamic shape so its not possible to make a static shared memory. For `AsyncVectorEnv`, disable `shared_memory`."
     )
@@ -110,7 +134,7 @@ def _create_dynamic_shared_memory(space: Graph | Sequence, n: int = 1, ctx=mp):
 
 @singledispatch
 def read_from_shared_memory(
-    space: Space, shared_memory: dict | tuple | SynchronizedArray, n: int = 1
+    space: Space, shared_memory: _SharedMemory, n: int = 1
 ) -> dict[str, Any] | tuple[Any, ...] | np.ndarray:
     """Read the batch of observations from shared memory as a numpy array.
 
@@ -146,15 +170,22 @@ def read_from_shared_memory(
 @read_from_shared_memory.register(MultiDiscrete)
 @read_from_shared_memory.register(MultiBinary)
 def _read_base_from_shared_memory(
-    space: Box | Discrete | MultiDiscrete | MultiBinary, shared_memory, n: int = 1
-):
-    return np.frombuffer(shared_memory.get_obj(), dtype=space.dtype).reshape(
-        (n,) + space.shape
-    )
+    space: Box | Discrete | MultiDiscrete | MultiBinary,
+    shared_memory: SynchronizedArray[Any],
+    n: int = 1,
+) -> np.ndarray:
+    assert space.shape is not None
+    # the `ty:ignore` is needed because of a bug in the typeshed `multiprocessing` stubs
+    return np.frombuffer(  # ty:ignore[no-matching-overload]
+        shared_memory.get_obj(),
+        dtype=space.dtype,
+    ).reshape((n,) + space.shape)
 
 
 @read_from_shared_memory.register(Tuple)
-def _read_tuple_from_shared_memory(space: Tuple, shared_memory, n: int = 1):
+def _read_tuple_from_shared_memory(
+    space: Tuple, shared_memory: tuple[_SharedMemory, ...], n: int = 1
+) -> tuple[Any, ...]:
     return tuple(
         read_from_shared_memory(subspace, memory, n=n)
         for (memory, subspace) in zip(shared_memory, space.spaces, strict=True)
@@ -162,7 +193,9 @@ def _read_tuple_from_shared_memory(space: Tuple, shared_memory, n: int = 1):
 
 
 @read_from_shared_memory.register(Dict)
-def _read_dict_from_shared_memory(space: Dict, shared_memory, n: int = 1):
+def _read_dict_from_shared_memory(
+    space: Dict, shared_memory: dict[str, _SharedMemory], n: int = 1
+) -> dict[str, Any]:
     return {
         key: read_from_shared_memory(subspace, shared_memory[key], n=n)
         for (key, subspace) in space.spaces.items()
@@ -171,11 +204,13 @@ def _read_dict_from_shared_memory(space: Dict, shared_memory, n: int = 1):
 
 @read_from_shared_memory.register(Text)
 def _read_text_from_shared_memory(
-    space: Text, shared_memory, n: int = 1
+    space: Text, shared_memory: SynchronizedArray[c_int32], n: int = 1
 ) -> tuple[str, ...]:
-    data = np.frombuffer(shared_memory.get_obj(), dtype=np.int32).reshape(
-        (n, space.max_length)
-    )
+    # the `ty:ignore` is needed because of a bug in the typeshed `multiprocessing` stubs
+    data = np.frombuffer(  # ty:ignore[no-matching-overload]
+        shared_memory.get_obj(),
+        dtype=np.int32,
+    ).reshape((n, space.max_length))
 
     return tuple(
         "".join(
@@ -191,7 +226,7 @@ def _read_text_from_shared_memory(
 
 @read_from_shared_memory.register(OneOf)
 def _read_one_of_from_shared_memory(
-    space: OneOf, shared_memory, n: int = 1
+    space: OneOf, shared_memory: _SharedMemoryOneOf, n: int = 1
 ) -> tuple[Any, ...]:
     sample_indexes = np.frombuffer(shared_memory[0].get_obj(), dtype=np.int64)
 
@@ -211,7 +246,7 @@ def write_to_shared_memory(
     index: int,
     value: np.ndarray,
     shared_memory: dict[str, Any] | tuple[Any, ...] | SynchronizedArray,
-):
+) -> None:
     """Write the observation of a single environment into shared memory.
 
     Args:
@@ -241,12 +276,13 @@ def write_to_shared_memory(
 def _write_base_to_shared_memory(
     space: Box | Discrete | MultiDiscrete | MultiBinary,
     index: int,
-    value,
-    shared_memory,
-):
+    value: np.typing.ArrayLike,
+    shared_memory: SynchronizedArray[Any],
+) -> None:
     assert space.shape is not None
     size = int(np.prod(space.shape))
-    destination = np.frombuffer(shared_memory.get_obj(), dtype=space.dtype)
+    # the `ty:ignore` is needed because of a bug in the typeshed `multiprocessing` stubs
+    destination = np.frombuffer(shared_memory.get_obj(), dtype=space.dtype)  # ty:ignore[no-matching-overload]
     np.copyto(
         destination[index * size : (index + 1) * size],
         np.asarray(value, dtype=space.dtype).flatten(),
@@ -255,8 +291,11 @@ def _write_base_to_shared_memory(
 
 @write_to_shared_memory.register(Tuple)
 def _write_tuple_to_shared_memory(
-    space: Tuple, index: int, values: tuple[Any, ...], shared_memory
-):
+    space: Tuple,
+    index: int,
+    values: tuple[Any, ...],
+    shared_memory: tuple[_SharedMemory, ...],
+) -> None:
     for value, memory, subspace in zip(
         values, shared_memory, space.spaces, strict=True
     ):
@@ -265,26 +304,29 @@ def _write_tuple_to_shared_memory(
 
 @write_to_shared_memory.register(Dict)
 def _write_dict_to_shared_memory(
-    space: Dict, index: int, values: dict[str, Any], shared_memory
-):
+    space: Dict, index: int, values: dict[str, Any], shared_memory: Mapping[str, Any]
+) -> None:
     for key, subspace in space.spaces.items():
         write_to_shared_memory(subspace, index, values[key], shared_memory[key])
 
 
 @write_to_shared_memory.register(Text)
-def _write_text_to_shared_memory(space: Text, index: int, values: str, shared_memory):
+def _write_text_to_shared_memory(
+    space: Text, index: int, values: str, shared_memory: SynchronizedArray[c_int32]
+) -> None:
     size = space.max_length
-    destination = np.frombuffer(shared_memory.get_obj(), dtype=np.int32)
+    # the `ty:ignore` is needed because of a bug in the typeshed `multiprocessing` stubs
+    destination = np.frombuffer(shared_memory.get_obj(), dtype=np.int32)  # ty:ignore[no-matching-overload]
     np.copyto(
         destination[index * size : (index + 1) * size],
-        flatten(space, values),
+        flatten(space, values),  # ty:ignore[invalid-argument-type]
     )
 
 
 @write_to_shared_memory.register(OneOf)
 def _write_oneof_to_shared_memory(
-    space: OneOf, index: int, values: tuple[int, Any], shared_memory
-):
+    space: OneOf, index: int, values: tuple[int, Any], shared_memory: _SharedMemoryOneOf
+) -> None:
     subspace_idx, space_value = values
 
     destination = np.frombuffer(shared_memory[0].get_obj(), dtype=np.int64)

--- a/gymnasium/vector/utils/shared_memory.py
+++ b/gymnasium/vector/utils/shared_memory.py
@@ -34,10 +34,10 @@ if TYPE_CHECKING:
 __all__ = ["create_shared_memory", "read_from_shared_memory", "write_to_shared_memory"]
 
 
-_SharedMemory: TypeAlias = dict[str, Any] | tuple[Any, ...] | SynchronizedArray[Any]
+_SharedMemory: TypeAlias = dict[str, Any] | tuple[Any, ...] | SynchronizedArray
 _SharedMemoryOneOf: TypeAlias = tuple[
-    SynchronizedArray[c_int64],
-    Unpack[tuple[SynchronizedArray[Any], ...]],
+    "SynchronizedArray[c_int64]",
+    "Unpack[tuple[SynchronizedArray[Any], ...]]",
 ]
 
 

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -9,11 +9,11 @@
 
 from __future__ import annotations
 
-import typing
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from collections.abc import Sequence as _PySequence
 from copy import deepcopy
 from functools import singledispatch
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import numpy as np
 
@@ -32,6 +32,9 @@ from gymnasium.spaces import (
     Text,
     Tuple,
 )
+
+if TYPE_CHECKING:
+    from typing_extensions import Never
 
 __all__ = [
     "batch_space",
@@ -74,14 +77,14 @@ def batch_space(space: Space[Any], n: int = 1) -> Space[Any]:
 
 
 @batch_space.register(Box)
-def _batch_space_box(space: Box, n: int = 1):
+def _batch_space_box(space: Box, n: int = 1) -> Box:
     repeats = tuple([n] + [1] * space.low.ndim)
     low, high = np.tile(space.low, repeats), np.tile(space.high, repeats)
     return Box(low=low, high=high, dtype=space.dtype, seed=deepcopy(space.np_random))
 
 
 @batch_space.register(Discrete)
-def _batch_space_discrete(space: Discrete, n: int = 1):
+def _batch_space_discrete(space: Discrete, n: int = 1) -> MultiDiscrete:
     return MultiDiscrete(
         np.full((n,), space.n, dtype=space.dtype),
         dtype=space.dtype,
@@ -91,7 +94,7 @@ def _batch_space_discrete(space: Discrete, n: int = 1):
 
 
 @batch_space.register(MultiDiscrete)
-def _batch_space_multidiscrete(space: MultiDiscrete, n: int = 1):
+def _batch_space_multidiscrete(space: MultiDiscrete, n: int = 1) -> Box:
     repeats = tuple([n] + [1] * space.nvec.ndim)
     low = np.tile(space.start, repeats)
     high = low + np.tile(space.nvec, repeats) - 1
@@ -104,7 +107,7 @@ def _batch_space_multidiscrete(space: MultiDiscrete, n: int = 1):
 
 
 @batch_space.register(MultiBinary)
-def _batch_space_multibinary(space: MultiBinary, n: int = 1):
+def _batch_space_multibinary(space: MultiBinary, n: int = 1) -> Box:
     return Box(
         low=0,
         high=1,
@@ -115,7 +118,7 @@ def _batch_space_multibinary(space: MultiBinary, n: int = 1):
 
 
 @batch_space.register(Tuple)
-def _batch_space_tuple(space: Tuple, n: int = 1):
+def _batch_space_tuple(space: Tuple, n: int = 1) -> Tuple:
     return Tuple(
         tuple(batch_space(subspace, n=n) for subspace in space.spaces),
         seed=deepcopy(space.np_random),
@@ -123,7 +126,7 @@ def _batch_space_tuple(space: Tuple, n: int = 1):
 
 
 @batch_space.register(Dict)
-def _batch_space_dict(space: Dict, n: int = 1):
+def _batch_space_dict(space: Dict, n: int = 1) -> Dict:
     return Dict(
         {key: batch_space(subspace, n=n) for key, subspace in space.items()},
         seed=deepcopy(space.np_random),
@@ -135,7 +138,7 @@ def _batch_space_dict(space: Dict, n: int = 1):
 @batch_space.register(Sequence)
 @batch_space.register(OneOf)
 @batch_space.register(Space)
-def _batch_space_custom(space: Graph | Text | Sequence | OneOf, n: int = 1):
+def _batch_space_custom(space: Graph | Text | Sequence | OneOf, n: int = 1) -> Tuple:
     # Without deepcopy, then the space.np_random is batched_space.spaces[0].np_random
     # Which is an issue if you are sampling actions of both the original space and the batched space
     batched_space = Tuple(
@@ -148,7 +151,7 @@ def _batch_space_custom(space: Graph | Text | Sequence | OneOf, n: int = 1):
 
 
 @singledispatch
-def batch_differing_spaces(spaces: typing.Sequence[Space]) -> Space:
+def batch_differing_spaces(spaces: _PySequence[Space]) -> Space:
     """Batch a Sequence of spaces where subspaces to contain minor differences.
 
     Args:
@@ -175,7 +178,7 @@ def batch_differing_spaces(spaces: typing.Sequence[Space]) -> Space:
 
 
 @batch_differing_spaces.register(Box)
-def _batch_differing_spaces_box(spaces: list[Box]):
+def _batch_differing_spaces_box(spaces: _PySequence[Box]) -> Box:
     assert all(spaces[0].dtype == space.dtype for space in spaces), (
         f"Expected all dtypes to be equal, actually {[space.dtype for space in spaces]}"
     )
@@ -195,7 +198,7 @@ def _batch_differing_spaces_box(spaces: list[Box]):
 
 
 @batch_differing_spaces.register(Discrete)
-def _batch_differing_spaces_discrete(spaces: list[Discrete]):
+def _batch_differing_spaces_discrete(spaces: _PySequence[Discrete]) -> MultiDiscrete:
     # select the "largest" to fit others.
     # Assumes all spaces dtype are of int dtype
     dtypes = [space.dtype for space in spaces]
@@ -209,7 +212,7 @@ def _batch_differing_spaces_discrete(spaces: list[Discrete]):
 
 
 @batch_differing_spaces.register(MultiDiscrete)
-def _batch_differing_spaces_multi_discrete(spaces: list[MultiDiscrete]):
+def _batch_differing_spaces_multi_discrete(spaces: _PySequence[MultiDiscrete]) -> Box:
     assert all(spaces[0].dtype == space.dtype for space in spaces), (
         f"Expected all dtypes to be equal, actually {[space.dtype for space in spaces]}"
     )
@@ -229,7 +232,7 @@ def _batch_differing_spaces_multi_discrete(spaces: list[MultiDiscrete]):
 
 
 @batch_differing_spaces.register(MultiBinary)
-def _batch_differing_spaces_multi_binary(spaces: list[MultiBinary]):
+def _batch_differing_spaces_multi_binary(spaces: _PySequence[MultiBinary]) -> Box:
     assert all(spaces[0].shape == space.shape for space in spaces)
 
     return Box(
@@ -242,7 +245,7 @@ def _batch_differing_spaces_multi_binary(spaces: list[MultiBinary]):
 
 
 @batch_differing_spaces.register(Tuple)
-def _batch_differing_spaces_tuple(spaces: list[Tuple]):
+def _batch_differing_spaces_tuple(spaces: _PySequence[Tuple]) -> Tuple:
     return Tuple(
         tuple(
             batch_differing_spaces(subspaces)
@@ -253,7 +256,7 @@ def _batch_differing_spaces_tuple(spaces: list[Tuple]):
 
 
 @batch_differing_spaces.register(Dict)
-def _batch_differing_spaces_dict(spaces: list[Dict]):
+def _batch_differing_spaces_dict(spaces: _PySequence[Dict]) -> Dict:
     assert all(spaces[0].keys() == space.keys() for space in spaces)
 
     return Dict(
@@ -269,14 +272,16 @@ def _batch_differing_spaces_dict(spaces: list[Dict]):
 @batch_differing_spaces.register(Text)
 @batch_differing_spaces.register(Sequence)
 @batch_differing_spaces.register(OneOf)
-def _batch_spaces_undefined(spaces: list[Graph | Text | Sequence | OneOf]):
+def _batch_spaces_undefined(
+    spaces: _PySequence[Graph | Text | Sequence | OneOf],
+) -> Tuple:
     return Tuple(
         [deepcopy(space) for space in spaces], seed=deepcopy(spaces[0].np_random)
     )
 
 
 @singledispatch
-def iterate(space: Space[_T], items: _T) -> Iterator:
+def iterate(space: Space[_T], items: _T) -> Iterator[Any]:
     """Iterate over the elements of a (batched) space.
 
     Args:
@@ -311,14 +316,16 @@ def iterate(space: Space[_T], items: _T) -> Iterator:
 
 
 @iterate.register(Discrete)
-def _iterate_discrete(space: Discrete, items: Iterable):
+def _iterate_discrete(space: Discrete, items: Iterable[Any]) -> Never:
     raise TypeError("Unable to iterate over a space of type `Discrete`.")
 
 
 @iterate.register(Box)
 @iterate.register(MultiDiscrete)
 @iterate.register(MultiBinary)
-def _iterate_base(space: Box | MultiDiscrete | MultiBinary, items: np.ndarray):
+def _iterate_base(
+    space: Box | MultiDiscrete | MultiBinary, items: np.ndarray
+) -> Iterator[Any]:
     try:
         return iter(items)
     except TypeError as e:
@@ -328,7 +335,7 @@ def _iterate_base(space: Box | MultiDiscrete | MultiBinary, items: np.ndarray):
 
 
 @iterate.register(Tuple)
-def _iterate_tuple(space: Tuple, items: tuple[Any, ...]):
+def _iterate_tuple(space: Tuple, items: tuple[Any, ...]) -> Iterator[Any]:
     # If this is a tuple of custom subspaces only, then simply iterate over items
     if all(type(subspace) in iterate.registry for subspace in space):
         return zip(
@@ -350,7 +357,7 @@ def _iterate_tuple(space: Tuple, items: tuple[Any, ...]):
 
 
 @iterate.register(Dict)
-def _iterate_dict(space: Dict, items: dict[str, Any]):
+def _iterate_dict(space: Dict, items: Mapping[str, Any]) -> Iterator[dict[str, Any]]:
     keys, values = zip(
         *[
             (key, iterate(subspace, items[key]))
@@ -364,7 +371,7 @@ def _iterate_dict(space: Dict, items: dict[str, Any]):
 
 @singledispatch
 def concatenate(
-    space: Space, items: Iterable, out: tuple[Any, ...] | dict[str, Any] | np.ndarray
+    space: Space, items: Iterable, out: tuple[Any, ...] | Mapping[str, Any] | np.ndarray
 ) -> tuple[Any, ...] | dict[str, Any] | np.ndarray:
     """Concatenate multiple samples from space into a single object.
 
@@ -418,7 +425,7 @@ def _concatenate_tuple(
 
 @concatenate.register(Dict)
 def _concatenate_dict(
-    space: Dict, items: Iterable, out: dict[str, Any]
+    space: Dict, items: Iterable, out: Mapping[str, Any]
 ) -> dict[str, Any]:
     return {
         key: concatenate(subspace, [item[key] for item in items], out[key])
@@ -431,14 +438,14 @@ def _concatenate_dict(
 @concatenate.register(Sequence)
 @concatenate.register(Space)
 @concatenate.register(OneOf)
-def _concatenate_custom(space: Space, items: Iterable, out: None) -> tuple[Any, ...]:
+def _concatenate_custom(space: Space, items: Iterable[_T], out: None) -> tuple[_T, ...]:
     return tuple(items)
 
 
 @singledispatch
 def create_empty_array(
     space: Space, n: int = 1, fn: Callable = np.zeros
-) -> tuple[Any, ...] | dict[str, Any] | np.ndarray:
+) -> tuple[Any, ...] | dict[str, Any] | np.ndarray | None:
     """Create an empty (possibly nested and normally numpy-based) array, used in conjunction with ``concatenate(..., out=array)``.
 
     In most cases, the array will be contained within the batched space, however, this is not guaranteed.
@@ -476,17 +483,23 @@ def create_empty_array(
 @create_empty_array.register(Discrete)
 @create_empty_array.register(MultiDiscrete)
 @create_empty_array.register(MultiBinary)
-def _create_empty_array_multi(space: Box, n: int = 1, fn=np.zeros) -> np.ndarray:
+def _create_empty_array_multi(
+    space: Box, n: int = 1, fn: Callable = np.zeros
+) -> np.ndarray:
     return fn((n,) + space.shape, dtype=space.dtype)
 
 
 @create_empty_array.register(Tuple)
-def _create_empty_array_tuple(space: Tuple, n: int = 1, fn=np.zeros) -> tuple[Any, ...]:
+def _create_empty_array_tuple(
+    space: Tuple, n: int = 1, fn: Callable = np.zeros
+) -> tuple[Any, ...]:
     return tuple(create_empty_array(subspace, n=n, fn=fn) for subspace in space.spaces)
 
 
 @create_empty_array.register(Dict)
-def _create_empty_array_dict(space: Dict, n: int = 1, fn=np.zeros) -> dict[str, Any]:
+def _create_empty_array_dict(
+    space: Dict, n: int = 1, fn: Callable = np.zeros
+) -> dict[str, Any]:
     return {
         key: create_empty_array(subspace, n=n, fn=fn) for key, subspace in space.items()
     }
@@ -494,9 +507,11 @@ def _create_empty_array_dict(space: Dict, n: int = 1, fn=np.zeros) -> dict[str, 
 
 @create_empty_array.register(Graph)
 def _create_empty_array_graph(
-    space: Graph, n: int = 1, fn=np.zeros
+    space: Graph, n: int = 1, fn: Callable = np.zeros
 ) -> tuple[GraphInstance, ...]:
     if space.edge_space is not None:
+        assert space.node_space.shape is not None
+        assert space.edge_space.shape
         return tuple(
             GraphInstance(
                 nodes=fn((1,) + space.node_space.shape, dtype=space.node_space.dtype),
@@ -506,6 +521,7 @@ def _create_empty_array_graph(
             for _ in range(n)
         )
     else:
+        assert space.node_space.shape is not None
         return tuple(
             GraphInstance(
                 nodes=fn((1,) + space.node_space.shape, dtype=space.node_space.dtype),
@@ -517,13 +533,15 @@ def _create_empty_array_graph(
 
 
 @create_empty_array.register(Text)
-def _create_empty_array_text(space: Text, n: int = 1, fn=np.zeros) -> tuple[str, ...]:
+def _create_empty_array_text(
+    space: Text, n: int = 1, fn: Callable = np.zeros
+) -> tuple[str, ...]:
     return tuple(space.characters[0] * space.min_length for _ in range(n))
 
 
 @create_empty_array.register(Sequence)
 def _create_empty_array_sequence(
-    space: Sequence, n: int = 1, fn=np.zeros
+    space: Sequence, n: int = 1, fn: Callable = np.zeros
 ) -> tuple[Any, ...]:
     if space.stack:
         return tuple(
@@ -534,10 +552,14 @@ def _create_empty_array_sequence(
 
 
 @create_empty_array.register(OneOf)
-def _create_empty_array_oneof(space: OneOf, n: int = 1, fn=np.zeros):
+def _create_empty_array_oneof(
+    space: OneOf, n: int = 1, fn: Callable = np.zeros
+) -> tuple[tuple[()], ...]:
     return tuple(tuple() for _ in range(n))
 
 
 @create_empty_array.register(Space)
-def _create_empty_array_custom(space, n=1, fn=np.zeros):
+def _create_empty_array_custom(
+    space: Space, n: int = 1, fn: Callable = np.zeros
+) -> None:
     return None

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -511,7 +511,7 @@ def _create_empty_array_graph(
 ) -> tuple[GraphInstance, ...]:
     if space.edge_space is not None:
         assert space.node_space.shape is not None
-        assert space.edge_space.shape
+        assert space.edge_space.shape is not None
         return tuple(
             GraphInstance(
                 nodes=fn((1,) + space.node_space.shape, dtype=space.node_space.dtype),

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -121,7 +121,7 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
 
     metadata: dict[str, Any] = {}
     spec: EnvSpec | None = None
-    render_mode: tuple[RenderFrame, ...] | None = None
+    render_mode: str | None = None
     closed: bool = False
 
     observation_space: gym.Space
@@ -502,7 +502,7 @@ class VectorWrapper(VectorEnv):
         return self.env.spec
 
     @property
-    def render_mode(self) -> tuple[RenderFrame, ...] | None:
+    def render_mode(self) -> str | None:
         """Returns the `render_mode` from the base environment."""
         return self.env.render_mode
 

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -13,6 +13,8 @@ from gymnasium.logger import warn
 from gymnasium.utils import seeding
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from gymnasium.envs.registration import EnvSpec
 
 ArrayType = TypeVar("ArrayType")
@@ -119,7 +121,7 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
 
     metadata: dict[str, Any] = {}
     spec: EnvSpec | None = None
-    render_mode: str | None = None
+    render_mode: tuple[RenderFrame, ...] | None = None
     closed: bool = False
 
     observation_space: gym.Space
@@ -210,7 +212,7 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
             f"{self.__str__()} render function is not implemented."
         )
 
-    def close(self, **kwargs: Any):
+    def close(self, **kwargs: Any) -> None:
         """Close all parallel environments and release resources.
 
         It also closes all the existing image viewers, then calls :meth:`close_extras` and set
@@ -233,7 +235,7 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
         self.close_extras(**kwargs)
         self.closed = True
 
-    def close_extras(self, **kwargs: Any):
+    def close_extras(self) -> None:
         """Clean up the extra resources e.g. beyond what's in this base class."""
         pass
 
@@ -249,7 +251,7 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
         return self._np_random
 
     @np_random.setter
-    def np_random(self, value: np.random.Generator):
+    def np_random(self, value: np.random.Generator) -> None:
         self._np_random = value
         self._np_random_seed = -1
 
@@ -268,7 +270,7 @@ class VectorEnv(Generic[ObsType, ActType, ArrayType]):
         return self._np_random_seed
 
     @property
-    def unwrapped(self):
+    def unwrapped(self) -> Self:
         """Return the base environment."""
         return self
 
@@ -360,7 +362,9 @@ class VectorWrapper(VectorEnv):
         Don't forget to call ``super().__init__(env)`` if the subclass overrides :meth:`__init__`.
     """
 
-    def __init__(self, env: VectorEnv):
+    env: VectorEnv
+
+    def __init__(self, env: VectorEnv) -> None:
         """Initialize the vectorized environment wrapper.
 
         Args:
@@ -378,10 +382,7 @@ class VectorWrapper(VectorEnv):
         self._metadata: dict[str, Any] | None = None
 
     def reset(
-        self,
-        *,
-        seed: int | list[int] | None = None,
-        options: dict[str, Any] | None = None,
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
     ) -> tuple[ObsType, dict[str, Any]]:
         """Reset all environment using seed and options."""
         return self.env.reset(seed=seed, options=options)
@@ -396,20 +397,20 @@ class VectorWrapper(VectorEnv):
         """Returns the render mode from the base vector environment."""
         return self.env.render()
 
-    def close(self, **kwargs: Any):
+    def close(self, **kwargs: Any) -> None:
         """Close all environments."""
         return self.env.close(**kwargs)
 
-    def close_extras(self, **kwargs: Any):
+    def close_extras(self, **kwargs: Any) -> None:
         """Close all extra resources."""
         return self.env.close_extras(**kwargs)
 
     @property
-    def unwrapped(self):
+    def unwrapped(self) -> VectorEnv:
         """Return the base non-wrapped environment."""
         return self.env.unwrapped
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return the string representation of the vectorized environment."""
         return f"<{self.__class__.__name__}, {self.env}>"
 
@@ -421,7 +422,7 @@ class VectorWrapper(VectorEnv):
         return self._observation_space
 
     @observation_space.setter
-    def observation_space(self, space: gym.Space):
+    def observation_space(self, space: gym.Space) -> None:
         """Sets the observation space of the vector environment."""
         self._observation_space = space
 
@@ -433,7 +434,7 @@ class VectorWrapper(VectorEnv):
         return self._action_space
 
     @action_space.setter
-    def action_space(self, space: gym.Space):
+    def action_space(self, space: gym.Space) -> None:
         """Sets the action space of the vector environment."""
         self._action_space = space
 
@@ -445,7 +446,7 @@ class VectorWrapper(VectorEnv):
         return self._single_observation_space
 
     @single_observation_space.setter
-    def single_observation_space(self, space: gym.Space):
+    def single_observation_space(self, space: gym.Space) -> None:
         """Sets the single observation space of the vector environment."""
         self._single_observation_space = space
 
@@ -457,7 +458,7 @@ class VectorWrapper(VectorEnv):
         return self._single_action_space
 
     @single_action_space.setter
-    def single_action_space(self, space):
+    def single_action_space(self, space: gym.Space) -> None:
         """Sets the single action space of the vector environment."""
         self._single_action_space = space
 
@@ -476,7 +477,7 @@ class VectorWrapper(VectorEnv):
         return self.env.np_random
 
     @np_random.setter
-    def np_random(self, value: np.random.Generator):
+    def np_random(self, value: np.random.Generator) -> None:
         self.env.np_random = value
 
     @property
@@ -485,14 +486,14 @@ class VectorWrapper(VectorEnv):
         return self.env.np_random_seed
 
     @property
-    def metadata(self):
+    def metadata(self) -> dict[str, Any]:
         """The metadata of the vector environment."""
         if self._metadata is not None:
             return self._metadata
         return self.env.metadata
 
     @metadata.setter
-    def metadata(self, value):
+    def metadata(self, value: dict[str, Any]) -> None:
         self._metadata = value
 
     @property
@@ -506,12 +507,12 @@ class VectorWrapper(VectorEnv):
         return self.env.render_mode
 
     @property
-    def closed(self):
+    def closed(self) -> bool:
         """If the environment has closes."""
         return self.env.closed
 
     @closed.setter
-    def closed(self, value: bool):
+    def closed(self, value: bool) -> None:
         self.env.closed = value
 
 
@@ -521,7 +522,7 @@ class VectorObservationWrapper(VectorWrapper):
     Equivalent to :class:`gymnasium.ObservationWrapper` for vectorized environments.
     """
 
-    def __init__(self, env: VectorEnv):
+    def __init__(self, env: VectorEnv) -> None:
         """Vector observation wrapper that batch transforms observations.
 
         Args:
@@ -539,10 +540,7 @@ class VectorObservationWrapper(VectorWrapper):
             )
 
     def reset(
-        self,
-        *,
-        seed: int | list[int] | None = None,
-        options: dict[str, Any] | None = None,
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
     ) -> tuple[ObsType, dict[str, Any]]:
         """Modifies the observation returned from the environment ``reset`` using the :meth:`observation`."""
         observations, infos = self.env.reset(seed=seed, options=options)


### PR DESCRIPTION
# Description

Here's yet another batch of static typing improvements and fixes, this time for `gymnasium.vector.*` and `gymnasium.vector.utils.*`.

## Type of change

Static typing fixes and improvements.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

