### PR TITLE
Add WireHarness-MultiAgent-RL to third-party robotics environments

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -363,6 +363,13 @@ A gymnasium environment that sends continuous Linux server log data and kernel e
 
   Highly scalable and customizable Safe Reinforcement Learning library.
 
+- [WireHarness-MultiAgent-RL: Multi-agent wire harness routing in MuJoCo](https://github.com/ludwigstr/WireHarness-MultiAgent-RL)
+
+  ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-%3E%3D0.29-blue)
+  ![GitHub stars](https://img.shields.io/github/stars/ludwigstr/WireHarness-MultiAgent-RL)
+  
+  MuJoCo-based  environment for multi-agent wire harness routing. Five planar movers must coordinate to navigate cable harnesses to predefined target configurations on an assembly board without causing cable collisions.
+
 ### Telecommunication Systems environments
 *Interact and/or manage wireless and/or wired telecommunication systems.*
 - [mobile-env: Environments for coordination of wireless mobile networks](https://github.com/stefanbschneider/mobile-env)

--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -363,12 +363,12 @@ A gymnasium environment that sends continuous Linux server log data and kernel e
 
   Highly scalable and customizable Safe Reinforcement Learning library.
 
-- [WireHarness-MultiAgent-RL: Multi-agent wire harness routing in MuJoCo](https://github.com/ludwigstr/WireHarness-MultiAgent-RL)
+- [WireHarness-MultiAgent-RL: Centralized multi-robot wire handling in MuJoCo](https://github.com/ludwigstr/WireHarness-MultiAgent-RL)
 
   ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-%3E%3D0.29-blue)
   ![GitHub stars](https://img.shields.io/github/stars/ludwigstr/WireHarness-MultiAgent-RL)
 
-  MuJoCo-based environment for multi-agent wire harness routing. Five planar movers must coordinate to navigate cable harnesses to predefined target configurations on an assembly board without causing cable collisions.
+  MuJoCo-based Gymnasium environment for centralized multi-robot wire handling. A single policy controls five planar movers via a joint action space to navigate cable harnesses to target configurations on an assembly board without causing collisions.
 
 ### Telecommunication Systems environments
 *Interact and/or manage wireless and/or wired telecommunication systems.*

--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -367,8 +367,8 @@ A gymnasium environment that sends continuous Linux server log data and kernel e
 
   ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-%3E%3D0.29-blue)
   ![GitHub stars](https://img.shields.io/github/stars/ludwigstr/WireHarness-MultiAgent-RL)
-  
-  MuJoCo-based  environment for multi-agent wire harness routing. Five planar movers must coordinate to navigate cable harnesses to predefined target configurations on an assembly board without causing cable collisions.
+
+  MuJoCo-based environment for multi-agent wire harness routing. Five planar movers must coordinate to navigate cable harnesses to predefined target configurations on an assembly board without causing cable collisions.
 
 ### Telecommunication Systems environments
 *Interact and/or manage wireless and/or wired telecommunication systems.*


### PR DESCRIPTION
# Description

Adds **WireHarness-MultiAgent-RL** to the list of third-party robotics environments.

WireHarness-MultiAgent-RL is a MuJoCo-based Gymnasium environment for multi-agent wire harness routing research. Five planar movers must coordinate to navigate cable segments to predefined target configurations on an assembly board without causing cable collisions. The environment is fully compatible with `gymnasium>=0.29` and supports `gym.make()` after a
one-line import.

Repository: https://github.com/ludwigstr/WireHarness-MultiAgent-RL

## Type of change

- [x] Documentation only change (no code changed)

### Screenshots

| Rendered entry |
|----------------|
| ![entry](https://github.com/ludwigstr/WireHarness-MultiAgent-RL/raw/main/docs/simulation.png) |
<img width="640" height="352" alt="frame_12_step031" src="https://github.com/user-attachments/assets/4727e32c-8a4f-493c-a9ed-3f42530cd823" />


# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with
      `pre-commit run --all-files`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
