### PR TITLE
perf: use pygame.display.init() instead of pygame.init() in all environments

### DIFF
--- a/gymnasium/envs/box2d/bipedal_walker.py
+++ b/gymnasium/envs/box2d/bipedal_walker.py
@@ -631,7 +631,6 @@ class BipedalWalker(gym.Env, EzPickle):
             ) from e
 
         if self.screen is None and self.render_mode == "human":
-            pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((VIEWPORT_W, VIEWPORT_H))
         if self.clock is None:

--- a/gymnasium/envs/box2d/car_racing.py
+++ b/gymnasium/envs/box2d/car_racing.py
@@ -602,7 +602,6 @@ class CarRacing(gym.Env, EzPickle):
 
         pygame.font.init()
         if self.screen is None and mode == "human":
-            pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((WINDOW_W, WINDOW_H))
         if self.clock is None:

--- a/gymnasium/envs/box2d/lunar_lander.py
+++ b/gymnasium/envs/box2d/lunar_lander.py
@@ -683,7 +683,6 @@ class LunarLander(gym.Env, EzPickle):
             ) from e
 
         if self.screen is None and self.render_mode == "human":
-            pygame.init()
             pygame.display.init()
             self.screen = pygame.display.set_mode((VIEWPORT_W, VIEWPORT_H))
         if self.clock is None:

--- a/gymnasium/envs/classic_control/acrobot.py
+++ b/gymnasium/envs/classic_control/acrobot.py
@@ -297,9 +297,8 @@ class AcrobotEnv(Env):
             ) from e
 
         if self.screen is None:
-            pygame.init()
+            pygame.display.init()
             if self.render_mode == "human":
-                pygame.display.init()
                 self.screen = pygame.display.set_mode(
                     (self.SCREEN_DIM, self.SCREEN_DIM)
                 )

--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -264,9 +264,8 @@ class CartPoleEnv(gym.Env[np.ndarray, int | np.ndarray]):
             ) from e
 
         if self.screen is None:
-            pygame.init()
+            pygame.display.init()
             if self.render_mode == "human":
-                pygame.display.init()
                 self.screen = pygame.display.set_mode(
                     (self.screen_width, self.screen_height)
                 )
@@ -523,7 +522,7 @@ class CartPoleVectorEnv(VectorEnv):
             ) from e
 
         if self.screens is None:
-            pygame.init()
+            pygame.display.init()
 
             self.screens = [
                 pygame.Surface((self.screen_width, self.screen_height))

--- a/gymnasium/envs/classic_control/continuous_mountain_car.py
+++ b/gymnasium/envs/classic_control/continuous_mountain_car.py
@@ -215,9 +215,8 @@ class Continuous_MountainCarEnv(gym.Env):
             ) from e
 
         if self.screen is None:
-            pygame.init()
+            pygame.display.init()
             if self.render_mode == "human":
-                pygame.display.init()
                 self.screen = pygame.display.set_mode(
                     (self.screen_width, self.screen_height)
                 )

--- a/gymnasium/envs/classic_control/mountain_car.py
+++ b/gymnasium/envs/classic_control/mountain_car.py
@@ -191,9 +191,8 @@ class MountainCarEnv(gym.Env):
             ) from e
 
         if self.screen is None:
-            pygame.init()
+            pygame.display.init()
             if self.render_mode == "human":
-                pygame.display.init()
                 self.screen = pygame.display.set_mode(
                     (self.screen_width, self.screen_height)
                 )

--- a/gymnasium/envs/classic_control/pendulum.py
+++ b/gymnasium/envs/classic_control/pendulum.py
@@ -189,9 +189,8 @@ class PendulumEnv(gym.Env):
             ) from e
 
         if self.screen is None:
-            pygame.init()
+            pygame.display.init()
             if self.render_mode == "human":
-                pygame.display.init()
                 self.screen = pygame.display.set_mode(
                     (self.screen_dim, self.screen_dim)
                 )

--- a/gymnasium/envs/phys2d/cartpole.py
+++ b/gymnasium/envs/phys2d/cartpole.py
@@ -240,7 +240,7 @@ class CartPoleFunctional(
                 'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             ) from e
 
-        pygame.init()
+        pygame.display.init()
         screen = pygame.Surface((screen_width, screen_height))
         clock = pygame.time.Clock()
 

--- a/gymnasium/envs/phys2d/pendulum.py
+++ b/gymnasium/envs/phys2d/pendulum.py
@@ -211,7 +211,7 @@ class PendulumFunctional(
                 'pygame is not installed, run `pip install "gymnasium[classic_control]"`'
             ) from e
 
-        pygame.init()
+        pygame.display.init()
         screen = pygame.Surface((screen_width, screen_height))
         clock = pygame.time.Clock()
 

--- a/gymnasium/envs/tabular/blackjack.py
+++ b/gymnasium/envs/tabular/blackjack.py
@@ -376,7 +376,8 @@ class BlackjackFunctional(
         suits = ["C", "D", "H", "S"]
         dealer_top_card_suit = rng.choice(suits)
         dealer_top_card_value_str = rng.choice(["J", "Q", "K"])
-        pygame.init()
+        pygame.display.init()
+        pygame.font.init()
         screen = pygame.Surface((screen_width, screen_height))
 
         return screen, dealer_top_card_value_str, dealer_top_card_suit

--- a/gymnasium/envs/tabular/cliffwalking.py
+++ b/gymnasium/envs/tabular/cliffwalking.py
@@ -232,7 +232,7 @@ class CliffWalkingFunctional(
             12 * cell_size[1],
         )
 
-        pygame.init()
+        pygame.display.init()
         screen = pygame.Surface((window_size[1], window_size[0]))
 
         shape = (4, 12)

--- a/gymnasium/envs/toy_text/blackjack.py
+++ b/gymnasium/envs/toy_text/blackjack.py
@@ -264,12 +264,11 @@ class BlackjackEnv(gym.Env):
         white = (255, 255, 255)
 
         if not hasattr(self, "screen"):
-            pygame.init()
+            pygame.display.init()
+            pygame.font.init()
             if self.render_mode == "human":
-                pygame.display.init()
                 self.screen = pygame.display.set_mode((screen_width, screen_height))
             else:
-                pygame.font.init()
                 self.screen = pygame.Surface((screen_width, screen_height))
 
         if not hasattr(self, "clock"):

--- a/gymnasium/envs/toy_text/cliffwalking.py
+++ b/gymnasium/envs/toy_text/cliffwalking.py
@@ -234,10 +234,9 @@ class CliffWalkingEnv(Env):
                 'pygame is not installed, run `pip install "gymnasium[toy-text]"`'
             ) from e
         if self.window_surface is None:
-            pygame.init()
+            pygame.display.init()
 
             if mode == "human":
-                pygame.display.init()
                 pygame.display.set_caption("CliffWalking")
                 self.window_surface = pygame.display.set_mode(self.window_size)
             else:  # rgb_array

--- a/gymnasium/envs/toy_text/frozen_lake.py
+++ b/gymnasium/envs/toy_text/frozen_lake.py
@@ -371,10 +371,9 @@ class FrozenLakeEnv(Env):
             ) from e
 
         if self.window_surface is None:
-            pygame.init()
+            pygame.display.init()
 
             if mode == "human":
-                pygame.display.init()
                 pygame.display.set_caption("Frozen Lake")
                 self.window_surface = pygame.display.set_mode(self.window_size)
             elif mode == "rgb_array":

--- a/gymnasium/envs/toy_text/taxi.py
+++ b/gymnasium/envs/toy_text/taxi.py
@@ -498,7 +498,7 @@ class TaxiEnv(Env):
             ) from e
 
         if self.window is None:
-            pygame.init()
+            pygame.display.init()
             pygame.display.set_caption("Taxi")
             if mode == "human":
                 self.window = pygame.display.set_mode(WINDOW_SIZE)

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -558,7 +558,6 @@ class HumanRendering(
         )
 
         if self.window is None:
-            pygame.init()
             pygame.display.init()
             self.window = pygame.display.set_mode(self.screen_size)
 

--- a/gymnasium/wrappers/vector/rendering.py
+++ b/gymnasium/wrappers/vector/rendering.py
@@ -181,7 +181,6 @@ class HumanRendering(VectorWrapper, gym.utils.RecordConstructorArgs):
             ] = scaled_render
 
         if self.window is None:
-            pygame.init()
             pygame.display.init()
             self.window = pygame.display.set_mode(self.screen_size)
 

--- a/tests/envs/test_rendering.py
+++ b/tests/envs/test_rendering.py
@@ -5,6 +5,38 @@ from gymnasium.logger import warn
 from tests.envs.utils import all_testing_env_specs
 
 
+def test_pygame_selective_init():
+    """Rendering must use pygame.display.init(), not pygame.init().
+
+    pygame.init() initialises every subsystem including audio (mixer),
+    which is unnecessary and can fail in headless CI environments.
+    After rendering an rgb_array frame the display subsystem must be
+    initialised while the mixer must remain uninitialised.
+    """
+    try:
+        import pygame
+    except ImportError:
+        pytest.skip("pygame not installed")
+
+    import os
+
+    os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+    os.environ.setdefault("SDL_AUDIODRIVER", "dummy")
+
+    import gymnasium as gym
+
+    env = gym.make("CartPole-v1", render_mode="rgb_array")
+    env.reset(seed=0)
+    env.render()
+
+    assert pygame.display.get_init(), "pygame.display must be initialised after render"
+    assert pygame.mixer.get_init() is None, (
+        "pygame.mixer must NOT be initialised by render (use pygame.display.init() "
+        "not pygame.init())"
+    )
+    env.close()
+
+
 def check_rendered(rendered_frame, mode: str):
     """Check that the rendered frame is as expected."""
     if mode == "rgb_array_list":


### PR DESCRIPTION
## Description

Replace `pygame.init()` with `pygame.display.init()` (and `pygame.font.init()` where text rendering is used) across all environment and wrapper files that render via pygame.

`pygame.init()` initialises every subsystem — including audio (mixer), joystick, CDROM, etc. — none of which RL environments need. Selective initialisation is:
- **Faster** at startup (the audio-device enumeration in `pygame.init()` can take several seconds on Windows/macOS).
- **Avoids spurious failures/warnings** in headless CI / containerised environments where the audio device is absent.
- Consistent with the recommendation in Farama-Foundation/PettingZoo#1252.

Files changed: CartPole (+ vector), ContinuousMountainCar, MountainCar, Pendulum, Acrobot, LunarLander, BipedalWalker, CarRacing, Blackjack (toy_text + tabular), CliffWalking (toy_text + tabular), FrozenLake, Taxi, phys2d variants, and the scalar + vector `HumanRendering` wrappers.

Adds `test_pygame_selective_init`, a regression test that asserts `pygame.display` is initialised while `pygame.mixer` is **not** after an `rgb_array` render.

Verified in a headless container: every patched env renders `rgb_array` without a display, and `pygame.mixer.get_init()` is `None` after rendering (it was `(44100, -16, 2)` with the old `pygame.init()`).

Fixes #1585

---
*This PR was produced with the assistance of an AI coding assistant.*

## Checklist

- [x] I have run the `pre-commit` checks with `pre-commit run --all-files`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes