### PR TITLE
Fix typing errors and add missing annotations in `wrappers.vector.*`

### DIFF
--- a/gymnasium/wrappers/vector/__init__.py
+++ b/gymnasium/wrappers/vector/__init__.py
@@ -1,7 +1,7 @@
 """Wrappers for vector environments."""
 
 # pyright: reportUnsupportedDunderAll=false
-import importlib
+from typing import TYPE_CHECKING
 
 from gymnasium.wrappers.vector.common import RecordEpisodeStatistics
 from gymnasium.wrappers.vector.dict_info_to_list import DictInfoToList
@@ -72,38 +72,44 @@ __all__ = [
     "NumpyToTorch",
 ]
 
+if TYPE_CHECKING:
+    from .array_conversion import ArrayConversion
+    from .jax_to_numpy import JaxToNumpy
+    from .jax_to_torch import JaxToTorch
+    from .numpy_to_torch import NumpyToTorch
+else:
+    import importlib
 
-# As these wrappers requires `jax` or `torch`, they are loaded by runtime on users trying to access them
-#   to avoid `import jax` or `import torch` on `import gymnasium`.
-_wrapper_to_class = {
-    # data converters
-    "ArrayConversion": "array_conversion",
-    "JaxToNumpy": "jax_to_numpy",
-    "JaxToTorch": "jax_to_torch",
-    "NumpyToTorch": "numpy_to_torch",
-}
+    # As these wrappers requires `jax` or `torch`, they are loaded by runtime on users trying to access them
+    #   to avoid `import jax` or `import torch` on `import gymnasium`.
+    _wrapper_to_class = {
+        # data converters
+        "ArrayConversion": "array_conversion",
+        "JaxToNumpy": "jax_to_numpy",
+        "JaxToTorch": "jax_to_torch",
+        "NumpyToTorch": "numpy_to_torch",
+    }
 
+    def __getattr__(wrapper_name: str):
+        """Load a wrapper by name.
 
-def __getattr__(wrapper_name: str):
-    """Load a wrapper by name.
+        This optimizes the loading of gymnasium wrappers by only loading the wrapper if it is used.
+        Errors will be raised if the wrapper does not exist or if the version is not the latest.
 
-    This optimizes the loading of gymnasium wrappers by only loading the wrapper if it is used.
-    Errors will be raised if the wrapper does not exist or if the version is not the latest.
+        Args:
+            wrapper_name: The name of a wrapper to load.
 
-    Args:
-        wrapper_name: The name of a wrapper to load.
+        Returns:
+            The specified wrapper.
 
-    Returns:
-        The specified wrapper.
+        Raises:
+            AttributeError: If the wrapper does not exist.
+            DeprecatedWrapper: If the version is not the latest.
+        """
+        # Check if the requested wrapper is in the _wrapper_to_class dictionary
+        if wrapper_name in _wrapper_to_class:
+            import_stmt = f"gymnasium.wrappers.vector.{_wrapper_to_class[wrapper_name]}"
+            module = importlib.import_module(import_stmt)
+            return getattr(module, wrapper_name)
 
-    Raises:
-        AttributeError: If the wrapper does not exist.
-        DeprecatedWrapper: If the version is not the latest.
-    """
-    # Check if the requested wrapper is in the _wrapper_to_class dictionary
-    if wrapper_name in _wrapper_to_class:
-        import_stmt = f"gymnasium.wrappers.vector.{_wrapper_to_class[wrapper_name]}"
-        module = importlib.import_module(import_stmt)
-        return getattr(module, wrapper_name)
-
-    raise AttributeError(f"module {__name__!r} has no attribute {wrapper_name!r}")
+        raise AttributeError(f"module {__name__!r} has no attribute {wrapper_name!r}")

--- a/gymnasium/wrappers/vector/array_conversion.py
+++ b/gymnasium/wrappers/vector/array_conversion.py
@@ -37,11 +37,11 @@ class ArrayConversion(VectorWrapper, gym.utils.RecordConstructorArgs):
     def __init__(
         self,
         env: VectorEnv,
-        env_xp: ModuleType | str,
-        target_xp: ModuleType | str,
+        env_xp: ModuleType,
+        target_xp: ModuleType,
         env_device: Device | None = None,
         target_device: Device | None = None,
-    ):
+    ) -> None:
         """Wrapper class to change inputs and outputs of environment to any Array API framework.
 
         Args:
@@ -108,7 +108,7 @@ class ArrayConversion(VectorWrapper, gym.utils.RecordConstructorArgs):
             device=self._target_device,
         )
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
         """Returns the object pickle state with args and kwargs."""
         env_xp_name = self._env_xp.__name__.replace("array_api_compat.", "")
         target_xp_name = self._target_xp.__name__.replace("array_api_compat.", "")
@@ -122,7 +122,7 @@ class ArrayConversion(VectorWrapper, gym.utils.RecordConstructorArgs):
             "env": self.env,
         }
 
-    def __setstate__(self, d):
+    def __setstate__(self, d: dict[str, Any]) -> None:
         """Sets the object pickle state using d."""
         self.env = d["env"]
         self._env_xp = module_name_to_namespace(d["env_xp_name"])

--- a/gymnasium/wrappers/vector/common.py
+++ b/gymnasium/wrappers/vector/common.py
@@ -151,7 +151,7 @@ class RecordEpisodeStatistics(VectorWrapper):
     ) -> tuple[
         np.ndarray,
         npt.NDArray[np.float64],
-        npt.NDArray[np.int_],
+        npt.NDArray[np.bool_],
         npt.NDArray[np.bool_],
         dict[str, Any],
     ]:

--- a/gymnasium/wrappers/vector/common.py
+++ b/gymnasium/wrappers/vector/common.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 import time
 from collections import deque
+from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 
-from gymnasium.core import ActType, ObsType
 from gymnasium.logger import warn
 from gymnasium.vector.vector_env import (
-    ArrayType,
     AutoresetMode,
     VectorEnv,
     VectorWrapper,
@@ -64,12 +64,24 @@ class RecordEpisodeStatistics(VectorWrapper):
                      't': array([0.007812, 0.      , 0.      ], dtype=float32)},
     """
 
+    episode_count: int
+
+    # 1-d arrays
+    episode_start_times: np.ndarray[tuple[int], np.dtype[np.float64]]
+    episode_returns: np.ndarray[tuple[int], np.dtype[np.float64]]
+    episode_lengths: np.ndarray[tuple[int], np.dtype[np.int_]]
+    prev_dones: np.ndarray[tuple[int], np.dtype[np.bool_]]
+
+    time_queue: deque[np.float64]
+    return_queue: deque[np.float64]
+    length_queue: deque[np.int_]
+
     def __init__(
         self,
         env: VectorEnv,
         buffer_length: int = 100,
         stats_key: str = "episode",
-    ):
+    ) -> None:
         """This wrapper will keep track of cumulative rewards and episode lengths.
 
         Args:
@@ -90,10 +102,10 @@ class RecordEpisodeStatistics(VectorWrapper):
 
         self.episode_count = 0
 
-        self.episode_start_times: np.ndarray = np.zeros((self.num_envs,))
-        self.episode_returns: np.ndarray = np.zeros((self.num_envs,))
-        self.episode_lengths: np.ndarray = np.zeros((self.num_envs,), dtype=int)
-        self.prev_dones: np.ndarray = np.zeros((self.num_envs,), dtype=bool)
+        self.episode_start_times = np.zeros((self.num_envs,))
+        self.episode_returns = np.zeros((self.num_envs,))
+        self.episode_lengths = np.zeros((self.num_envs,), dtype=int)
+        self.prev_dones = np.zeros((self.num_envs,), dtype=bool)
 
         self.time_queue = deque(maxlen=buffer_length)
         self.return_queue = deque(maxlen=buffer_length)
@@ -102,8 +114,8 @@ class RecordEpisodeStatistics(VectorWrapper):
     def reset(
         self,
         seed: int | list[int] | None = None,
-        options: dict | None = None,
-    ):
+        options: dict[str, Any] | None = None,
+    ) -> tuple[np.ndarray, dict[str, Any]]:
         """Resets the environment using kwargs and resets the episode returns and lengths."""
         obs, info = super().reset(seed=seed, options=options)
 
@@ -135,8 +147,14 @@ class RecordEpisodeStatistics(VectorWrapper):
         return obs, info
 
     def step(
-        self, actions: ActType
-    ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, dict]:
+        self, actions: np.ndarray
+    ) -> tuple[
+        np.ndarray,
+        npt.NDArray[np.float64],
+        npt.NDArray[np.int_],
+        npt.NDArray[np.bool_],
+        dict[str, Any],
+    ]:
         """Steps through the environment, recording the episode statistics."""
         (
             observations,
@@ -180,7 +198,6 @@ class RecordEpisodeStatistics(VectorWrapper):
                 infos[f"_{self._stats_key}"] = dones
 
             self.episode_count += num_dones
-
             for i in np.where(dones):
                 self.time_queue.extend(episode_time_length[i])
                 self.return_queue.extend(self.episode_returns[i])

--- a/gymnasium/wrappers/vector/dict_info_to_list.py
+++ b/gymnasium/wrappers/vector/dict_info_to_list.py
@@ -81,7 +81,7 @@ class DictInfoToList(VectorWrapper):
         np.ndarray,
         npt.NDArray[np.float64],
         npt.NDArray[np.bool_],
-        npt.NDArray[np.bool],
+        npt.NDArray[np.bool_],
         list[dict[str, Any]],
     ]:  # ty:ignore[invalid-method-override]
         """Steps through the environment, convert dict info to list."""

--- a/gymnasium/wrappers/vector/dict_info_to_list.py
+++ b/gymnasium/wrappers/vector/dict_info_to_list.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from typing import Any
 
 import numpy as np
+import numpy.typing as npt
 
-from gymnasium.core import ActType, ObsType
-from gymnasium.vector.vector_env import ArrayType, VectorEnv, VectorWrapper
+from gymnasium.vector.vector_env import VectorEnv, VectorWrapper
 
 __all__ = ["DictInfoToList"]
 
@@ -66,7 +66,7 @@ class DictInfoToList(VectorWrapper):
      * v1.0.0 - Renamed to ``DictInfoToList``
     """
 
-    def __init__(self, env: VectorEnv):
+    def __init__(self, env: VectorEnv) -> None:
         """This wrapper will convert the info into the list format.
 
         Args:
@@ -74,9 +74,16 @@ class DictInfoToList(VectorWrapper):
         """
         super().__init__(env)
 
+    # ty reports an error because the last return is a `dict` in super but a `list` here
     def step(
-        self, actions: ActType
-    ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, list[dict[str, Any]]]:
+        self, actions: np.ndarray
+    ) -> tuple[
+        np.ndarray,
+        npt.NDArray[np.float64],
+        npt.NDArray[np.bool_],
+        npt.NDArray[np.bool],
+        list[dict[str, Any]],
+    ]:  # ty:ignore[invalid-method-override]
         """Steps through the environment, convert dict info to list."""
         observation, reward, terminated, truncated, infos = self.env.step(actions)
         assert isinstance(infos, dict)
@@ -84,12 +91,10 @@ class DictInfoToList(VectorWrapper):
 
         return observation, reward, terminated, truncated, list_info
 
+    # ty reports an error because the last return is a `dict` in super but a `list` here
     def reset(
-        self,
-        *,
-        seed: int | list[int] | None = None,
-        options: dict[str, Any] | None = None,
-    ) -> tuple[ObsType, list[dict[str, Any]]]:
+        self, *, seed: int | None = None, options: dict[str, Any] | None = None
+    ) -> tuple[np.ndarray, list[dict[str, Any]]]:  # ty:ignore[invalid-method-override]
         """Resets the environment using kwargs."""
         obs, infos = self.env.reset(seed=seed, options=options)
         assert isinstance(infos, dict)
@@ -97,7 +102,9 @@ class DictInfoToList(VectorWrapper):
 
         return obs, list_info
 
-    def _convert_info_to_list(self, vector_infos: dict) -> list[dict[str, Any]]:
+    def _convert_info_to_list(
+        self, vector_infos: dict[str, Any]
+    ) -> list[dict[str, Any]]:
         """Convert the dict info to list.
 
         Convert the dict info of the vectorized environment

--- a/gymnasium/wrappers/vector/rendering.py
+++ b/gymnasium/wrappers/vector/rendering.py
@@ -6,7 +6,7 @@ import gc
 import os
 from collections.abc import Callable, Sequence
 from copy import deepcopy
-from typing import Any, SupportsFloat
+from typing import TYPE_CHECKING, Any, SupportsFloat
 
 import numpy as np
 
@@ -18,6 +18,9 @@ from gymnasium.logger import warn
 from gymnasium.vector import VectorEnv, VectorWrapper
 from gymnasium.vector.vector_env import ArrayType
 
+if TYPE_CHECKING:
+    import pygame
+
 
 class HumanRendering(VectorWrapper, gym.utils.RecordConstructorArgs):
     """Adds support for Human-based Rendering for Vector-based environments."""
@@ -28,6 +31,14 @@ class HumanRendering(VectorWrapper, gym.utils.RecordConstructorArgs):
         "depth_array",
         "depth_array_list",
     ]
+
+    screen_size: tuple[int, int] | None
+    scaled_subenv_size: tuple[int, int] | None
+    num_rows: int | None
+    num_cols: int | None
+    window: pygame.Surface | None
+    clock: pygame.time.Clock | None
+    metadata: dict[str, Any]
 
     def __init__(self, env: VectorEnv, screen_size: tuple[int, int] | None = None):
         """Constructor for Human Rendering of Vector-based environments.
@@ -155,6 +166,8 @@ class HumanRendering(VectorWrapper, gym.utils.RecordConstructorArgs):
             ) from e
 
         merged_rgb_array = np.zeros(self.screen_size + (3,), dtype=np.uint8)
+        assert self.num_cols is not None
+        assert self.num_rows is not None
         cols, rows = np.meshgrid(np.arange(self.num_cols), np.arange(self.num_rows))
 
         for i, col, row in zip(range(self.num_envs), cols.flatten(), rows.flatten()):  # noqa: B905
@@ -181,7 +194,7 @@ class HumanRendering(VectorWrapper, gym.utils.RecordConstructorArgs):
         self.clock.tick(self.metadata["render_fps"])
         pygame.display.flip()
 
-    def close(self):
+    def close(self) -> None:
         """Close the rendering window."""
         if self.window is not None:
             import pygame
@@ -222,6 +235,27 @@ class RecordVideo(
     >>> len(os.listdir("save_videos_5envs"))
     2
     """
+
+    autoreset_mode: gym.vector.AutoresetMode
+    has_autoreset: bool
+    episode_trigger: Callable[[int], bool] | None
+    step_trigger: Callable[[int], bool] | None
+    gc_trigger: Callable[[int], bool] | None
+    disable_logger: bool
+    record_first_only: bool
+    video_aspect_ratio: tuple[int, int]
+    frame_cols: int
+    frame_rows: int
+    video_folder: str
+    frames_per_sec: int
+    name_prefix: str
+    _video_name: str | None
+    video_length: float
+    recording: bool
+    recorded_frames: list[np.ndarray]
+    render_history: list[np.ndarray]
+    step_id: int
+    episode_id: int
 
     def __init__(
         self,
@@ -315,13 +349,13 @@ class RecordVideo(
 
         if fps is None:
             fps = self.metadata.get("render_fps", 30)
-        self.frames_per_sec: int = fps
-        self.name_prefix: str = name_prefix
-        self._video_name: str | None = None
-        self.video_length: int = video_length if video_length != 0 else float("inf")
-        self.recording: bool = False
-        self.recorded_frames: list[np.ndarray] = []
-        self.render_history: list[np.ndarray] = []
+        self.frames_per_sec = fps
+        self.name_prefix = name_prefix
+        self._video_name = None
+        self.video_length = video_length if video_length != 0 else float("inf")
+        self.recording = False
+        self.recorded_frames = []
+        self.render_history = []
 
         self.step_id = -1
         self.episode_id = -1
@@ -353,7 +387,7 @@ class RecordVideo(
         self.frame_rows = best_rows
         self.frame_cols = best_cols
 
-    def _concat_frames(self, frames):
+    def _concat_frames(self, frames: np.typing.ArrayLike) -> np.ndarray:
         """Concatenates a list of frames into one large frame."""
         frames = np.array(frames)
         n_frames, h, w, c = frames.shape
@@ -366,7 +400,7 @@ class RecordVideo(
             grid[r * h : (r + 1) * h, c_ * w : (c_ + 1) * w] = frames[idx]
         return grid
 
-    def _capture_frame(self):
+    def _capture_frame(self) -> None:
         assert self.recording, "Cannot capture a frame, recording wasn't started."
 
         envs_frame = self.env.render()
@@ -460,13 +494,13 @@ class RecordVideo(
         else:
             return render_out
 
-    def close(self):
+    def close(self) -> None:
         """Closes the wrapper then the video recorder."""
         super().close()
         if self.recording:
             self.stop_recording()
 
-    def start_recording(self, video_name: str):
+    def start_recording(self, video_name: str) -> None:
         """Start a new recording. If it is already recording, stops the current recording before starting the new one."""
         if self.recording:
             self.stop_recording()
@@ -474,7 +508,7 @@ class RecordVideo(
         self.recording = True
         self._video_name = video_name
 
-    def stop_recording(self):
+    def stop_recording(self) -> None:
         """Stop current recording and saves the video."""
         assert self.recording, "stop_recording was called, but no recording was started"
         if len(self.recorded_frames) == 0:
@@ -501,7 +535,7 @@ class RecordVideo(
         if self.gc_trigger and self.gc_trigger(self.episode_id):
             gc.collect()
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Warn the user in case last video wasn't saved."""
         if len(self.recorded_frames) > 0:
             logger.warn("Unable to save last video! Did you call close()?")

--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -10,7 +10,6 @@ from typing import Any
 import numpy as np
 
 import gymnasium as gym
-from gymnasium.core import ObsType
 from gymnasium.logger import warn
 from gymnasium.spaces import Box
 from gymnasium.vector.utils import batch_space
@@ -63,7 +62,13 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         >>> envs.close()
     """
 
-    def __init__(self, env: VectorEnv, epsilon: float = 1e-8):
+    single_observation_space: Box  # f32
+    observation_space: Box  # f32
+    obs_rms: RunningMeanStd  # f32
+    epsilon: float
+    _update_running_mean: bool
+
+    def __init__(self, env: VectorEnv, epsilon: float = 1e-8) -> None:
         """This wrapper will normalize observations s.t. each coordinate is centered with unit variance.
 
         Args:
@@ -87,7 +92,8 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
             dtype=np.float32,
         )
         self.single_observation_space = new_single_space
-        self.observation_space = batch_space(new_single_space, self.num_envs)
+        # ty doesn't support `@single_dispatch` (yet?)
+        self.observation_space = batch_space(new_single_space, self.num_envs)  # ty:ignore[invalid-assignment]
 
         self.obs_rms = RunningMeanStd(
             shape=self.single_observation_space.shape,
@@ -102,7 +108,7 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         return self._update_running_mean
 
     @update_running_mean.setter
-    def update_running_mean(self, setting: bool):
+    def update_running_mean(self, setting: bool) -> None:
         """Sets the property to freeze/continue the running mean calculation of the observation statistics."""
         self._update_running_mean = setting
 
@@ -111,7 +117,7 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         *,
         seed: int | list[int] | None = None,
         options: dict[str, Any] | None = None,
-    ) -> tuple[ObsType, dict[str, Any]]:
+    ) -> tuple[np.ndarray, dict[str, Any]]:
         """Reset function for `NormalizeObservationWrapper` which is disabled for partial resets."""
         assert (
             options is None
@@ -120,7 +126,9 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         )
         return super().reset(seed=seed, options=options)
 
-    def observations(self, observations: ObsType) -> ObsType:
+    def observations(
+        self, observations: np.ndarray[tuple[int], np.dtype[np.floating]]
+    ) -> np.ndarray[tuple[int], np.dtype[np.float32]]:
         """Defines the vector observation normalization function.
 
         Args:

--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -92,7 +92,7 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
             dtype=np.float32,
         )
         self.single_observation_space = new_single_space
-        # ty doesn't support `@single_dispatch` (yet?)
+        # TODO: remove ignore comment once `ty` supports `@single_dispatch`
         self.observation_space = batch_space(new_single_space, self.num_envs)  # ty:ignore[invalid-assignment]
 
         self.obs_rms = RunningMeanStd(

--- a/gymnasium/wrappers/vector/stateful_reward.py
+++ b/gymnasium/wrappers/vector/stateful_reward.py
@@ -5,13 +5,12 @@
 
 from __future__ import annotations
 
-from typing import Any, SupportsFloat
+from typing import Any
 
 import numpy as np
 
 import gymnasium as gym
-from gymnasium.core import ActType, ObsType
-from gymnasium.vector.vector_env import ArrayType, VectorEnv, VectorWrapper
+from gymnasium.vector.vector_env import VectorEnv, VectorWrapper
 from gymnasium.wrappers.utils import RunningMeanStd
 
 __all__ = ["NormalizeReward"]
@@ -64,12 +63,19 @@ class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
         np.float64(0.2780030923586878)
     """
 
