### PR TITLE
fix(wrappers): correct RecordVideo vector step return type annotation (closes #1580)

### DIFF
--- a/gymnasium/wrappers/vector/rendering.py
+++ b/gymnasium/wrappers/vector/rendering.py
@@ -6,7 +6,7 @@ import gc
 import os
 from collections.abc import Callable, Sequence
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, SupportsFloat
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -444,7 +444,7 @@ class RecordVideo(
 
     def step(
         self, actions: ActType
-    ) -> tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]:
+    ) -> tuple[ObsType, ArrayType, ArrayType, ArrayType, dict[str, Any]]:
         """Steps through the environment using action, recording observations if :attr:`self.recording`."""
         obs, rewards, terminations, truncations, info = self.env.step(actions)
         self.step_id += 1

--- a/tests/wrappers/vector/test_record_video.py
+++ b/tests/wrappers/vector/test_record_video.py
@@ -206,3 +206,47 @@ def test_video_length(autoreset_mode, video_length: int = 10, n_envs=10):
     mp4_files = [file for file in os.listdir("videos") if file.endswith(".mp4")]
     shutil.rmtree("videos")
     assert len(mp4_files) == 1
+
+
+def test_record_video_step_returns_arrays_not_scalars():
+    """Regression test for https://github.com/Farama-Foundation/Gymnasium/issues/1580.
+
+    ``RecordVideo.step`` previously declared a return type of
+    ``tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]``, which
+    misled static type checkers (Pyright/Pylance) into thinking that
+    ``terminations`` / ``truncations`` were Python ``bool``s rather than
+    numpy arrays. At runtime they are arrays of shape ``(num_envs,)``, the
+    same as the underlying :class:`VectorEnv.step`, so the annotation now
+    matches the runtime contract.
+    """
+    envs = gym.make_vec(
+        "CartPole-v1",
+        num_envs=4,
+        render_mode="rgb_array",
+        vectorization_mode=gym.VectorizeMode.SYNC,
+    )
+    envs = RecordVideo(envs, "videos", video_aspect_ratio=(1, 1))
+
+    envs.reset(seed=42)
+    envs.action_space.seed(42)
+    obs, rewards, terminations, truncations, info = envs.step(
+        envs.action_space.sample()
+    )
+
+    try:
+        assert isinstance(rewards, np.ndarray)
+        assert rewards.shape == (4,)
+        assert isinstance(terminations, np.ndarray)
+        assert terminations.shape == (4,)
+        assert isinstance(truncations, np.ndarray)
+        assert truncations.shape == (4,)
+        # The caller pattern from the original bug report — calling array
+        # methods on the returned terminations/truncations — must work.
+        done = terminations | truncations
+        assert isinstance(done, np.ndarray)
+        assert done.shape == (4,)
+        _ = done.any()
+    finally:
+        envs.close()
+        if os.path.isdir("videos"):
+            shutil.rmtree("videos")


### PR DESCRIPTION
# Description

Fixes #1580.

The vector `RecordVideo.step` annotated its return type as
`tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]`, but the
runtime implementation delegates to `self.env.step(actions)` whose
canonical signature on `VectorEnv` is
`tuple[ObsType, ArrayType, ArrayType, ArrayType, dict[str, Any]]`. The
existing logic immediately below — `terminations[0] or truncations[0]`
on the next line — already relies on array semantics, confirming the
values are arrays at runtime.

The bogus `SupportsFloat, bool, bool` annotation caused static type
checkers (Pyright/Pylance) to falsely report errors on legitimate
caller code that used numpy array methods like `.any()` on the
returned `terminations` / `truncations`, e.g. the exact snippet from
the bug report:

```python
obs, reward, terminated, truncated, info = envs.step(action)
done = terminated | truncated     # Pyright: "bool" has no attribute "|"
if done.any():                    # Pyright: "bool" has no attribute "any"
    ...
```

The sibling `HumanRendering.step` in the same file already uses the
correct `ArrayType, ArrayType, ArrayType` annotation, so this brings
`RecordVideo` into alignment with both its sibling and the underlying
`VectorEnv.step` contract.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Behavior

| Caller code | Before (Pyright) | After (Pyright) | Runtime |
| --- | --- | --- | --- |
| `done = terminations \| truncations` | falsely flagged | accepted | works |
| `done.any()` | falsely flagged | accepted | works |
| `terminations.shape` | falsely flagged | accepted | `(num_envs,)` |
| `terminations[0]` | accepted (already in repo) | accepted | works |

# Checklist

- [x] I have run `ruff check` / `ruff format --check` on the touched files (both clean)
- [x] I have made corresponding changes — none needed beyond the annotation + regression test
- [x] My changes generate no new warnings (`ty check` baseline diagnostics on `rendering.py` unchanged)
- [x] I have added tests that prove my fix is effective — `test_record_video_step_returns_arrays_not_scalars` exercises the exact caller pattern from #1580
- [x] New and existing unit tests pass locally with my changes (all 18 existing `tests/wrappers/vector/test_record_video.py` cases + the new regression test)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7, 1M context). The fix shape, regression-test design, and behavior-matrix table were drafted by the AI and verified by the author.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>