### PR TITLE
Bump `ty`  to `0.0.34` and fix new errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,4 +53,4 @@ repos:
         language: python
         pass_filenames: false
         types: [python]
-        additional_dependencies: ["ty==0.0.9"]
+        additional_dependencies: ["ty==0.0.34", "numpy", "cloudpickle"]

--- a/gymnasium/envs/box2d/bipedal_walker.py
+++ b/gymnasium/envs/box2d/bipedal_walker.py
@@ -382,7 +382,7 @@ class BipedalWalker(gym.Env, EzPickle):
             self.terrain_y.append(y)
             counter -= 1
             if counter == 0:
-                counter = self.np_random.integers(TERRAIN_GRASS / 2, TERRAIN_GRASS)
+                counter = self.np_random.integers(TERRAIN_GRASS // 2, TERRAIN_GRASS)
                 if state == GRASS and hardcore:
                     state = self.np_random.integers(1, _STATES_)
                     oneshot = True

--- a/gymnasium/envs/mujoco/reacher_v5.py
+++ b/gymnasium/envs/mujoco/reacher_v5.py
@@ -1,12 +1,14 @@
 __credits__ = ["Kallinteris-Andreas"]
 
+from typing import Any, Final
+
 import numpy as np
 
 from gymnasium import utils
 from gymnasium.envs.mujoco import MujocoEnv
 from gymnasium.spaces import Box
 
-DEFAULT_CAMERA_CONFIG = {"trackbodyid": 0}
+DEFAULT_CAMERA_CONFIG: Final[dict[str, float]] = {"trackbodyid": 0}
 
 
 class ReacherEnv(MujocoEnv, utils.EzPickle):
@@ -133,7 +135,7 @@ class ReacherEnv(MujocoEnv, utils.EzPickle):
     * v0: Initial versions release
     """
 
-    metadata = {
+    metadata: dict[str, Any] = {
         "render_modes": [
             "human",
             "rgb_array",
@@ -146,7 +148,7 @@ class ReacherEnv(MujocoEnv, utils.EzPickle):
         self,
         xml_file: str = "reacher.xml",
         frame_skip: int = 2,
-        default_camera_config: dict[str, float | int] = DEFAULT_CAMERA_CONFIG,
+        default_camera_config: dict[str, float] = DEFAULT_CAMERA_CONFIG,
         reward_dist_weight: float = 1,
         reward_control_weight: float = 1,
         **kwargs,

--- a/gymnasium/envs/mujoco/utils.py
+++ b/gymnasium/envs/mujoco/utils.py
@@ -6,11 +6,11 @@ Author: @Kallinteris-Andreas
 import mujoco
 import numpy as np
 
-import gymnasium
+from gymnasium.envs.mujoco import MujocoEnv
 
 
 def get_state(
-    env: gymnasium.envs.mujoco.MujocoEnv,
+    env: MujocoEnv,
     state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_FULLPHYSICS,
 ):
     """Gets the state of `env`.
@@ -27,7 +27,7 @@ def get_state(
 
 
 def set_state(
-    env: gymnasium.envs.mujoco.MujocoEnv,
+    env: MujocoEnv,
     state: np.ndarray,
     state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_FULLPHYSICS,
 ):
@@ -50,7 +50,7 @@ def set_state(
 
 
 def check_mujoco_reset_state(
-    env: gymnasium.envs.mujoco.MujocoEnv,
+    env: MujocoEnv,
     seed=1234,
     state_type: mujoco.mjtState = mujoco.mjtState.mjSTATE_INTEGRATION,
 ):

--- a/gymnasium/envs/phys2d/cartpole.py
+++ b/gymnasium/envs/phys2d/cartpole.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import jax
 import jax.numpy as jnp
@@ -16,9 +16,13 @@ from gymnasium.experimental.functional import ActType, FuncEnv
 from gymnasium.utils import EzPickle
 from gymnasium.vector import AutoresetMode
 
+if TYPE_CHECKING:
+    import pygame
+
+
 PRNGKeyType: TypeAlias = jax.Array
 StateType: TypeAlias = jax.Array
-RenderStateType = tuple["pygame.Surface", "pygame.time.Clock"]  # type: ignore  # noqa: F821
+RenderStateType = tuple["pygame.Surface", "pygame.time.Clock"]
 
 
 @struct.dataclass

--- a/gymnasium/envs/phys2d/pendulum.py
+++ b/gymnasium/envs/phys2d/pendulum.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from os import path
-from typing import Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 import jax
 import jax.numpy as jnp
@@ -17,9 +17,13 @@ from gymnasium.experimental.functional import ActType, FuncEnv
 from gymnasium.utils import EzPickle
 from gymnasium.vector import AutoresetMode
 
+if TYPE_CHECKING:
+    import pygame
+
+
 PRNGKeyType: TypeAlias = jax.Array
 StateType: TypeAlias = jax.Array
-RenderStateType = tuple["pygame.Surface", "pygame.time.Clock", float | None]  # type: ignore  # noqa: F821
+RenderStateType = tuple["pygame.Surface", "pygame.time.Clock", float | None]
 
 
 @struct.dataclass

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -101,7 +101,7 @@ class EnvSpec:
     disable_env_checker: bool = field(default=False)
 
     # Environment arguments
-    kwargs: dict = field(default_factory=dict)
+    kwargs: dict[str, Any] = field(default_factory=dict)
 
     # post-init attributes
     namespace: str | None = field(init=False)
@@ -415,7 +415,7 @@ def _check_version_exists(ns: str | None, name: str, version: int | None) -> Non
 
     latest_spec = max(
         versioned_specs, key=lambda env_spec: env_spec.version, default=None
-    )  # type: ignore
+    )
     if latest_spec is not None and version > latest_spec.version:
         version_list_msg = ", ".join(f"`v{env_spec.version}`" for env_spec in env_specs)
         message += f" It provides versioned environments: [ {version_list_msg} ]."
@@ -439,7 +439,7 @@ def _check_spec_register(testing_spec: EnvSpec) -> None:
             and env_spec.name == testing_spec.name
             and env_spec.version is not None
         ),
-        key=lambda spec_: int(spec_.version),  # type: ignore
+        key=lambda spec_: int(spec_.version),
         default=None,
     )
 