+    return_rms: RunningMeanStd
+    accumulated_reward: np.ndarray[tuple[int], np.dtype[np.float32]]
+    gamma: float
+    epsilon: float
+    _update_running_mean: bool
+    _prev_dones: np.ndarray[tuple[int], np.dtype[np.float32]]
+
     def __init__(
         self,
         env: VectorEnv,
         gamma: float = 0.99,
         epsilon: float = 1e-8,
-    ):
+    ) -> None:
         """This wrapper will normalize immediate rewards s.t. their exponential moving average has an approximately fixed variance.
 
         Args:
@@ -93,7 +99,7 @@ class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
         return self._update_running_mean
 
     @update_running_mean.setter
-    def update_running_mean(self, setting: bool):
+    def update_running_mean(self, setting: bool) -> None:
         """Sets the property to freeze/continue the running mean calculation of the reward statistics."""
         self._update_running_mean = setting
 
@@ -102,15 +108,21 @@ class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
         *,
         seed: int | list[int] | None = None,
         options: dict[str, Any] | None = None,
-    ) -> tuple[ObsType, dict[str, Any]]:
+    ) -> tuple[np.ndarray, dict[str, Any]]:
         """Resets the environment and clears accumulated reward tracking state."""
         self.accumulated_reward[:] = 0
         self._prev_dones[:] = 0
         return super().reset(seed=seed, options=options)
 
     def step(
-        self, actions: ActType
-    ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, dict[str, Any]]:
+        self, actions: np.ndarray
+    ) -> tuple[
+        np.ndarray,
+        np.ndarray[tuple[int], np.dtype[np.float64]],
+        np.ndarray[tuple[int], np.dtype[np.bool_]],
+        np.ndarray[tuple[int], np.dtype[np.bool_]],
+        dict[str, Any],
+    ]:
         """Steps through the environment, normalizing the reward returned."""
         obs, reward, terminated, truncated, info = super().step(actions)
         active = ~self._prev_dones.astype(bool)
@@ -129,7 +141,7 @@ class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
             info,
         )
 
-    def normalize(self, reward: SupportsFloat):
+    def normalize(self, reward: float | np.floating | np.integer) -> np.float64:
         """Normalizes the rewards with the running mean rewards and their variance."""
         if self._update_running_mean:
             self.return_rms.update(self.accumulated_reward)

--- a/gymnasium/wrappers/vector/vectorize_action.py
+++ b/gymnasium/wrappers/vector/vectorize_action.py
@@ -4,19 +4,30 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from copy import deepcopy
-from typing import Any
+from typing import TYPE_CHECKING, Any, Generic
 
 import numpy as np
 
 from gymnasium import Space
-from gymnasium.core import ActType, Env
+from gymnasium.core import Env
 from gymnasium.logger import warn
 from gymnasium.vector import VectorActionWrapper, VectorEnv
 from gymnasium.vector.utils import batch_space, concatenate, create_empty_array, iterate
 from gymnasium.wrappers import transform_action
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeVar
 
-class TransformAction(VectorActionWrapper):
+    _T_contra = TypeVar("_T_contra", contravariant=True, default=Any)
+    _T_co = TypeVar("_T_co", covariant=True, default=_T_contra)
+else:
+    from typing import TypeVar
+
+    _T_contra = TypeVar("_T_contra", contravariant=True)
+    _T_co = TypeVar("_T_co", covariant=True)
+
+
+class TransformAction(VectorActionWrapper, Generic[_T_contra, _T_co]):
     """Transforms an action via a function provided to the wrapper.
 
     The function :attr:`func` will be applied to all vector actions.
@@ -58,13 +69,17 @@ class TransformAction(VectorActionWrapper):
                [-0.46543318, -0.00615723]], dtype=float32)
     """
 
+    single_action_space: Space
+    action_space: Space
+    func: Callable[[_T_contra], _T_co]
+
     def __init__(
         self,
         env: VectorEnv,
-        func: Callable[[ActType], Any],
+        func: Callable[[_T_contra], _T_co],
         action_space: Space | None = None,
         single_action_space: Space | None = None,
-    ):
+    ) -> None:
         """Constructor for the lambda action wrapper.
 
         Args:
@@ -91,7 +106,7 @@ class TransformAction(VectorActionWrapper):
 
         self.func = func
 
-    def actions(self, actions: ActType) -> ActType:
+    def actions(self, actions: _T_contra) -> _T_co:
         """Applies the :attr:`func` to the actions."""
         return self.func(actions)
 
@@ -129,16 +144,25 @@ class VectorizeTransformAction(VectorActionWrapper):
     class _SingleEnv(Env):
         """Fake single-agent environment used for the single-agent wrapper."""
 
-        def __init__(self, action_space: Space):
+        action_space: Space
+
+        def __init__(self, action_space: Space) -> None:
             """Constructor for the fake environment."""
             self.action_space = action_space
+
+    wrapper: transform_action.TransformAction
+    single_action_space: Space
+    action_space: Space
+
+    same_out: bool
+    out: np.ndarray
 
     def __init__(
         self,
         env: VectorEnv,
         wrapper: type[transform_action.TransformAction],
         **kwargs: Any,
-    ):
+    ) -> None:
         """Constructor for the vectorized lambda action wrapper.
 
         Args:
@@ -153,9 +177,10 @@ class VectorizeTransformAction(VectorActionWrapper):
         self.action_space = batch_space(self.single_action_space, self.num_envs)
 
         self.same_out = self.action_space == self.env.action_space
-        self.out = create_empty_array(self.env.single_action_space, self.num_envs)
+        # ty doesn't support `@single_dispatch` yet
+        self.out = create_empty_array(self.env.single_action_space, self.num_envs)  # ty:ignore[invalid-assignment]
 
-    def actions(self, actions: ActType) -> ActType:
+    def actions(self, actions: np.ndarray) -> np.ndarray:
         """Applies the wrapper to each of the action.
 
         Args:
@@ -165,7 +190,7 @@ class VectorizeTransformAction(VectorActionWrapper):
             The updated actions using the wrapper func
         """
         if self.same_out:
-            return concatenate(
+            actions_out = concatenate(
                 self.env.single_action_space,
                 tuple(
                     self.wrapper.func(action)
@@ -174,7 +199,7 @@ class VectorizeTransformAction(VectorActionWrapper):
                 actions,
             )
         else:
-            return deepcopy(
+            actions_out = deepcopy(
                 concatenate(
                     self.env.single_action_space,
                     tuple(
@@ -184,6 +209,8 @@ class VectorizeTransformAction(VectorActionWrapper):
                     self.out,
                 )
             )
+        # ty doesn't support `@single_dispatch` yet
+        return actions_out  # ty:ignore[invalid-return-type]
 
 
 class ClipAction(VectorizeTransformAction):
@@ -204,7 +231,7 @@ class ClipAction(VectorizeTransformAction):
                [-0.42884544,  0.00080468]], dtype=float32)
     """
 
-    def __init__(self, env: VectorEnv):
+    def __init__(self, env: VectorEnv) -> None:
         """Constructor for the Clip Action wrapper.
 
         Args:
@@ -253,7 +280,7 @@ class RescaleAction(VectorizeTransformAction):
         env: VectorEnv,
         min_action: float | int | np.ndarray,
         max_action: float | int | np.ndarray,
-    ):
+    ) -> None:
         """Initializes the :class:`RescaleAction` wrapper.
 
         Args:

--- a/gymnasium/wrappers/vector/vectorize_observation.py
+++ b/gymnasium/wrappers/vector/vectorize_observation.py
@@ -4,20 +4,32 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from copy import deepcopy
-from typing import Any
+from typing import TYPE_CHECKING, Any, Generic
 
 import numpy as np
+import numpy.typing as npt
 
 from gymnasium import Space
-from gymnasium.core import ActType, Env, ObsType
+from gymnasium.core import Env
 from gymnasium.logger import warn
 from gymnasium.vector import VectorEnv, VectorObservationWrapper
 from gymnasium.vector.utils import batch_space, concatenate, create_empty_array, iterate
-from gymnasium.vector.vector_env import ArrayType, AutoresetMode
+from gymnasium.vector.vector_env import AutoresetMode
 from gymnasium.wrappers import transform_observation
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeVar
 
-class TransformObservation(VectorObservationWrapper):
+    _T_contra = TypeVar("_T_contra", contravariant=True, default=Any)
+    _T_co = TypeVar("_T_co", covariant=True, default=_T_contra)
+else:
+    from typing import TypeVar
+
+    _T_contra = TypeVar("_T_contra", contravariant=True)
+    _T_co = TypeVar("_T_co", covariant=True)
+
+
+class TransformObservation(VectorObservationWrapper, Generic[_T_contra, _T_co]):
     """Transforms an observation via a function provided to the wrapper.
 
     This function allows the manual specification of the vector-observation function as well as the single-observation function.
@@ -53,13 +65,17 @@ class TransformObservation(VectorObservationWrapper):
         >>> envs.close()
     """
 
+    single_observation_space: Space
+    observation_space: Space
+    func: Callable[[_T_contra], _T_co]
+
     def __init__(
         self,
         env: VectorEnv,
-        func: Callable[[ObsType], Any],
+        func: Callable[[_T_contra], _T_co],
         observation_space: Space | None = None,
         single_observation_space: Space | None = None,
-    ):
+    ) -> None:
         """Constructor for the transform observation wrapper.
 
         Args:
@@ -79,7 +95,7 @@ class TransformObservation(VectorObservationWrapper):
         else:
             self.observation_space = observation_space
             if single_observation_space is not None:
-                self._single_observation_space = single_observation_space
+                self.single_observation_space = single_observation_space
             # TODO: We could compute single_observation_space from the observation_space if only the latter is provided and avoid the warning below.
         if self.observation_space != batch_space(
             self.single_observation_space, self.num_envs
@@ -90,7 +106,7 @@ class TransformObservation(VectorObservationWrapper):
 
         self.func = func
 
-    def observations(self, observations: ObsType) -> ObsType:
+    def observations(self, observations: _T_contra) -> _T_co:
         """Apply function to the vector observation."""
         return self.func(observations)
 
@@ -139,16 +155,25 @@ class VectorizeTransformObservation(VectorObservationWrapper):
     class _SingleEnv(Env):
         """Fake single-agent environment used for the single-agent wrapper."""
 
-        def __init__(self, observation_space: Space):
+        observation_space: Space
+
+        def __init__(self, observation_space: Space) -> None:
             """Constructor for the fake environment."""
             self.observation_space = observation_space
+
+    autoreset_mode: AutoresetMode
+    wrapper: transform_observation.TransformObservation
+    single_observation_space: Space
+    observation_space: Space
+    same_out: bool
+    out: np.ndarray
 
     def __init__(
         self,
         env: VectorEnv,
         wrapper: type[transform_observation.TransformObservation],
         **kwargs: Any,
-    ):
+    ) -> None:
         """Constructor for the vectorized transform observation wrapper.
 
         Args:
