### PR TITLE
Various fixes regarding typing & code style

### DIFF
--- a/gymnasium/envs/box2d/car_dynamics.py
+++ b/gymnasium/envs/box2d/car_dynamics.py
@@ -8,6 +8,8 @@ Created by Oleg Klimov
 """
 
 import math
+from dataclasses import dataclass
+from typing import Any
 
 import Box2D
 import numpy as np
@@ -334,14 +336,18 @@ class Car:
                 pygame.draw.polygon(surface, color=WHEEL_WHITE, points=white_poly)
 
     def _create_particle(self, point1, point2, grass):
+        @dataclass(slots=True)
         class Particle:
-            pass
+            color: tuple[int, int, int]
+            poly: list[tuple[int, int]]
+            grass: Any
+            ttl: int = 1
 
-        p = Particle()
-        p.color = WHEEL_COLOR if not grass else MUD_COLOR
-        p.ttl = 1
-        p.poly = [(point1[0], point1[1]), (point2[0], point2[1])]
-        p.grass = grass
+        p = Particle(
+            color=WHEEL_COLOR if not grass else MUD_COLOR,
+            poly=[(point1[0], point1[1]), (point2[0], point2[1])],
+            grass=grass,
+        )
         self.particles.append(p)
         while len(self.particles) > 30:
             self.particles.pop(0)

--- a/gymnasium/envs/box2d/car_dynamics.py
+++ b/gymnasium/envs/box2d/car_dynamics.py
@@ -8,6 +8,7 @@ Created by Oleg Klimov
 """
 
 import math
+from collections import deque
 from dataclasses import dataclass
 from typing import Any
 
@@ -49,6 +50,14 @@ HULL_POLY4 = [(-50, -120), (+50, -120), (+50, -90), (-50, -90)]
 WHEEL_COLOR = (0, 0, 0)
 WHEEL_WHITE = (77, 77, 77)
 MUD_COLOR = (102, 102, 0)
+
+
+@dataclass(slots=True)
+class Particle:
+    color: tuple[int, int, int]
+    poly: list[tuple[int, int]]
+    grass: Any
+    ttl: int = 1
 
 
 class Car:
@@ -137,7 +146,7 @@ class Car:
             w.userData = w
             self.wheels.append(w)
         self.drawlist = self.wheels + [self.hull]
-        self.particles = []
+        self.particles = deque(maxlen=30)
 
     def gas(self, gas):
         """control: rear wheel drive
@@ -336,21 +345,12 @@ class Car:
                 pygame.draw.polygon(surface, color=WHEEL_WHITE, points=white_poly)
 
     def _create_particle(self, point1, point2, grass):
-        @dataclass(slots=True)
-        class Particle:
-            color: tuple[int, int, int]
-            poly: list[tuple[int, int]]
-            grass: Any
-            ttl: int = 1
-
         p = Particle(
             color=WHEEL_COLOR if not grass else MUD_COLOR,
             poly=[(point1[0], point1[1]), (point2[0], point2[1])],
             grass=grass,
         )
         self.particles.append(p)
-        while len(self.particles) > 30:
-            self.particles.pop(0)
         return p
 
     def destroy(self):

--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -5,6 +5,7 @@ permalink: https://perma.cc/C9ZM-652R
 """
 
 import math
+from typing import Any
 
 import numpy as np
 
@@ -596,7 +597,7 @@ class CartPoleVectorEnv(VectorEnv):
             for screen in self.screens
         ]
 
-    def close(self):
+    def close(self, **kwargs: Any):
         if self.screens is not None:
             import pygame
 

--- a/gymnasium/envs/functional_jax_env.py
+++ b/gymnasium/envs/functional_jax_env.py
@@ -224,7 +224,7 @@ class FunctionalJaxVectorEnv(
         else:
             raise NotImplementedError
 
-    def close(self):
+    def close(self, **kwargs: Any):
         """Closes the environments and render state if set."""
         if self.render_state is not None:
             self.func_env.render_close(self.render_state)

--- a/gymnasium/envs/toy_text/taxi.py
+++ b/gymnasium/envs/toy_text/taxi.py
@@ -1,6 +1,7 @@
 from contextlib import closing
 from io import StringIO
 from os import path
+from typing import Any
 
 import numpy as np
 
@@ -366,6 +367,7 @@ class TaxiEnv(Env):
         self.render_mode = render_mode
         self.fickle_passenger = fickle_passenger
         self.fickle_step = False
+        self.lastaction: Any = None
 
         # pygame utils
         self.window = None

--- a/gymnasium/spaces/dict.py
+++ b/gymnasium/spaces/dict.py
@@ -23,7 +23,7 @@ else:
 
 
 class Dict(
-    Space[dict[str, Space[_T_co]]],
+    Space[dict[str, Space]],
     typing.Mapping[str, Space[_T_co]],
     Generic[_T_co],
 ):

--- a/gymnasium/wrappers/vector/array_conversion.py
+++ b/gymnasium/wrappers/vector/array_conversion.py
@@ -85,7 +85,7 @@ class ArrayConversion(VectorWrapper, gym.utils.RecordConstructorArgs):
     def reset(
         self,
         *,
-        seed: int | list[int] | None = None,
+        seed: int | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[ObsType, dict[str, Any]]:
         """Resets the environment returning xp-based observation and info.

--- a/gymnasium/wrappers/vector/common.py
+++ b/gymnasium/wrappers/vector/common.py
@@ -113,7 +113,7 @@ class RecordEpisodeStatistics(VectorWrapper):
 
     def reset(
         self,
-        seed: int | list[int] | None = None,
+        seed: int | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[np.ndarray, dict[str, Any]]:
         """Resets the environment using kwargs and resets the episode returns and lengths."""

--- a/gymnasium/wrappers/vector/rendering.py
+++ b/gymnasium/wrappers/vector/rendering.py
@@ -193,14 +193,14 @@ class HumanRendering(VectorWrapper, gym.utils.RecordConstructorArgs):
         self.clock.tick(self.metadata["render_fps"])
         pygame.display.flip()
 
-    def close(self) -> None:
+    def close(self, **kwargs: Any) -> None:
         """Close the rendering window."""
         if self.window is not None:
             import pygame
 
             pygame.display.quit()
             pygame.quit()
-        super().close()
+        super().close(**kwargs)
 
 
 class RecordVideo(
@@ -493,9 +493,9 @@ class RecordVideo(
         else:
             return render_out
 
-    def close(self) -> None:
+    def close(self, **kwargs: Any) -> None:
         """Closes the wrapper then the video recorder."""
-        super().close()
+        super().close(**kwargs)
         if self.recording:
             self.stop_recording()
 

--- a/gymnasium/wrappers/vector/rendering.py
+++ b/gymnasium/wrappers/vector/rendering.py
@@ -82,7 +82,7 @@ class HumanRendering(VectorWrapper, gym.utils.RecordConstructorArgs):
     def reset(
         self,
         *,
-        seed: int | list[int] | None = None,
+        seed: int | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[ObsType, dict[str, Any]]:
         """Reset the base environment and render a frame to the screen."""

--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -115,7 +115,7 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
     def reset(
         self,
         *,
-        seed: int | list[int] | None = None,
+        seed: int | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[np.ndarray, dict[str, Any]]:
         """Reset function for `NormalizeObservationWrapper` which is disabled for partial resets."""

--- a/gymnasium/wrappers/vector/stateful_reward.py
+++ b/gymnasium/wrappers/vector/stateful_reward.py
@@ -106,7 +106,7 @@ class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
     def reset(
         self,
         *,
-        seed: int | list[int] | None = None,
+        seed: int | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[np.ndarray, dict[str, Any]]:
         """Resets the environment and clears accumulated reward tracking state."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,39 +55,7 @@ other = [
     "seaborn >= 0.13",
 ]
 all = [
-    # All dependencies above except accept-rom-license
-    # NOTE: No need to manually remove the duplicates, setuptools automatically does that.
-    # atari
-    "ale_py >=0.9",
-    # box2d
-    "box2d-py ==2.3.5",
-    "pygame-ce >=2.1.3",
-    "swig ==4.*",
-    # classic-control
-    "pygame-ce >=2.1.3",
-    # mujoco
-    "mujoco >=2.1.5",
-    "imageio >=2.14.1",
-    "packaging >=23.0",
-    # toy-text
-    "pygame-ce >=2.1.3",
-    # jax
-    "jax >=0.4.16",
-    "jaxlib >=0.4.16",
-    "flax >= 0.5.0",
-    "array-api-compat >=1.11.0",
-    "numpy>=2.1",
-    # torch
-    "torch >=1.13.0",
-    "array-api-compat >=1.11.0",
-    "numpy>=2.1",
-    # array-api
-    "array-api-compat >=1.11.0",
-    "numpy>=2.1",
-    # other
-    "opencv-python >=3.0",
-    "matplotlib >=3.0",
-    "moviepy >=1.0.0",
+    "gymnasium[atari, box2d, classic-control, mujoco, toy-text, jax, torch, array-api, other]"
 ]
 
 testing = [

--- a/tests/vector/test_vector_wrapper.py
+++ b/tests/vector/test_vector_wrapper.py
@@ -23,7 +23,7 @@ class DummyVectorWrapper(VectorWrapper):
     def reset(
         self,
         *,
-        seed: int | list[int] | None = None,
+        seed: int | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[ObsType, dict[str, Any]]:
         """Updates the ``counter`` each time at ``reset`` is called."""

--- a/tests/wrappers/vector/test_dict_info_to_list.py
+++ b/tests/wrappers/vector/test_dict_info_to_list.py
@@ -31,7 +31,7 @@ class ResetOptionAsInfo(VectorEnv):
     def reset(
         self,
         *,
-        seed: int | list[int] | None = None,
+        seed: int | None = None,
         options: dict[str, Any] | None = None,  # options are passed are the info output
     ) -> tuple[ObsType, dict[str, Any]]:
         return None, options


### PR DESCRIPTION
# Description

Efforts toward #1593, these are the changes I deem safe to merge without further discussion with the maintainers. Many other changes will change the signature / behaviour, may need to resort to enabling ignore comments https://github.com/Farama-Foundation/Gymnasium/issues/1599.

- Replace the handwritten & outdated `all` extra definition with a self-reference f0df2bcb8e9bfb784a45a646da639a6135bc21f5
- Fix incorrect type hints mentioning `seed` can be a `list[int]` when it would raise exception 4678021246863e8d93fe06ef17cec3c3a925881a
- Make `Particle`, a temporary class in Box2D `Car` class, a proper dataclass 30a344202817134e4ce5e4ef8d8300a97a2236a6 645a5a3fe0239b683f4b9eec71ed16cbc77542b7
- Minor optimization in Box2D `Car` class: avoid `list.pop(0)` with a `deque` with `max_len 645a5a3fe0239b683f4b9eec71ed16cbc77542b7
- Fix type annotation in `Dict` space: `dict` is invariant so current `dict[str, Space[_T_co]]` is incorrect, also `Dict.__getitem__` returns `Space[Any]` anyway, so we're not losing anything a8afed8c45c389d1a21d687744b96f7ead7a0938
- Add missing `**kwargs` in override `close` method declarations eaf5d918cf0c001c460b5cc811dd177f1d0c0c09
- `TaxiEnv.lastaction` was not declared in the constructor, declaring it there ade8a22331a47e026ae43274a5f14ac3a7061c8a


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Unfortunately, pre-commit would still not function due to many typing warning from ty blocking us.
- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