@@ -731,7 +731,7 @@ def make(
             )
 
     try:
-        env = env_creator(**env_spec_kwargs)
+        env = env_creator(**env_spec_kwargs)  # ty:ignore[call-top-callable]
     except TypeError as e:
         if (
             str(e).find("got an unexpected keyword argument 'render_mode'") >= 0
@@ -914,7 +914,7 @@ def make_vec(
             )
 
         env = gym.vector.SyncVectorEnv(
-            env_fns=(create_single_env for _ in range(num_envs)),
+            env_fns=[create_single_env for _ in range(num_envs)],
             **vector_kwargs,
         )
     elif vectorization_mode == VectorizeMode.ASYNC:
@@ -958,7 +958,7 @@ def make_vec(
         ):
             env_spec_kwargs["max_episode_steps"] = env_spec.max_episode_steps
 
-        env = env_creator(num_envs=num_envs, **env_spec_kwargs)
+        env = env_creator(num_envs=num_envs, **env_spec_kwargs)  # ty:ignore[call-top-callable]
     else:
         raise error.Error(f"Unknown vectorization mode: {vectorization_mode}")
 

--- a/gymnasium/envs/tabular/blackjack.py
+++ b/gymnasium/envs/tabular/blackjack.py
@@ -2,7 +2,7 @@
 
 import math
 import os
-from typing import NamedTuple, TypeAlias
+from typing import TYPE_CHECKING, NamedTuple, TypeAlias
 
 import jax
 import jax.numpy as jnp
@@ -17,6 +17,10 @@ from gymnasium.experimental.functional import ActType, FuncEnv, StateType
 from gymnasium.utils import EzPickle, seeding
 from gymnasium.vector import AutoresetMode
 from gymnasium.wrappers import HumanRendering
+
+if TYPE_CHECKING:
+    import pygame
+
 
 PRNGKeyType: TypeAlias = jax.Array
 RenderStateType = tuple["pygame.Surface", str, int]  # type: ignore  # noqa: F821

--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -293,7 +293,7 @@ def play(
         if isinstance(key_combination, int):
             key_combination = (key_combination,)
         key_code = tuple(
-            sorted(ord(key) if isinstance(key, str) else key for key in key_combination)  # ty:ignore[not-iterable]
+            sorted(ord(key) if isinstance(key, str) else key for key in key_combination)
         )
         key_code_to_action[key_code] = action
 

--- a/gymnasium/utils/step_api_compatibility.py
+++ b/gymnasium/utils/step_api_compatibility.py
@@ -25,9 +25,9 @@ TerminatedTruncatedStepType = tuple[
 
 
 def convert_to_terminated_truncated_step_api(
-    step_returns: DoneStepType | TerminatedTruncatedStepType,
+    step_returns: DoneStepType[ObsType] | TerminatedTruncatedStepType[ObsType],
     is_vector_env: bool = False,
-) -> TerminatedTruncatedStepType:
+) -> TerminatedTruncatedStepType[ObsType]:
     """Function to transform step returns to new step API irrespective of input API.
 
     .. py:currentmodule:: gymnasium.Env
@@ -44,7 +44,7 @@ def convert_to_terminated_truncated_step_api(
 
         # Cases to handle - info single env /  info vector env (list) / info vector env (dict)
         if is_vector_env is False:
-            truncated = infos.pop("TimeLimit.truncated", False)  # ty:ignore[no-matching-overload,too-many-positional-arguments]
+            truncated = infos.pop("TimeLimit.truncated", False)  # ty:ignore[too-many-positional-arguments]
             return (
                 observations,
                 rewards,
@@ -110,7 +110,7 @@ def convert_to_done_step_api(
         elif isinstance(infos, list):
             for info, env_truncated, env_terminated in zip(
                 infos, truncated, terminated, strict=True
-            ):
+            ):  # ty:ignore[not-iterable]
                 if env_truncated or env_terminated:
                     info["TimeLimit.truncated"] = env_truncated and not env_terminated
             return (

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -258,10 +258,10 @@ class SyncVectorEnv(VectorEnv):
         Returns:
             The batched environment step results
         """
-        actions = iterate(self.action_space, actions)
+        actions_iter = iterate(self.action_space, actions)
 
         infos = {}
-        for i, (action, _) in enumerate(zip(actions, self.envs, strict=True)):
+        for i, (action, _) in enumerate(zip(actions_iter, self.envs, strict=True)):
             if self.autoreset_mode == AutoresetMode.NEXT_STEP:
                 if self._autoreset_envs[i]:
                     self._env_obs[i], env_info = self.envs[i].reset()

--- a/gymnasium/vector/utils/shared_memory.py
+++ b/gymnasium/vector/utils/shared_memory.py
@@ -228,7 +228,8 @@ def _read_text_from_shared_memory(
 def _read_one_of_from_shared_memory(
     space: OneOf, shared_memory: _SharedMemoryOneOf, n: int = 1
 ) -> tuple[Any, ...]:
-    sample_indexes = np.frombuffer(shared_memory[0].get_obj(), dtype=np.int64)
+    # typeshed bug: `Array[_SimpleCData[c_int64]]` is missing `__buffer__` method stubs
+    sample_indexes = np.frombuffer(shared_memory[0].get_obj(), dtype=np.int64)  # ty:ignore[no-matching-overload]
 
     subspace_samples = tuple(
         read_from_shared_memory(subspace, memory, n=n)
@@ -329,7 +330,8 @@ def _write_oneof_to_shared_memory(
 ) -> None:
     subspace_idx, space_value = values
 
-    destination = np.frombuffer(shared_memory[0].get_obj(), dtype=np.int64)
+    # typeshed bug: `Array[_SimpleCData[c_int64]]` is missing `__buffer__` method stubs
+    destination = np.frombuffer(shared_memory[0].get_obj(), dtype=np.int64)  # ty:ignore[no-matching-overload]
     np.copyto(destination[index : index + 1], subspace_idx)
 
     # only the subspace's memory is updated with the sample value, ignoring the other memories as data might not match

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -13,7 +13,7 @@ import gc
 import os
 from collections.abc import Callable
 from copy import deepcopy
-from typing import Any, Generic, SupportsFloat
+from typing import Any, Generic, SupportsFloat, cast
 
 import numpy as np
 
@@ -626,9 +626,9 @@ class AddWhiteNoise(
         self.probability_of_noise_per_pixel = probability_of_noise_per_pixel
         self.is_noise_grayscale = is_noise_grayscale
 
-    def render(self) -> RenderFrame:
+    def render(self) -> np.ndarray:
         """Compute the render frames as specified by render_mode attribute during initialization of the environment, then add white noise."""
-        render_out = super().render()
+        render_out = cast(np.ndarray, super().render())
 
         if self.is_noise_grayscale:
             noise = (
@@ -715,7 +715,7 @@ class ObstructView(
 
     def render(self) -> RenderFrame:
         """Compute the render frames as specified by render_mode attribute during initialization of the environment, then add white noise patches."""
-        render_out = super().render()
+        render_out = cast(np.ndarray, super().render())
 
         render_shape = render_out.shape
         n_pixels = render_shape[0] * render_shape[1]

--- a/gymnasium/wrappers/transform_reward.py
+++ b/gymnasium/wrappers/transform_reward.py
@@ -109,5 +109,7 @@ class ClipReward(TransformReward[ObsType, ActType], gym.utils.RecordConstructorA
             self, min_reward=min_reward, max_reward=max_reward
         )
         TransformReward.__init__(
-            self, env=env, func=lambda x: np.clip(x, a_min=min_reward, a_max=max_reward)
+            self,
+            env=env,
+            func=lambda x: np.clip(x, a_min=min_reward, a_max=max_reward),  # ty:ignore[no-matching-overload]
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,10 @@ convention = "google"
 include = ["gymnasium"]
 exclude = ["tests", "**/node_modules", "**/__pycache__"]
 
+[tool.ty.analysis]
+replace-imports-with-any = ["Box2D.**", "mujoco.**", "glfw.**"]
+respect-type-ignore-comments = false
+
 [tool.ty.environment]
 python-version = "3.10"
 python-platform = "all"


### PR DESCRIPTION
# Description

Since `ty==0.0.9`, `ty` it has been improved in many ways (it's still very much feature-incomplete and often wrong, but that's a topic for another time). This upgrades `ty` to the latest `0.0.34` version, and fixes a bunch of new `ty` errors (many of which false positives).

This also tweaks the config a bit, so that it no longer complains about missing/untyped imports for `Box2D`, `mujoco`, and `glfw`. It also doesn't consider blanket `# type: ignore` (mypy-style) comments anymore.

For better type-checking, I've added two of the required dependencies to the prek env (numpy and cloudpickle). Without these, `ty` would treat any numpy or cloudpickle function as `Any`, effectively disabling type-checking in those cases.

## Type of change

Maintenance and static typing fixes.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