@@ -176,11 +201,18 @@ class VectorizeTransformObservation(VectorObservationWrapper):
         )
 
         self.same_out = self.observation_space == self.env.observation_space
-        self.out = create_empty_array(self.single_observation_space, self.num_envs)
+        # ty doesn't support `@single_dispatch` yet
+        self.out = create_empty_array(self.single_observation_space, self.num_envs)  # ty:ignore[invalid-assignment]
 
     def step(
-        self, actions: ActType
-    ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, dict[str, Any]]:
+        self, actions: np.ndarray
+    ) -> tuple[
+        np.ndarray,
+        npt.NDArray[np.float64],
+        npt.NDArray[np.bool_],
+        npt.NDArray[np.bool_],
+        dict[str, Any],
+    ]:
         """Steps through the vector environments, transforming the observation and for final obs individually transformed."""
         obs, rewards, terminations, truncations, infos = self.env.step(actions)
         obs = self.observations(obs)
@@ -196,10 +228,10 @@ class VectorizeTransformObservation(VectorObservationWrapper):
 
         return obs, rewards, terminations, truncations, infos
 
-    def observations(self, observations: ObsType) -> ObsType:
+    def observations(self, observations: np.ndarray) -> np.ndarray:
         """Iterates over the vector observations applying the single-agent wrapper ``observation`` then concatenates the observations together again."""
         if self.same_out:
-            return concatenate(
+            observations_out = concatenate(
                 self.single_observation_space,
                 tuple(
                     self.wrapper.func(obs)
@@ -208,7 +240,7 @@ class VectorizeTransformObservation(VectorObservationWrapper):
                 observations,
             )
         else:
-            return deepcopy(
+            observations_out = deepcopy(
                 concatenate(
                     self.single_observation_space,
                     tuple(
@@ -218,6 +250,8 @@ class VectorizeTransformObservation(VectorObservationWrapper):
                     self.out,
                 )
             )
+        # ty doesn't support `@single_dispatch` yet
+        return observations_out  # ty:ignore[invalid-return-type]
 
 
 class FilterObservation(VectorizeTransformObservation):
@@ -243,7 +277,7 @@ class FilterObservation(VectorizeTransformObservation):
               dtype=float32)}
     """
 
-    def __init__(self, env: VectorEnv, filter_keys: Sequence[str | int]):
+    def __init__(self, env: VectorEnv, filter_keys: Sequence[str | int]) -> None:
         """Constructor for the filter observation wrapper.
 
         Args:
@@ -271,7 +305,7 @@ class FlattenObservation(VectorizeTransformObservation):
         >>> envs.close()
     """
 
-    def __init__(self, env: VectorEnv):
+    def __init__(self, env: VectorEnv) -> None:
         """Constructor for any environment's observation space that implements ``spaces.utils.flatten_space`` and ``spaces.utils.flatten``.
 
         Args:
@@ -296,7 +330,7 @@ class GrayscaleObservation(VectorizeTransformObservation):
         >>> envs.close()
     """
 
-    def __init__(self, env: VectorEnv, keep_dim: bool = False):
+    def __init__(self, env: VectorEnv, keep_dim: bool = False) -> None:
         """Constructor for an RGB image based environments to make the image grayscale.
 
         Args:
@@ -324,7 +358,7 @@ class ResizeObservation(VectorizeTransformObservation):
         >>> envs.close()
     """
 
-    def __init__(self, env: VectorEnv, shape: tuple[int, ...]):
+    def __init__(self, env: VectorEnv, shape: tuple[int, ...]) -> None:
         """Constructor that requires an image environment observation space with a shape.
 
         Args:
@@ -350,7 +384,7 @@ class ReshapeObservation(VectorizeTransformObservation):
         >>> envs.close()
     """
 
-    def __init__(self, env: VectorEnv, shape: int | tuple[int, ...]):
+    def __init__(self, env: VectorEnv, shape: int | tuple[int, ...]) -> None:
         """Constructor for env with Box observation space that has a shape product equal to the new shape product.
 
         Args:
@@ -383,9 +417,9 @@ class RescaleObservation(VectorizeTransformObservation):
     def __init__(
         self,
         env: VectorEnv,
-        min_obs: np.floating | np.integer | np.ndarray,
-        max_obs: np.floating | np.integer | np.ndarray,
-    ):
+        min_obs: float | np.floating | np.integer | np.ndarray,
+        max_obs: float | np.floating | np.integer | np.ndarray,
+    ) -> None:
         """Constructor that requires the env observation spaces to be a :class:`Box`.
 
         Args:
@@ -418,7 +452,7 @@ class DtypeObservation(VectorizeTransformObservation):
         >>> envs.close()
     """
 
-    def __init__(self, env: VectorEnv, dtype: Any):
+    def __init__(self, env: VectorEnv, dtype: Any) -> None:
         """Constructor for Dtype observation wrapper.
 
         Args:

--- a/gymnasium/wrappers/vector/vectorize_reward.py
+++ b/gymnasium/wrappers/vector/vectorize_reward.py
@@ -3,17 +3,33 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any, Generic
 
 import numpy as np
 
 from gymnasium import Env
 from gymnasium.vector import VectorEnv, VectorRewardWrapper
-from gymnasium.vector.vector_env import ArrayType
 from gymnasium.wrappers import transform_reward
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeVar
 
-class TransformReward(VectorRewardWrapper):
+    _ArrayT_contra = TypeVar(
+        "_ArrayT_contra", bound=np.ndarray, contravariant=True, default=Any
+    )
+    _ArrayT_co = TypeVar(
+        "_ArrayT_co", bound=np.ndarray, covariant=True, default=_ArrayT_contra
+    )
+else:
+    from typing import TypeVar
+
+    _ArrayT_contra = TypeVar("_ArrayT_contra", bound=np.ndarray, contravariant=True)
+    _ArrayT_co = TypeVar("_ArrayT_co", bound=np.ndarray, covariant=True)
+
+_ArrayT = TypeVar("_ArrayT", bound=np.ndarray)
+
+
+class TransformReward(VectorRewardWrapper, Generic[_ArrayT_contra, _ArrayT_co]):
     """A reward wrapper that allows a custom function to modify the step reward.
 
     Example with reward transformation:
@@ -34,7 +50,11 @@ class TransformReward(VectorRewardWrapper):
                [-4.3118435e-01, -1.5342437e-03]], dtype=float32)
     """
 
-    def __init__(self, env: VectorEnv, func: Callable[[ArrayType], ArrayType]):
+    func: Callable[[_ArrayT_contra], _ArrayT_co]
+
+    def __init__(
+        self, env: VectorEnv, func: Callable[[_ArrayT_contra], _ArrayT_co]
+    ) -> None:
         """Initialize LambdaReward wrapper.
 
         Args:
@@ -45,9 +65,9 @@ class TransformReward(VectorRewardWrapper):
 
         self.func = func
 
-    def rewards(self, reward: ArrayType) -> ArrayType:
+    def rewards(self, rewards: _ArrayT_contra) -> _ArrayT_co:
         """Apply function to reward."""
-        return self.func(reward)
+        return self.func(rewards)
 
 
 class VectorizeTransformReward(VectorRewardWrapper):
@@ -66,12 +86,14 @@ class VectorizeTransformReward(VectorRewardWrapper):
         array([-0., -0., -0.])
     """
 
+    wrapper: transform_reward.TransformReward
+
     def __init__(
         self,
         env: VectorEnv,
         wrapper: type[transform_reward.TransformReward],
         **kwargs: Any,
-    ):
+    ) -> None:
         """Constructor for the vectorized lambda reward wrapper.
 
         Args:
@@ -83,11 +105,11 @@ class VectorizeTransformReward(VectorRewardWrapper):
 
         self.wrapper = wrapper(Env(), **kwargs)
 
-    def rewards(self, reward: ArrayType) -> ArrayType:
+    def rewards(self, rewards: _ArrayT) -> _ArrayT:
         """Iterates over the reward updating each with the wrapper func."""
-        for i, r in enumerate(reward):
-            reward[i] = self.wrapper.func(r)
-        return reward
+        for i, r in enumerate(rewards):
+            rewards[i] = self.wrapper.func(r)
+        return rewards
 
 
 class ClipReward(VectorizeTransformReward):
@@ -113,7 +135,7 @@ class ClipReward(VectorizeTransformReward):
         env: VectorEnv,
         min_reward: float | np.ndarray | None = None,
         max_reward: float | np.ndarray | None = None,
-    ):
+    ) -> None:
         """Constructor for ClipReward wrapper.
 
         Args:


### PR DESCRIPTION
# Description

A batch of static typing fixes and type coverage improvements targeting the `gymnasium.wrappers.vector.*`  submodules. 

This also several cases of incorrect `TypeVar` usage patterns: unbound use (i.e. as "free" type variables), incorrect variance, and missing upper type parameter bounds. These issues aren't limited to this subpackage, and I wasn't able to fix all cases here because of that. I'll hope to be able to circle back to these though once these issues in the dependent classes (e.g. base classes, wrapped env classes, etc.) have been resolved. I've used PEP 696 type parameter defaults (or a backport thereof via `typing_extensions`) to keep things backwards compatible (type-checkers might complain about missing type arguments otherwise),

I also corrected a minor runtime bug in `vectorize_obsercation.TransformObservation`, where the wrong `_single_observation_space` attribute was written to (spurious underscore). I realize it's a bit out-of-scope, but I figured it was small enough to also fix here. I wouldn't mind moving this to a separate PR though if that what's preferred.

This fixes 28 ty warnings in total.

## Type of change

Static typing fixes and improvements.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes