### PR TITLE
[WIP] Correct NumPy version constraints & fix PyTest Dockerfile

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -26,7 +26,9 @@ jobs:
             --tag gymnasium-all-docker .
       - name: Run tests
         run: docker run gymnasium-all-docker pytest tests/*
-      - name: Run doctests
+      # NumPy 1.x and 2.x have different scalar reprs and floating-point promotion behaviour
+      - name: Run doctests for numpy >= 2.1
+        if: matrix.numpy-version == '>=2.1'
         run: docker run gymnasium-all-docker pytest --doctest-modules gymnasium/
 
   build-necessary:

--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -12,6 +12,11 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         numpy-version: ['>=1.21,<2.0', '>=2.1']
+        exclude:
+          - python-version: '3.13'
+            numpy-version: '>=1.21,<2.0'
+          - python-version: '3.14'
+            numpy-version: '>=1.21,<2.0'
     steps:
       - uses: actions/checkout@v7
       - run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,12 +45,7 @@ repos:
 #  - repo: https://github.com/pycqa/pydocstyle
 #        exclude: ^(gymnasium/envs/box2d)|(gymnasium/envs/classic_control)|(gymnasium/envs/mujoco)|(gymnasium/envs/toy_text)|(tests/envs)|(tests/spaces)|(tests/utils)|(tests/vector)|(docs/)
 
-  - repo: local
+  - repo: https://github.com/astral-sh/ty-pre-commit
+    rev: v0.0.54
     hooks:
       - id: ty
-        name: ty check
-        entry: ty check .
-        language: python
-        pass_filenames: false
-        types: [python]
-        additional_dependencies: ["ty==0.0.34", "numpy", "cloudpickle"]

--- a/bin/all-py.Dockerfile
+++ b/bin/all-py.Dockerfile
@@ -1,7 +1,7 @@
 # A Dockerfile that sets up a full Gymnasium install with test dependencies
 ARG PYTHON_VERSION
-ARG NUMPY_VERSION=">=1.21,<2.0"
 FROM python:$PYTHON_VERSION
+ARG NUMPY_VERSION=">=1.21,<2.0"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -19,9 +19,7 @@ COPY . /usr/local/gymnasium/
 WORKDIR /usr/local/gymnasium/
 
 # Specify the numpy version to cover both 1.x and 2.x
-RUN uv pip install --system --upgrade "numpy$NUMPY_VERSION"
-
 # Test with PyTorch CPU build, since CUDA is not available in CI anyway
-RUN uv pip install --system .[all,testing] --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu
+RUN uv pip install --system .[all,testing] "numpy$NUMPY_VERSION" --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu
 
 ENTRYPOINT ["/usr/local/gymnasium/bin/docker_entrypoint"]

--- a/docs/environments/box2d.md
+++ b/docs/environments/box2d.md
@@ -17,6 +17,10 @@ box2d/lunar_lander
    :file: box2d/list.html
 ```
 
+```{warning}
+If you plan to use box2d with Python version >= 3.14, know that at the moment the upstream project [pybox2d](https://github.com/pybox2d/pybox2d) does not provide pre-built wheels for >= 3.13. As a workaround, the `box2d` extra builds [box2d-py](https://pypi.org/project/box2d-py/) from source and additionally requires `swig`. Make sure you have [SWIG](https://swig.org/) installed on your system.
+```
+
 These environments all involve toy games based around physics control, using [box2d](https://box2d.org/) based physics and PyGame-based rendering. These environments were contributed back in the early days of OpenAI Gym by Oleg Klimov, and have become popular toy benchmarks ever since. All environments are highly configurable via arguments specified in each environment's documentation.
 
 The unique dependencies for this set of environments can be installed via:
@@ -26,4 +30,4 @@ pip install swig
 pip install gymnasium[box2d]
 ````
 
-[SWIG](https://swig.org/) is necessary for building the wheel for [box2d-py](https://pypi.org/project/box2d-py/), the Python package that provides bindings to box2d.
+[SWIG](https://swig.org/) is necessary for building the wheel for [box2d-py](https://pypi.org/project/box2d-py/), the Python package that provides bindings to box2d on Python 3.14+. For Python 3.13 or below we use the pre-built wheel from [pybox2d](https://github.com/pybox2d/pybox2d).

--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -213,7 +213,7 @@ class MultiDiscrete(Space[NDArray[_IntegerT_co]], Generic[_IntegerT_co]):
                 f"Expects the mask dtype to be np.int8, actual dtype: {sub_mask.dtype}"
             )
 
-            valid_action_mask = sub_mask == 1
+            valid_action_mask: np.typing.NDArray[np.bool_] = sub_mask == 1
             assert np.all(np.logical_or(sub_mask == 0, valid_action_mask)), (
                 f"Expects all masks values to 0 or 1, actual values: {sub_mask}"
             )

--- a/gymnasium/wrappers/array_conversion.py
+++ b/gymnasium/wrappers/array_conversion.py
@@ -41,8 +41,8 @@ except ImportError as e:
     ) from e
 
 
-if Version(np.__version__) < Version("2.1.0"):
-    raise DependencyNotInstalled("Array API functionality requires numpy >= 2.1.0")
+if Version(np.__version__) < Version("1.22.0"):
+    raise DependencyNotInstalled("Array API functionality requires numpy >= 1.22")
 
 
 __all__ = ["ArrayConversion", "array_conversion"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,14 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-# Update dependencies in `all` if any are added or removed
 atari = ["ale_py >=0.9"]
-box2d = ["box2d ==2.3.10", "pygame-ce >=2.1.3", "swig ==4.*"]
+# Note: box2d - provides wheel for <=3.13, but no source distribution; box2d-py - build from source
+box2d = [
+    "pygame-ce >=2.1.3",
+    "box2d ==2.3.10; python_version < '3.14'",
+    "box2d-py ==2.3.8; python_version >= '3.14'",
+    "swig ==4.*; python_version >= '3.14'"
+]
 classic-control = ["pygame-ce >=2.1.3"]
 mujoco = ["mujoco >=2.1.5", "imageio >=2.14.1", "packaging >=23.0"]
 toy-text = ["pygame-ce >=2.1.3"]
@@ -134,6 +139,9 @@ exclude = ["tests", "**/node_modules", "**/__pycache__"]
 [tool.ty.analysis]
 replace-imports-with-any = ["Box2D.**", "mujoco.**", "glfw.**"]
 respect-type-ignore-comments = false
+
+[tool.ty.terminal]
+error-on-warning = false
 
 [tool.ty.environment]
 python-version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "numpy >=1.21.0",
+    "numpy >=1.22.0",
     "cloudpickle >=1.2.0",
     "typing-extensions >=4.3.0",
     "farama-notifications >=0.0.1",
@@ -49,10 +49,9 @@ jax = [
     "jaxlib >=0.4.16",
     "flax >=0.5.0",
     "array-api-compat >=1.11.0",
-    "numpy>=2.1",
 ]
-torch = ["torch >=1.13.0", "array-api-compat >=1.11.0", "numpy>=2.1"]
-array-api = ["array-api-compat >=1.11.0", "numpy>=2.1", "packaging >=23.0"]
+torch = ["torch >=1.13.0", "array-api-compat >=1.11.0"]
+array-api = ["array-api-compat >=1.11.0", "packaging >=23.0"]
 other = [
     "moviepy >=1.0.0",
     "matplotlib >=3.0",

--- a/tests/wrappers/vector/test_array_conversion.py
+++ b/tests/wrappers/vector/test_array_conversion.py
@@ -63,6 +63,9 @@ def test_array_conversion_wrapper(env_xp, target_xp):
     env_xp_compat = module_namespace(env_xp)
     env = create_vector_env(env_xp_compat)
 
+    # NumPy's "bool" type was deprecated in 1.20 and restored in 2.0, but "bool_" is always valid
+    target_xp_bool = getattr(target_xp, "bool", None) or target_xp.bool_
+
     # Check that the reset and step for env_xp environment are as expected
     obs, info = env.reset()
     # env_xp is automatically converted to the compatible namespace by array_namespace, so we need
@@ -89,9 +92,9 @@ def test_array_conversion_wrapper(env_xp, target_xp):
     assert array_namespace(obs) is target_xp_compat
     assert array_namespace(reward) is target_xp_compat
     assert array_namespace(terminated) is target_xp_compat
-    assert terminated.dtype == target_xp.bool
+    assert terminated.dtype == target_xp_bool
     assert array_namespace(truncated) is target_xp_compat
-    assert truncated.dtype == target_xp.bool
+    assert truncated.dtype == target_xp_bool
     assert isinstance(info, dict) and array_namespace(info["data"]) is target_xp_compat
 
     # Check that the wrapped environment can render. This implicitly returns None and requires  a
@@ -99,33 +102,39 @@ def test_array_conversion_wrapper(env_xp, target_xp):
     wrapped_env.render()
 
 
-@pytest.mark.parametrize("wrapper", ["JaxToNumpy", "JaxToTorch", "NumpyToTorch"])
-def test_specialized_wrappers(wrapper: str):
+@pytest.mark.parametrize("wrapper_str", ["JaxToNumpy", "JaxToTorch", "NumpyToTorch"])
+def test_specialized_wrappers(wrapper_str: str):
     # Imports need to happen inside the function to avoid loading dependencies that may not be
     # installed (i.e. jax and torch)
-    if wrapper == "JaxToNumpy":
+    if wrapper_str == "JaxToNumpy":
         jax = pytest.importorskip("jax")
         from gymnasium.wrappers.vector import JaxToNumpy  # noqa: E402
 
         env_xp, target_xp = jax.numpy, np
         wrapper = JaxToNumpy
-    elif wrapper == "JaxToTorch":
+    elif wrapper_str == "JaxToTorch":
         jax = pytest.importorskip("jax")
         torch = pytest.importorskip("torch")
         from gymnasium.wrappers.vector import JaxToTorch  # noqa: E402
 
         env_xp, target_xp = jax.numpy, torch
         wrapper = JaxToTorch
-    elif wrapper == "NumpyToTorch":
+    elif wrapper_str == "NumpyToTorch":
         torch = pytest.importorskip("torch")
         from gymnasium.wrappers.vector import NumpyToTorch  # noqa: E402
 
         env_xp, target_xp = np, torch
         wrapper = NumpyToTorch
     else:
-        raise TypeError(f"Unknown specialized conversion wrapper {type(wrapper)}")
+        raise TypeError(f"Unknown specialized conversion wrapper {wrapper_str}")
     env_xp_compat = module_namespace(env_xp)
     target_xp_compat = module_namespace(target_xp)
+
+    # NumPy's "bool" type was deprecated in 1.20 and restored in 2.0, but "bool_" is always valid
+    target_xp_bool = getattr(
+        target_xp,
+        "bool_" if wrapper_str.endswith("Numpy") else "bool",
+    )
 
     # The unwrapped test env sanity check is already covered by test_array_conversion_wrapper for
     # all known frameworks, including the specialized ones.
@@ -142,9 +151,9 @@ def test_specialized_wrappers(wrapper: str):
     assert array_namespace(obs) is target_xp_compat
     assert array_namespace(reward) is target_xp_compat
     assert array_namespace(terminated) is target_xp_compat
-    assert terminated.dtype == target_xp.bool
+    assert terminated.dtype == target_xp_bool
     assert array_namespace(truncated) is target_xp_compat
-    assert truncated.dtype == target_xp.bool
+    assert truncated.dtype == target_xp_bool
     assert isinstance(info, dict) and array_namespace(info["data"]) is target_xp_compat
 
     # Check that the wrapped environment can render. This implicitly returns None and requires a


### PR DESCRIPTION
> For future reference, the two commits were merged in a reversed order, resulting in this PR's commit containing changes in #1604, but the content should be all good.

I'll rebase & squash after #1604 gets merged, first commit is from #1604 to get CI running.

# Description
1. As mentioned in #1605, the Dockerfile used by "Run PyTest" workflow incorrectly put `ARG NUMPY_VERSION` before `FROM` and did not actually apply NumPy constraints correctly.
2. As mentioned in #1605, version matrix for "Run PyTest" workflow need to exclude Python 3.13/14 + NumPy 1.x requirements. (also pointed out by [#1603](https://github.com/Farama-Foundation/Gymnasium/pull/1603))
3. NumPy requirements in `pyproject.toml` is a mess, I fixed it by removing NumPy 2.x requirements in jax/pytorch/array-api-compat extras because they make no sense (torch doesn't specify version, jax does not even depend on it), then bumping base NumPy requirement from 1.21 to 1.22 that `array-api-compat` requires.


Fixes #1605

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
