### PR TITLE
fix: remove duplicate classic control extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dynamic = ["version"]
 atari = ["ale_py >=0.9"]
 box2d = ["box2d ==2.3.10", "pygame-ce >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame-ce >=2.1.3"]
-classic_control = ["pygame-ce >=2.1.3"]  # kept for backward compatibility
 mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1", "packaging >=23.0"]
 toy-text = ["pygame-ce >=2.1.3"]
 toy_text = ["pygame-ce >=2.1.3"] # kept for backward compatibility

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ box2d = ["box2d ==2.3.10", "pygame-ce >=2.1.3", "swig ==4.*"]
 classic-control = ["pygame-ce >=2.1.3"]
 mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1", "packaging >=23.0"]
 toy-text = ["pygame-ce >=2.1.3"]
-toy_text = ["pygame-ce >=2.1.3"] # kept for backward compatibility
 jax = [
     "jax >=0.4.16",
     "jaxlib >=0.4.16",


### PR DESCRIPTION
# Description

Removes the duplicate `classic_control` optional dependency entry from `pyproject.toml`.

The `classic-control` and `classic_control` extras normalize to the same name, which causes `uv` to fail when parsing `pyproject.toml` during CI.

Fixes #1593

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Not applicable.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes