### PR TITLE
Fix ty pre-commit hook and add box2d-py fallback for Python 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,12 +45,7 @@ repos:
 #  - repo: https://github.com/pycqa/pydocstyle
 #        exclude: ^(gymnasium/envs/box2d)|(gymnasium/envs/classic_control)|(gymnasium/envs/mujoco)|(gymnasium/envs/toy_text)|(tests/envs)|(tests/spaces)|(tests/utils)|(tests/vector)|(docs/)
 
-  - repo: local
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.54
     hooks:
       - id: ty
-        name: ty check
-        entry: ty check .
-        language: python
-        pass_filenames: false
-        types: [python]
-        additional_dependencies: ["ty==0.0.34", "numpy", "cloudpickle"]

--- a/docs/environments/box2d.md
+++ b/docs/environments/box2d.md
@@ -17,6 +17,10 @@ box2d/lunar_lander
    :file: box2d/list.html
 ```
 
+```{warning}
+If you plan to use box2d with Python version >= 3.14, know that at the moment the upstream project [pybox2d](https://github.com/pybox2d/pybox2d) does not provide pre-built wheels for >= 3.13. As a workaround, the `box2d` extra builds [box2d-py](https://pypi.org/project/box2d-py/) from source and additionally requires `swig`. Make sure you have [SWIG](https://swig.org/) installed on your system.
+```
+
 These environments all involve toy games based around physics control, using [box2d](https://box2d.org/) based physics and PyGame-based rendering. These environments were contributed back in the early days of OpenAI Gym by Oleg Klimov, and have become popular toy benchmarks ever since. All environments are highly configurable via arguments specified in each environment's documentation.
 
 The unique dependencies for this set of environments can be installed via:
@@ -26,4 +30,4 @@ pip install swig
 pip install gymnasium[box2d]
 ````
 
-[SWIG](https://swig.org/) is necessary for building the wheel for [box2d-py](https://pypi.org/project/box2d-py/), the Python package that provides bindings to box2d.
+[SWIG](https://swig.org/) is necessary for building the wheel for [box2d-py](https://pypi.org/project/box2d-py/), the Python package that provides bindings to box2d on Python 3.14+. For Python 3.13 or below we use the pre-built wheel from [pybox2d](https://github.com/pybox2d/pybox2d).

--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -213,7 +213,7 @@ class MultiDiscrete(Space[NDArray[_IntegerT_co]], Generic[_IntegerT_co]):
                 f"Expects the mask dtype to be np.int8, actual dtype: {sub_mask.dtype}"
             )
 
-            valid_action_mask = sub_mask == 1
+            valid_action_mask: np.typing.NDArray[np.bool_] = sub_mask == 1
             assert np.all(np.logical_or(sub_mask == 0, valid_action_mask)), (
                 f"Expects all masks values to 0 or 1, actual values: {sub_mask}"
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,14 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-# Update dependencies in `all` if any are added or removed
 atari = ["ale_py >=0.9"]
-box2d = ["box2d ==2.3.10", "pygame-ce >=2.1.3", "swig ==4.*"]
+# Note: box2d - provides wheel for <=3.13, but no source distribution; box2d-py - build from source
+box2d = [
+    "pygame-ce >=2.1.3",
+    "box2d ==2.3.10; python_version < '3.14'",
+    "box2d-py ==2.3.8; python_version >= '3.14'",
+    "swig ==4.*; python_version >= '3.14'"
+]
 classic-control = ["pygame-ce >=2.1.3"]
 mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1", "packaging >=23.0"]
 toy-text = ["pygame-ce >=2.1.3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,6 +135,9 @@ exclude = ["tests", "**/node_modules", "**/__pycache__"]
 replace-imports-with-any = ["Box2D.**", "mujoco.**", "glfw.**"]
 respect-type-ignore-comments = false
 
+[tool.ty.terminal]
+error-on-warning = false
+
 [tool.ty.environment]
 python-version = "3.10"
 python-platform = "all"


### PR DESCRIPTION
> For future reference, the two commits were merged in an incorrect order, resulting in the commit generated by this PR being empty, but the content should be all good.

# Description
- Fix typing error in `MultiDiscrete.sample`: annotate `valid_action_mask` as `NDArray[np.bool_]` to satisfy `ty`
- Switch to the official `ty-pre-commit` hook: replaces the local hook with `astral-sh/ty-pre-commit` (v0.0.54) and sets `error-on-warning = false` so only errors block CI
- Add box2d-py source-build fallback on Python 3.14+: since pybox2d doesn't publish wheels for >= 3.13 and **provides no source distribution**, the `box2d` extra now conditionally pulls `box2d-py` + `swig` on 3.14+, this provides a way to support Python 3.14 before https://github.com/Farama-Foundation/Gymnasium/issues/1597
- Enhanced documents regarding `box2d` situation in `docs/environments/box2d.md`

## Context
- `box2d` replaced `box2d-py` in https://github.com/Farama-Foundation/Gymnasium/pull/1474
- `swig` was only required to build `box2d-py`, installing pre-built `box2d` wheel doesnt need that.

Fixes #1593 (fix CI on main) #1594 (support Python 3.14) #1599 (ty warnings) #1600 (fix ty in pre-commit)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
