### PR TITLE
Update most assertions into standard exceptions with helpful messages

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -314,9 +314,8 @@ class Wrapper(
             env: The environment to wrap
         """
         self.env = env
-        assert isinstance(env, Env), (
-            f"Expected env to be a `gymnasium.Env` but got {type(env)}"
-        )
+        if not isinstance(env, Env):
+            raise TypeError(f"Expected env to be a `gymnasium.Env` but got {type(env)}")
 
         self._action_space: spaces.Space[WrapperActType] | None = None
         self._observation_space: spaces.Space[WrapperObsType] | None = None

--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -596,9 +596,10 @@ def register(
     Changelogs:
         v1.0.0 - `autoreset` and `apply_api_compatibility` parameter was removed
     """
-    assert entry_point is not None or vector_entry_point is not None, (
-        "Either `entry_point` or `vector_entry_point` (or both) must be provided"
-    )
+    if entry_point is None and vector_entry_point is None:
+        raise ValueError(
+            "Either `entry_point` or `vector_entry_point` (or both) must be provided"
+        )
     ns, name, version = parse_env_id(id)
 
     if kwargs is None:
@@ -675,7 +676,8 @@ def make(
             env_spec.additional_wrappers = ()
     else:
         # For string id's, load the environment spec from the registry then make the environment spec
-        assert isinstance(id, str)
+        if not isinstance(id, str):
+            raise TypeError(f"Expected id to be a string or EnvSpec, got {type(id)}")
 
         # The environment name can include an unloaded module in "module:env_name" style
         env_spec = _find_spec(id)

--- a/gymnasium/spaces/dict.py
+++ b/gymnasium/spaces/dict.py
@@ -116,9 +116,10 @@ class Dict(
 
         self.spaces = cast("dict[str, Space[_T_co]]", spaces_dict)
         for key, space in self.spaces.items():
-            assert isinstance(space, Space), (
-                f"Dict space element is not an instance of Space: key='{key}', space={space}"
-            )
+            if not isinstance(space, Space):
+                raise TypeError(
+                    f"Dict space element is not an instance of Space: key='{key}', space={space}"
+                )
 
         # None for shape and dtype, since it'll require special handling
         super().__init__(None, None, seed)  # type: ignore
@@ -229,9 +230,10 @@ class Dict(
 
     def __setitem__(self, key: str, value: Space[Any]):
         """Set the space that is associated to `key`."""
-        assert isinstance(value, Space), (
-            f"Trying to set {key} to Dict space with value that is not a gymnasium space, actual type: {type(value)}"
-        )
+        if not isinstance(value, Space):
+            raise TypeError(
+                f"Trying to set {key} to Dict space with value that is not a gymnasium space, actual type: {type(value)}"
+            )
         self.spaces[key] = value
 
     def __iter__(self) -> Iterator[str]:

--- a/gymnasium/spaces/discrete.py
+++ b/gymnasium/spaces/discrete.py
@@ -95,13 +95,14 @@ class Discrete(Space[_IntegerT_co], Generic[_IntegerT_co]):
             start (int): The smallest element of this space.
             dtype: The space type, for example, ``int``, ``np.int64``, ``np.int32``, or ``np.uint8``.
         """
-        assert np.issubdtype(type(n), np.integer), (
-            f"Expects `n` to be an integer, actual dtype: {type(n)}"
-        )
-        assert n > 0, "n (counts) have to be positive"
-        assert np.issubdtype(type(start), np.integer), (
-            f"Expects `start` to be an integer, actual type: {type(start)}"
-        )
+        if not np.issubdtype(type(n), np.integer):
+            raise TypeError(f"Expects `n` to be an integer, actual dtype: {type(n)}")
+        if n <= 0:
+            raise ValueError(f"n (counts) have to be positive, actual value: {n}")
+        if not np.issubdtype(type(start), np.integer):
+            raise TypeError(
+                f"Expects `start` to be an integer, actual type: {type(start)}"
+            )
 
         # determine dtype
         if dtype is None:

--- a/gymnasium/spaces/graph.py
+++ b/gymnasium/spaces/graph.py
@@ -70,13 +70,16 @@ class Graph(Space[GraphInstance]):
             edge_space (Union[None, Box, Discrete]): space of the edge features.
             seed: Optionally, you can use this argument to seed the RNG that is used to sample from the space.
         """
-        assert isinstance(node_space, (Box, Discrete)), (
-            f"Values of the node_space should be instances of Box or Discrete, got {type(node_space)}"
-        )
-        if edge_space is not None:
-            assert isinstance(edge_space, (Box, Discrete)), (
-                f"Values of the edge_space should be instances of None Box or Discrete, got {type(edge_space)}"
+        if not isinstance(node_space, (Box, Discrete)):
+            raise TypeError(
+                f"Values of the node_space should be instances of Box or Discrete, got {type(node_space)}"
             )
+
+        if edge_space is not None:
+            if not isinstance(edge_space, (Box, Discrete)):
+                raise TypeError(
+                    f"Values of the edge_space should be instances of None, Box or Discrete, got {type(edge_space)}"
+                )
 
         self.node_space = node_space
         self.edge_space = edge_space

--- a/gymnasium/spaces/multi_binary.py
+++ b/gymnasium/spaces/multi_binary.py
@@ -46,10 +46,12 @@ class MultiBinary(Space[NDArray[np.int8]]):
         if isinstance(n, int):
             self.n = n = int(n)
             input_n = (n,)
-            assert (np.asarray(input_n) > 0).all()  # n (counts) have to be positive
+            if not (np.asarray(input_n) > 0).all():
+                raise ValueError(f"n (counts) have to be positive, got {n}")
         elif isinstance(n, (Sequence, np.ndarray)):
             self.n = input_n = tuple(int(i) for i in n)
-            assert (np.asarray(input_n) > 0).all()  # n (counts) have to be positive
+            if not (np.asarray(input_n) > 0).all():
+                raise ValueError(f"n (counts) have to be positive, got {n}")
         else:
             raise ValueError(
                 f"Expected n to be an int or a sequence of ints, actual type: {type(n)}"

--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -121,10 +121,12 @@ class MultiDiscrete(Space[NDArray[_IntegerT_co]], Generic[_IntegerT_co]):
         else:
             self.start = np.zeros(self.nvec.shape, dtype=dtype)
 
-        assert self.start.shape == self.nvec.shape, (
-            "start and nvec (counts) should have the same shape"
-        )
-        assert (self.nvec > 0).all(), "nvec (counts) have to be positive"
+        if self.start.shape != self.nvec.shape:
+            raise ValueError(
+                f"start and nvec (counts) should have the same shape, got {self.start.shape} and {self.nvec.shape}"
+            )
+        if not (self.nvec > 0).all():
+            raise ValueError("nvec (counts) have to be positive")
 
         super().__init__(self.nvec.shape, self.dtype, seed)
 

--- a/gymnasium/spaces/oneof.py
+++ b/gymnasium/spaces/oneof.py
@@ -47,13 +47,16 @@ class OneOf(Space[tuple[int, _T_co]], Generic[_T_co]):
             spaces (Iterable[Space]): The spaces that are involved in the cartesian product.
             seed: Optionally, you can use this argument to seed the RNGs of the ``spaces`` to ensure reproducible sampling.
         """
-        assert isinstance(spaces, Iterable), f"{spaces} is not an iterable"
+        if not isinstance(spaces, Iterable):
+            raise TypeError(f"{spaces} is not an iterable")
         self.spaces = tuple(spaces)
-        assert len(self.spaces) > 0, "Empty `OneOf` spaces are not supported."
+        if len(self.spaces) == 0:
+            raise ValueError("Empty `OneOf` spaces are not supported.")
         for space in self.spaces:
-            assert isinstance(space, Space), (
-                f"{space} does not inherit from `gymnasium.Space`. Actual Type: {type(space)}"
-            )
+            if not isinstance(space, Space):
+                raise TypeError(
+                    f"{space} does not inherit from `gymnasium.Space`. Actual Type: {type(space)}"
+                )
         super().__init__(None, None, seed)
 
     @property

--- a/gymnasium/spaces/sequence.py
+++ b/gymnasium/spaces/sequence.py
@@ -51,9 +51,10 @@ class Sequence(Space[tuple[Any, ...] | Any]):
             seed: Optionally, you can use this argument to seed the RNG that is used to sample from the space.
             stack: If ``True`` then the resulting samples would be stacked.
         """
-        assert isinstance(space, Space), (
-            f"Expects the feature space to be instance of a gym Space, actual type: {type(space)}"
-        )
+        if not isinstance(space, Space):
+            raise TypeError(
+                f"Expects the feature space to be instance of a gym Space, actual type: {type(space)}"
+            )
         self.feature_space = space
         self.stack = stack
         if self.stack:

--- a/gymnasium/spaces/text.py
+++ b/gymnasium/spaces/text.py
@@ -48,18 +48,22 @@ class Text(Space[str]):
             charset (Union[set], str): Character set, defaults to the lower and upper english alphabet plus latin digits.
             seed: The seed for sampling from the space.
         """
-        assert np.issubdtype(type(min_length), np.integer), (
-            f"Expects the min_length to be an integer, actual type: {type(min_length)}"
-        )
-        assert np.issubdtype(type(max_length), np.integer), (
-            f"Expects the max_length to be an integer, actual type: {type(max_length)}"
-        )
-        assert 0 <= min_length, (
-            f"Minimum text length must be non-negative, actual value: {min_length}"
-        )
-        assert min_length <= max_length, (
-            f"The min_length must be less than or equal to the max_length, min_length: {min_length}, max_length: {max_length}"
-        )
+        if not np.issubdtype(type(min_length), np.integer):
+            raise TypeError(
+                f"Expects the min_length to be an integer, actual type: {type(min_length)}"
+            )
+        if not np.issubdtype(type(max_length), np.integer):
+            raise TypeError(
+                f"Expects the max_length to be an integer, actual type: {type(max_length)}"
+            )
+        if min_length < 0:
+            raise ValueError(
+                f"Minimum text length must be non-negative, actual value: {min_length}"
+            )
+        if min_length > max_length:
+            raise ValueError(
+                f"The min_length must be less than or equal to the max_length, min_length: {min_length}, max_length: {max_length}"
+            )
 
         self.min_length: int = int(min_length)
         self.max_length: int = int(max_length)

--- a/gymnasium/spaces/tuple.py
+++ b/gymnasium/spaces/tuple.py
@@ -42,9 +42,10 @@ class Tuple(Space[tuple[_T_co, ...]], typing.Sequence[_T_co]):
         """
         self.spaces = tuple(spaces)
         for space in self.spaces:
-            assert isinstance(space, Space), (
-                f"{space} does not inherit from `gymnasium.Space`. Actual Type: {type(space)}"
-            )
+            if not isinstance(space, Space):
+                raise TypeError(
+                    f"{space} does not inherit from `gymnasium.Space`. Actual Type: {type(space)}"
+                )
         super().__init__(None, None, seed)
 
     @property

--- a/gymnasium/utils/env_match.py
+++ b/gymnasium/utils/env_match.py
@@ -41,7 +41,7 @@ def check_environments_match(
     skip_render = (
         skip_render
         or env_a.unwrapped.render_mode in [None, "human"]
-        or env_b.unwrapped.render in [None, "human"]
+        or env_b.unwrapped.render_mode in [None, "human"]
     )
 
     assert info_comparison in [
@@ -71,7 +71,7 @@ def check_environments_match(
             assert data_equivalence(info_a[key], info_b[key]), (
                 f"resetting info is not a superset, key {key} present in info_a with value = {info_a[key]}, in info_b with value = {info_b[key]}"
             )
-    elif info_comparison == "keys-equivalance":
+    elif info_comparison == "keys-equivalence":
         assert info_a.keys() == info_b.keys(), (
             f"resetting info keys are not equivalent, info_a's keys are {info_a.keys()}, info_b's keys are {info_b.keys()}"
         )
@@ -110,7 +110,7 @@ def check_environments_match(
                 assert data_equivalence(info_a[key], info_b[key]), (
                     f"stepping info is not a superset in step = {step}, key {key} present in info_a with value = {info_a[key]}, in info_b with value = {info_b[key]}"
                 )
-        elif info_comparison == "keys-equivalance":
+        elif info_comparison == "keys-equivalence":
             assert info_a.keys() == info_b.keys(), (
                 f"stepping info keys are not equivalent in step = {step}, info_a's keys are {info_a.keys()}, info_b's keys are {info_b.keys()}"
             )
@@ -138,7 +138,7 @@ def check_environments_match(
                     assert data_equivalence(info_a[key], info_b[key]), (
                         f"resetting info is not a superset in step = {step}, key {key} present in info_a with value = {info_a[key]}, in info_b with value = {info_b[key]}"
                     )
-            elif info_comparison == "keys-equivalance":
+            elif info_comparison == "keys-equivalence":
                 assert info_a.keys() == info_b.keys(), (
                     f"resetting info keys are not equivalent in step = {step}, info_a's keys are {info_a.keys()}, info_b's keys are {info_b.keys()}"
                 )

--- a/gymnasium/utils/play.py
+++ b/gymnasium/utils/play.py
@@ -98,7 +98,10 @@ class PlayableGame:
                     f"{self.env.spec.id} does not have explicit key to action mapping, "
                     "please specify one manually, `play(env, keys_to_action=...)`"
                 )
-        assert isinstance(keys_to_action, dict)
+        if not isinstance(keys_to_action, dict):
+            raise TypeError(
+                f"keys_to_action must be a dictionary, got {type(keys_to_action)}"
+            )
         relevant_keys = set(sum((list(k) for k in keys_to_action.keys()), []))
         return relevant_keys
 
@@ -269,24 +272,44 @@ def play(
         if env.has_wrapper_attr("get_keys_to_action"):
             keys_to_action = env.get_wrapper_attr("get_keys_to_action")()
         else:
-            assert env.spec is not None
+            if env.spec is None:
+                raise ValueError(
+                    "The environment must have an `env.spec` to auto-detect missing keys to action mappings."
+                )
             raise MissingKeysToAction(
                 f"{env.spec.id} does not have explicit key to action mapping, "
                 "please specify one manually"
             )
 
-    assert keys_to_action is not None
+    if keys_to_action is None:
+        raise ValueError("keys_to_action dictionary cannot be None")
 
     # validate the `keys_to_action` set provided
-    assert isinstance(keys_to_action, dict)
+    if not isinstance(keys_to_action, dict):
+        raise TypeError(
+            f"keys_to_action must be a dictionary, got {type(keys_to_action)}"
+        )
+
     for key, action in keys_to_action.items():
         if isinstance(key, tuple):
-            assert len(key) > 0
-            assert all(isinstance(k, (str, int)) for k in key)
+            if len(key) == 0:
+                raise ValueError(
+                    "Key combinations in keys_to_action tuples cannot be empty"
+                )
+            if not all(isinstance(k, (str, int)) for k in key):
+                raise TypeError(
+                    f"All keys in key combination tuple must be integers or strings, got {key}"
+                )
         else:
-            assert isinstance(key, (str, int))
+            if not isinstance(key, (str, int)):
+                raise TypeError(
+                    f"Keys in keys_to_action must be integers or strings, got {type(key)}"
+                )
 
-        assert action in env.action_space
+        if action not in env.action_space:
+            raise ValueError(
+                f"Action {action} is not a valid action in the environment action space: {env.action_space}"
+            )
 
     key_code_to_action = {}
     for key_combination, action in keys_to_action.items():
@@ -301,7 +324,10 @@ def play(
 
     if fps is None:
         fps = env.metadata.get("render_fps", 30)
-        assert isinstance(fps, int)
+        if not isinstance(fps, int):
+            raise TypeError(
+                f"Expected env.metadata['render_fps'] to be an integer, got {type(fps)}"
+            )
 
     done, obs = True, None
     clock = pygame.time.Clock()

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -200,8 +200,12 @@ class AsyncVectorEnv(VectorEnv):
         self.action_space = batch_space(self.single_action_space, self.num_envs)
 
         if isinstance(observation_mode, tuple) and len(observation_mode) == 2:
-            assert isinstance(observation_mode[0], Space)
-            assert isinstance(observation_mode[1], Space)
+            if not isinstance(observation_mode[0], Space) or not isinstance(
+                observation_mode[1], Space
+            ):
+                raise TypeError(
+                    f"Expected both elements of observation_mode to be Spaces, got {type(observation_mode[0])} and {type(observation_mode[1])}"
+                )
             self.observation_space, self.single_observation_space = observation_mode
         else:
             if observation_mode == "same":
@@ -327,9 +331,10 @@ class AsyncVectorEnv(VectorEnv):
             seed = [None for _ in range(self.num_envs)]
         elif isinstance(seed, int):
             seed = [seed + i for i in range(self.num_envs)]
-        assert len(seed) == self.num_envs, (
-            f"If seeds are passed as a list the length must match num_envs={self.num_envs} but got length={len(seed)}."
-        )
+        if len(seed) != self.num_envs:
+            raise ValueError(
+                f"If seeds are passed as a list the length must match num_envs={self.num_envs} but got length={len(seed)}."
+            )
 
         if self._state != AsyncState.DEFAULT:
             raise AlreadyPendingCallError(
@@ -339,18 +344,22 @@ class AsyncVectorEnv(VectorEnv):
 
         if options is not None and "reset_mask" in options:
             reset_mask = options.pop("reset_mask")
-            assert isinstance(reset_mask, np.ndarray), (
-                f"`options['reset_mask': mask]` must be a numpy array, got {type(reset_mask)}"
-            )
-            assert reset_mask.shape == (self.num_envs,), (
-                f"`options['reset_mask': mask]` must have shape `({self.num_envs},)`, got {reset_mask.shape}"
-            )
-            assert reset_mask.dtype == np.bool_, (
-                f"`options['reset_mask': mask]` must have `dtype=np.bool_`, got {reset_mask.dtype}"
-            )
-            assert np.any(reset_mask), (
-                f"`options['reset_mask': mask]` must contain a boolean array, got reset_mask={reset_mask}"
-            )
+            if not isinstance(reset_mask, np.ndarray):
+                raise TypeError(
+                    f"`options['reset_mask']` must be a numpy array, got {type(reset_mask)}"
+                )
+            if reset_mask.shape != (self.num_envs,):
+                raise ValueError(
+                    f"`options['reset_mask']` must have shape `({self.num_envs},)`, got {reset_mask.shape}"
+                )
+            if reset_mask.dtype != np.bool_:
+                raise TypeError(
+                    f"`options['reset_mask']` must have `dtype=np.bool_`, got {reset_mask.dtype}"
+                )
+            if not np.any(reset_mask):
+                raise ValueError(
+                    f"`options['reset_mask']` must contain a boolean array with at least one True value, got reset_mask={reset_mask}"
+                )
 
             for pipe, env_seed, env_reset in zip(
                 self.parent_pipes, seed, reset_mask, strict=True

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -119,8 +119,12 @@ class SyncVectorEnv(VectorEnv):
         self.action_space = batch_space(self.single_action_space, self.num_envs)
 
         if isinstance(observation_mode, tuple) and len(observation_mode) == 2:
-            assert isinstance(observation_mode[0], Space)
-            assert isinstance(observation_mode[1], Space)
+            if not isinstance(observation_mode[0], Space) or not isinstance(
+                observation_mode[1], Space
+            ):
+                raise TypeError(
+                    f"Expected both elements of observation_mode to be Spaces, got {type(observation_mode[0])} and {type(observation_mode[1])}"
+                )
             self.observation_space, self.single_observation_space = observation_mode
         else:
             if observation_mode == "same":
@@ -141,19 +145,22 @@ class SyncVectorEnv(VectorEnv):
         # check sub-environment obs and action spaces
         for env in self.envs:
             if observation_mode == "same":
-                assert env.observation_space == self.single_observation_space, (
-                    f"SyncVectorEnv(..., observation_mode='same') however the sub-environments observation spaces are not equivalent. single_observation_space={self.single_observation_space}, sub-environment observation_space={env.observation_space}. If this is intentional, use `observation_mode='different'` instead."
-                )
+                if env.observation_space != self.single_observation_space:
+                    raise RuntimeError(
+                        f"SyncVectorEnv(..., observation_mode='same') however the sub-environments observation spaces are not equivalent. single_observation_space={self.single_observation_space}, sub-environment observation_space={env.observation_space}. If this is intentional, use `observation_mode='different'` instead."
+                    )
             else:
-                assert is_space_dtype_shape_equiv(
+                if not is_space_dtype_shape_equiv(
                     env.observation_space, self.single_observation_space
-                ), (
-                    f"SyncVectorEnv(..., observation_mode='different' or custom space) however the sub-environments observation spaces do not share a common shape and dtype, single_observation_space={self.single_observation_space}, sub-environment observation space={env.observation_space}"
-                )
+                ):
+                    raise RuntimeError(
+                        f"SyncVectorEnv(..., observation_mode='different' or custom space) however the sub-environments observation spaces do not share a common shape and dtype, single_observation_space={self.single_observation_space}, sub-environment observation space={env.observation_space}"
+                    )
 
-            assert env.action_space == self.single_action_space, (
-                f"Sub-environment action space doesn't make the `single_action_space`, action_space={env.action_space}, single_action_space={self.single_action_space}"
-            )
+            if env.action_space != self.single_action_space:
+                raise RuntimeError(
+                    f"Sub-environment action space doesn't make the `single_action_space`, action_space={env.action_space}, single_action_space={self.single_action_space}"
+                )
 
         # Initialise attributes used in `step` and `reset`
         self._env_obs = [None for _ in range(self.num_envs)]
@@ -198,24 +205,29 @@ class SyncVectorEnv(VectorEnv):
             seed = [None for _ in range(self.num_envs)]
         elif isinstance(seed, int):
             seed = [seed + i for i in range(self.num_envs)]
-        assert len(seed) == self.num_envs, (
-            f"If seeds are passed as a list the length must match num_envs={self.num_envs} but got length={len(seed)}."
-        )
+        if len(seed) != self.num_envs:
+            raise ValueError(
+                f"If seeds are passed as a list the length must match num_envs={self.num_envs} but got length={len(seed)}."
+            )
 
         if options is not None and "reset_mask" in options:
             reset_mask = options.pop("reset_mask")
-            assert isinstance(reset_mask, np.ndarray), (
-                f"`options['reset_mask': mask]` must be a numpy array, got {type(reset_mask)}"
-            )
-            assert reset_mask.shape == (self.num_envs,), (
-                f"`options['reset_mask': mask]` must have shape `({self.num_envs},)`, got {reset_mask.shape}"
-            )
-            assert reset_mask.dtype == np.bool_, (
-                f"`options['reset_mask': mask]` must have `dtype=np.bool_`, got {reset_mask.dtype}"
-            )
-            assert np.any(reset_mask), (
-                f"`options['reset_mask': mask]` must contain a boolean array, got reset_mask={reset_mask}"
-            )
+            if not isinstance(reset_mask, np.ndarray):
+                raise TypeError(
+                    f"`options['reset_mask']` must be a numpy array, got {type(reset_mask)}"
+                )
+            if reset_mask.shape != (self.num_envs,):
+                raise ValueError(
+                    f"`options['reset_mask']` must have shape `({self.num_envs},)`, got {reset_mask.shape}"
+                )
+            if reset_mask.dtype != np.bool_:
+                raise TypeError(
+                    f"`options['reset_mask']` must have `dtype=np.bool_`, got {reset_mask.dtype}"
+                )
+            if not np.any(reset_mask):
+                raise ValueError(
+                    f"`options['reset_mask']` must contain a boolean array with at least one True value, got reset_mask={reset_mask}"
+                )
 
             self._terminations[reset_mask] = False
             self._truncations[reset_mask] = False

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -166,28 +166,34 @@ def batch_differing_spaces(spaces: _PySequence[Space]) -> Space:
         >>> batch_differing_spaces(spaces)
         MultiDiscrete([3 5 4 8])
     """
-    assert len(spaces) > 0, "Expects a non-empty list of spaces"
-    assert all(isinstance(space, type(spaces[0])) for space in spaces), (
-        f"Expects all spaces to be the same shape, actual types: {[type(space) for space in spaces]}"
-    )
-    assert type(spaces[0]) in batch_differing_spaces.registry, (
-        f"Requires the Space type to have a registered `batch_differing_space`, current list: {batch_differing_spaces.registry}"
-    )
+    if len(spaces) == 0:
+        raise ValueError("Expects a non-empty list of spaces")
+    if not all(isinstance(space, type(spaces[0])) for space in spaces):
+        raise TypeError(
+            f"Expects all spaces to be of the same type, actual types: {[type(space) for space in spaces]}"
+        )
+    if type(spaces[0]) not in batch_differing_spaces.registry:
+        raise TypeError(
+            f"Requires the Space type to have a registered `batch_differing_space`, current list: {batch_differing_spaces.registry}"
+        )
 
     return batch_differing_spaces.dispatch(type(spaces[0]))(spaces)
 
 
 @batch_differing_spaces.register(Box)
 def _batch_differing_spaces_box(spaces: _PySequence[Box]) -> Box:
-    assert all(spaces[0].dtype == space.dtype for space in spaces), (
-        f"Expected all dtypes to be equal, actually {[space.dtype for space in spaces]}"
-    )
-    assert all(spaces[0].low.shape == space.low.shape for space in spaces), (
-        f"Expected all Box.low shape to be equal, actually {[space.low.shape for space in spaces]}"
-    )
-    assert all(spaces[0].high.shape == space.high.shape for space in spaces), (
-        f"Expected all Box.high shape to be equal, actually {[space.high.shape for space in spaces]}"
-    )
+    if not all(spaces[0].dtype == space.dtype for space in spaces):
+        raise ValueError(
+            f"Expected all dtypes to be equal, actually {[space.dtype for space in spaces]}"
+        )
+    if not all(spaces[0].low.shape == space.low.shape for space in spaces):
+        raise ValueError(
+            f"Expected all Box.low shape to be equal, actually {[space.low.shape for space in spaces]}"
+        )
+    if not all(spaces[0].high.shape == space.high.shape for space in spaces):
+        raise ValueError(
+            f"Expected all Box.high shape to be equal, actually {[space.high.shape for space in spaces]}"
+        )
 
     return Box(
         low=np.array([space.low for space in spaces]),
@@ -213,15 +219,18 @@ def _batch_differing_spaces_discrete(spaces: _PySequence[Discrete]) -> MultiDisc
 
 @batch_differing_spaces.register(MultiDiscrete)
 def _batch_differing_spaces_multi_discrete(spaces: _PySequence[MultiDiscrete]) -> Box:
-    assert all(spaces[0].dtype == space.dtype for space in spaces), (
-        f"Expected all dtypes to be equal, actually {[space.dtype for space in spaces]}"
-    )
-    assert all(spaces[0].nvec.shape == space.nvec.shape for space in spaces), (
-        f"Expects all MultiDiscrete.nvec shape, actually {[space.nvec.shape for space in spaces]}"
-    )
-    assert all(spaces[0].start.shape == space.start.shape for space in spaces), (
-        f"Expects all MultiDiscrete.start shape, actually {[space.start.shape for space in spaces]}"
-    )
+    if not all(spaces[0].dtype == space.dtype for space in spaces):
+        raise ValueError(
+            f"Expected all dtypes to be equal, actually {[space.dtype for space in spaces]}"
+        )
+    if not all(spaces[0].nvec.shape == space.nvec.shape for space in spaces):
+        raise ValueError(
+            f"Expects all MultiDiscrete.nvec shape, actually {[space.nvec.shape for space in spaces]}"
+        )
+    if not all(spaces[0].start.shape == space.start.shape for space in spaces):
+        raise ValueError(
+            f"Expects all MultiDiscrete.start shape, actually {[space.start.shape for space in spaces]}"
+        )
 
     return Box(
         low=np.array([space.start for space in spaces]),
@@ -233,7 +242,10 @@ def _batch_differing_spaces_multi_discrete(spaces: _PySequence[MultiDiscrete]) -
 
 @batch_differing_spaces.register(MultiBinary)
 def _batch_differing_spaces_multi_binary(spaces: _PySequence[MultiBinary]) -> Box:
-    assert all(spaces[0].shape == space.shape for space in spaces)
+    if not all(spaces[0].shape == space.shape for space in spaces):
+        raise ValueError(
+            f"Expected all MultiBinary shapes to be equal, actually {[space.shape for space in spaces]}"
+        )
 
     return Box(
         low=0,
@@ -257,7 +269,10 @@ def _batch_differing_spaces_tuple(spaces: _PySequence[Tuple]) -> Tuple:
 
 @batch_differing_spaces.register(Dict)
 def _batch_differing_spaces_dict(spaces: _PySequence[Dict]) -> Dict:
-    assert all(spaces[0].keys() == space.keys() for space in spaces)
+    if not all(spaces[0].keys() == space.keys() for space in spaces):
+        raise ValueError(
+            f"Expected all Dict spaces to have the same keys, actually {[list(space.keys()) for space in spaces]}"
+        )
 
     return Dict(
         {

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -371,9 +371,10 @@ class VectorWrapper(VectorEnv):
             env: The environment to wrap
         """
         self.env = env
-        assert isinstance(env, VectorEnv), (
-            f"Expected env to be a `gymnasium.vector.VectorEnv` but got {type(env)}"
-        )
+        if not isinstance(env, VectorEnv):
+            raise TypeError(
+                f"Expected env to be a `gymnasium.vector.VectorEnv` but got {type(env)}"
+            )
 
         self._observation_space: gym.Space | None = None
         self._action_space: gym.Space | None = None
@@ -534,10 +535,13 @@ class VectorObservationWrapper(VectorWrapper):
                 f"Vector environment ({env}) is missing `autoreset_mode` metadata key."
             )
         else:
-            assert (
-                env.metadata["autoreset_mode"] == AutoresetMode.NEXT_STEP
-                or env.metadata["autoreset_mode"] == AutoresetMode.DISABLED
-            )
+            if env.metadata["autoreset_mode"] not in (
+                AutoresetMode.NEXT_STEP,
+                AutoresetMode.DISABLED,
+            ):
+                raise ValueError(
+                    f"Expected autoreset_mode to be NEXT_STEP or DISABLED, got {env.metadata['autoreset_mode']}"
+                )
 
     def reset(
         self, *, seed: int | None = None, options: dict[str, Any] | None = None

--- a/gymnasium/wrappers/atari_preprocessing.py
+++ b/gymnasium/wrappers/atari_preprocessing.py
@@ -99,20 +99,39 @@ class AtariPreprocessing(gym.Wrapper, gym.utils.RecordConstructorArgs):
                 'opencv-python package not installed, run `pip install "gymnasium[other]"` to get dependencies for atari'
             ) from e
 
-        assert frame_skip > 0
-        assert (isinstance(screen_size, int) and screen_size > 0) or (
-            isinstance(screen_size, tuple)
-            and len(screen_size) == 2
-            and all(isinstance(size, int) and size > 0 for size in screen_size)
-        ), f"Expect the `screen_size` to be positive, actually: {screen_size}"
+        if frame_skip <= 0:
+            raise ValueError(
+                f"Expect the `frame_skip` to be positive, actually: {frame_skip}"
+            )
+
+        if not (
+            (isinstance(screen_size, int) and screen_size > 0)
+            or (
+                isinstance(screen_size, tuple)
+                and len(screen_size) == 2
+                and all(isinstance(size, int) and size > 0 for size in screen_size)
+            )
+        ):
+            raise ValueError(
+                f"Expect the `screen_size` to be positive, actually: {screen_size}"
+            )
+
         if frame_skip > 1 and getattr(env.unwrapped, "_frameskip", None) != 1:
             raise ValueError(
                 "Disable frame-skipping in the original env. Otherwise, more than one frame-skip will happen as through this wrapper"
             )
-        assert noop_max >= 0
+
+        if noop_max < 0:
+            raise ValueError(
+                f"Expect the `noop_max` to be non-negative, actually: {noop_max}"
+            )
+
         self.noop_max = noop_max
         if noop_max > 0:
-            assert env.unwrapped.get_action_meanings()[0] == "NOOP"
+            if env.unwrapped.get_action_meanings()[0] != "NOOP":
+                raise ValueError(
+                    "When noop_max > 0, the first action meaning must be 'NOOP'"
+                )
 
         self.frame_skip = frame_skip
         self.screen_size: tuple[int, int] = (
@@ -126,7 +145,10 @@ class AtariPreprocessing(gym.Wrapper, gym.utils.RecordConstructorArgs):
         self.scale_obs = scale_obs
 
         # buffer of most recent two observations for max pooling
-        assert isinstance(env.observation_space, Box)
+        if not isinstance(env.observation_space, Box):
+            raise TypeError(
+                f"AtariPreprocessing wrapper requires a Box observation space, got {type(env.observation_space)}"
+            )
         if grayscale_obs:
             self.obs_buffer = [
                 np.empty(env.observation_space.shape[:2], dtype=np.uint8),

--- a/gymnasium/wrappers/common.py
+++ b/gymnasium/wrappers/common.py
@@ -97,9 +97,14 @@ class TimeLimit(
             env: The environment to apply the wrapper
             max_episode_steps: the environment step after which the episode is truncated (``elapsed >= max_episode_steps``)
         """
-        assert isinstance(max_episode_steps, int) and max_episode_steps > 0, (
-            f"Expect the `max_episode_steps` to be positive, actually: {max_episode_steps}"
-        )
+        if not isinstance(max_episode_steps, int):
+            raise TypeError(
+                f"Expect the `max_episode_steps` to be an integer, actually: {type(max_episode_steps)}"
+            )
+        if max_episode_steps <= 0:
+            raise ValueError(
+                f"Expect the `max_episode_steps` to be positive, actually: {max_episode_steps}"
+            )
         gym.utils.RecordConstructorArgs.__init__(
             self, max_episode_steps=max_episode_steps
         )

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -114,8 +114,12 @@ class RenderCollection(
         )
         gym.Wrapper.__init__(self, env)
 
-        assert env.render_mode is not None
-        assert not env.render_mode.endswith("_list")
+        if env.render_mode is None:
+            raise ValueError("Expected env.render_mode to be not None")
+        if env.render_mode.endswith("_list"):
+            raise ValueError(
+                f"Expected env.render_mode to not end with '_list', got '{env.render_mode}'"
+            )
 
         self.frame_list: list[RenderFrame] = []
         self.pop_frames = pop_frames
@@ -494,12 +498,14 @@ class HumanRendering(
         self.window = None  # Has to be initialized before asserts, as self.window is used in auto close
         self.clock = None
 
-        assert self.env.render_mode in self.ACCEPTED_RENDER_MODES, (
-            f"Expected env.render_mode to be one of {self.ACCEPTED_RENDER_MODES} but got '{env.render_mode}'"
-        )
-        assert "render_fps" in self.env.metadata, (
-            "The base environment must specify 'render_fps' to be used with the HumanRendering wrapper"
-        )
+        if self.env.render_mode not in self.ACCEPTED_RENDER_MODES:
+            raise ValueError(
+                f"Expected env.render_mode to be one of {self.ACCEPTED_RENDER_MODES} but got '{self.env.render_mode}'"
+            )
+        if "render_fps" not in self.env.metadata:
+            raise ValueError(
+                "The base environment must specify 'render_fps' to be used with the HumanRendering wrapper"
+            )
 
         if "human" not in self.metadata["render_modes"]:
             self.metadata = deepcopy(self.env.metadata)

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -226,7 +226,10 @@ class TimeAwareObservation(
 
         # Find the observation space
         if isinstance(env.observation_space, Dict):
-            assert dict_time_key not in env.observation_space.keys()
+            if dict_time_key in env.observation_space.keys():
+                raise ValueError(
+                    f"The `dict_time_key` ({dict_time_key!r}) already exists in the observation space."
+                )
             observation_space = Dict(
                 {dict_time_key: time_space, **env.observation_space.spaces}
             )
@@ -509,7 +512,11 @@ class NormalizeObservation(
         gym.utils.RecordConstructorArgs.__init__(self, epsilon=epsilon)
         gym.ObservationWrapper.__init__(self, env)
 
-        assert env.observation_space.shape is not None
+        if env.observation_space.shape is None:
+            raise ValueError(
+                "NormalizeObservation wrapper requires the observation space to have a shape."
+            )
+
         self.observation_space = gym.spaces.Box(
             low=-np.inf,
             high=np.inf,

--- a/gymnasium/wrappers/transform_action.py
+++ b/gymnasium/wrappers/transform_action.py
@@ -105,7 +105,10 @@ class ClipAction(
         Args:
             env: The environment to wrap
         """
-        assert isinstance(env.action_space, Box)
+        if not isinstance(env.action_space, Box):
+            raise TypeError(
+                f"ClipAction requires a Box action space, got {type(env.action_space)}"
+            )
 
         gym.utils.RecordConstructorArgs.__init__(self)
         TransformAction.__init__(
@@ -165,7 +168,10 @@ class RescaleAction(
             min_action (float, int or np.ndarray): The min values for each action. This may be a numpy array or a scalar.
             max_action (float, int or np.ndarray): The max values for each action. This may be a numpy array or a scalar.
         """
-        assert isinstance(env.action_space, Box)
+        if not isinstance(env.action_space, Box):
+            raise TypeError(
+                f"RescaleAction requires a Box action space, got {type(env.action_space)}"
+            )
 
         gym.utils.RecordConstructorArgs.__init__(
             self, min_action=min_action, max_action=max_action
@@ -274,9 +280,10 @@ class DiscretizeAction(
         if isinstance(bins, int):
             self.bins = np.array([bins] * self.n_dims)
         else:
-            assert len(bins) == self.n_dims, (
-                f"bins must match action dimensions: expected {self.n_dims}, got {len(bins)}"
-            )
+            if len(bins) != self.n_dims:
+                raise ValueError(
+                    f"bins must match action dimensions: expected {self.n_dims}, got {len(bins)}"
+                )
             self.bins = np.array(bins)
 
         self.bin_centers = [

--- a/gymnasium/wrappers/transform_observation.py
+++ b/gymnasium/wrappers/transform_observation.py
@@ -142,7 +142,10 @@ class FilterObservation(
 
         # Filters for dictionary space
         if isinstance(env.observation_space, spaces.Dict):
-            assert all(isinstance(key, str) for key in filter_keys)
+            if not all(isinstance(key, str) for key in filter_keys):
+                raise TypeError(
+                    f"All filter keys must be strings for a Dict space, got {filter_keys}"
+                )
 
             if any(
                 key not in env.observation_space.spaces.keys() for key in filter_keys
@@ -175,10 +178,12 @@ class FilterObservation(
             )
             # Filter for tuple observation
         elif isinstance(env.observation_space, spaces.Tuple):
-            assert all(isinstance(key, int) for key in filter_keys)
-            assert len(set(filter_keys)) == len(filter_keys), (
-                f"Duplicate keys exist, filter_keys: {filter_keys}"
-            )
+            if not all(isinstance(key, int) for key in filter_keys):
+                raise TypeError(
+                    f"All filter keys must be integers for a Tuple space, got {filter_keys}"
+                )
+            if len(set(filter_keys)) != len(filter_keys):
+                raise ValueError(f"Duplicate keys exist, filter_keys: {filter_keys}")
 
             if any(
                 0 < key and key >= len(env.observation_space) for key in filter_keys
@@ -291,16 +296,25 @@ class GrayscaleObservation(
             env: The environment to wrap
             keep_dim: If to keep the channel in the observation, if ``True``, ``obs.shape == 3`` else ``obs.shape == 2``
         """
-        assert isinstance(env.observation_space, spaces.Box)
-        assert (
-            len(env.observation_space.shape) == 3
-            and env.observation_space.shape[-1] == 3
-        )
-        assert (
+        if not isinstance(env.observation_space, spaces.Box):
+            raise TypeError(
+                f"GrayscaleObservation requires a Box observation space, got {type(env.observation_space)}"
+            )
+        if (
+            len(env.observation_space.shape) != 3
+            or env.observation_space.shape[-1] != 3
+        ):
+            raise ValueError(
+                f"GrayscaleObservation requires an image with 3 channels, got shape {env.observation_space.shape}"
+            )
+        if not (
             np.all(env.observation_space.low == 0)
             and np.all(env.observation_space.high == 255)
             and env.observation_space.dtype == np.uint8
-        )
+        ):
+            raise ValueError(
+                "GrayscaleObservation requires observation bounds 0 to 255 and dtype uint8"
+            )
         gym.utils.RecordConstructorArgs.__init__(self, keep_dim=keep_dim)
 
         self.keep_dim: Final[bool] = keep_dim
@@ -366,17 +380,40 @@ class ResizeObservation(
             env: The environment to wrap
             shape: The resized observation shape
         """
-        assert isinstance(env.observation_space, spaces.Box)
-        assert len(env.observation_space.shape) in {2, 3}
-        assert np.all(env.observation_space.low == 0) and np.all(
-            env.observation_space.high == 255
-        )
-        assert env.observation_space.dtype == np.uint8
+        if not isinstance(env.observation_space, spaces.Box):
+            raise TypeError(
+                f"ResizeObservation requires a Box observation space, got {type(env.observation_space)}"
+            )
+        if len(env.observation_space.shape) not in {2, 3}:
+            raise ValueError(
+                f"ResizeObservation requires a 2D or 3D image, got shape {env.observation_space.shape}"
+            )
+        if not (
+            np.all(env.observation_space.low == 0)
+            and np.all(env.observation_space.high == 255)
+        ):
+            raise ValueError("ResizeObservation requires observation bounds 0 to 255")
+        if env.observation_space.dtype != np.uint8:
+            raise ValueError(
+                f"ResizeObservation requires observation dtype uint8, got {env.observation_space.dtype}"
+            )
 
-        assert isinstance(shape, tuple)
-        assert len(shape) == 2
-        assert all(np.issubdtype(type(elem), np.integer) for elem in shape)
-        assert all(x > 0 for x in shape)
+        if not isinstance(shape, tuple):
+            raise TypeError(
+                f"ResizeObservation requires shape to be a tuple, got {type(shape)}"
+            )
+        if len(shape) != 2:
+            raise ValueError(
+                f"ResizeObservation requires shape tuple of length 2, got {shape}"
+            )
+        if not all(np.issubdtype(type(elem), np.integer) for elem in shape):
+            raise TypeError(
+                f"ResizeObservation requires shape elements to be integers, got {shape}"
+            )
+        if not all(x > 0 for x in shape):
+            raise ValueError(
+                f"ResizeObservation requires shape elements to be greater than 0, got {shape}"
+            )
 
         try:
             import cv2
@@ -436,12 +473,27 @@ class ReshapeObservation(
             env: The environment to wrap
             shape: The reshaped observation space
         """
-        assert isinstance(env.observation_space, spaces.Box)
-        assert np.prod(shape) == np.prod(env.observation_space.shape)
+        if not isinstance(env.observation_space, spaces.Box):
+            raise TypeError(
+                f"ReshapeObservation requires a Box observation space, got {type(env.observation_space)}"
+            )
+        if np.prod(shape) != np.prod(env.observation_space.shape):
+            raise ValueError(
+                "ReshapeObservation requires the product of the new shape to match the original shape"
+            )
 
-        assert isinstance(shape, tuple)
-        assert all(np.issubdtype(type(elem), np.integer) for elem in shape)
-        assert all(x > 0 or x == -1 for x in shape)
+        if not isinstance(shape, tuple):
+            raise TypeError(
+                f"ReshapeObservation requires shape to be a tuple, got {type(shape)}"
+            )
+        if not all(np.issubdtype(type(elem), np.integer) for elem in shape):
+            raise TypeError(
+                f"ReshapeObservation requires shape elements to be integers, got {shape}"
+            )
+        if not all(x > 0 or x == -1 for x in shape):
+            raise ValueError(
+                f"ReshapeObservation requires shape elements to be greater than 0 or -1, got {shape}"
+            )
 
         new_observation_space = spaces.Box(
             low=np.reshape(np.ravel(env.observation_space.low), shape),
@@ -497,7 +549,10 @@ class RescaleObservation(
             min_obs: The new minimum observation bound
             max_obs: The new maximum observation bound
         """
-        assert isinstance(env.observation_space, spaces.Box)
+        if not isinstance(env.observation_space, spaces.Box):
+            raise TypeError(
+                f"RescaleObservation requires a Box observation space, got {type(env.observation_space)}"
+            )
 
         gym.utils.RecordConstructorArgs.__init__(self, min_obs=min_obs, max_obs=max_obs)
 
@@ -532,10 +587,13 @@ class DtypeObservation(
             env: The environment to wrap
             dtype: The new dtype of the observation
         """
-        assert isinstance(
+        if not isinstance(
             env.observation_space,
             (spaces.Box, spaces.Discrete, spaces.MultiDiscrete, spaces.MultiBinary),
-        )
+        ):
+            raise TypeError(
+                f"DtypeObservation requires a Box, Discrete, MultiDiscrete, or MultiBinary space, got {type(env.observation_space)}"
+            )
 
         self.dtype = dtype
         if isinstance(env.observation_space, spaces.Box):
@@ -650,10 +708,16 @@ class AddRenderObservation(
             obs_key=obs_key,
         )
 
-        assert env.render_mode is not None and env.render_mode != "human"
+        if env.render_mode is None or env.render_mode == "human":
+            raise ValueError(
+                f"AddRenderObservation requires render_mode to be not None and not 'human', got {env.render_mode}"
+            )
         env.reset()
         pixels = env.render()
-        assert pixels is not None and isinstance(pixels, np.ndarray)
+        if pixels is None or not isinstance(pixels, np.ndarray):
+            raise TypeError(
+                f"AddRenderObservation expects env.render() to return a numpy array, got {type(pixels)}"
+            )
         pixel_space = spaces.Box(low=0, high=255, shape=pixels.shape, dtype=np.uint8)
 
         if render_only:
@@ -662,7 +726,10 @@ class AddRenderObservation(
                 self, env=env, func=lambda _: self.render(), observation_space=obs_space
             )
         elif isinstance(env.observation_space, spaces.Dict):
-            assert render_key not in env.observation_space.spaces.keys()
+            if render_key in env.observation_space.spaces.keys():
+                raise ValueError(
+                    f"AddRenderObservation render_key '{render_key}' already exists in the observation space"
+                )
 
             obs_space = spaces.Dict(
                 {render_key: pixel_space, **env.observation_space.spaces}
@@ -775,9 +842,10 @@ class DiscretizeObservation(
         if isinstance(bins, int):
             self.bins = np.array([bins] * self.n_dims)
         else:
-            assert len(bins) == self.n_dims, (
-                f"bins must match action dimensions: expected {self.n_dims}, got {len(bins)}"
-            )
+            if len(bins) != self.n_dims:
+                raise ValueError(
+                    f"bins must match action dimensions: expected {self.n_dims}, got {len(bins)}"
+                )
             self.bins = np.array(bins)
 
         self.bin_edges = [

--- a/gymnasium/wrappers/utils.py
+++ b/gymnasium/wrappers/utils.py
@@ -173,27 +173,53 @@ def rescale_box(
         A tuple containing the rescaled box space, the forward transformation function (original -> rescaled) and the
         backward transformation function (rescaled -> original).
     """
-    assert isinstance(box, Box)
+    if not isinstance(box, Box):
+        raise TypeError(f"Expected box to be a Box space, got {type(box)}")
 
     if not isinstance(new_min, np.ndarray):
-        assert np.issubdtype(type(new_min), np.integer) or np.issubdtype(
-            type(new_min), np.floating
-        )
+        if not (
+            np.issubdtype(type(new_min), np.integer)
+            or np.issubdtype(type(new_min), np.floating)
+        ):
+            raise TypeError(
+                f"Expected new_min to be an integer, float, or numpy array, got {type(new_min)}"
+            )
         new_min = np.full(box.shape, new_min)
-    assert new_min.shape == box.shape, (
-        f"{new_min.shape}, {box.shape}, {new_min}, {box.low}"
-    )
+    if new_min.shape != box.shape:
+        raise ValueError(
+            f"Expected new_min.shape to be {box.shape}, got {new_min.shape}"
+        )
 
     if not isinstance(new_max, np.ndarray):
-        assert np.issubdtype(type(new_max), np.integer) or np.issubdtype(
-            type(new_max), np.floating
-        )
+        if not (
+            np.issubdtype(type(new_max), np.integer)
+            or np.issubdtype(type(new_max), np.floating)
+        ):
+            raise TypeError(
+                f"Expected new_max to be an integer, float, or numpy array, got {type(new_max)}"
+            )
         new_max = np.full(box.shape, new_max)
-    assert new_max.shape == box.shape
-    assert np.all((new_min == box.low)[np.isinf(new_min) | np.isinf(box.low)])
-    assert np.all((new_max == box.high)[np.isinf(new_max) | np.isinf(box.high)])
-    assert np.all(new_min <= new_max)
-    assert np.all(box.low <= box.high)
+    if new_max.shape != box.shape:
+        raise ValueError(
+            f"Expected new_max.shape to be {box.shape}, got {new_max.shape}"
+        )
+
+    if not np.all((new_min == box.low)[np.isinf(new_min) | np.isinf(box.low)]):
+        raise ValueError(
+            "For unbounded components, the target bounds must match the original infinity bounds."
+        )
+    if not np.all((new_max == box.high)[np.isinf(new_max) | np.isinf(box.high)]):
+        raise ValueError(
+            "For unbounded components, the target bounds must match the original infinity bounds."
+        )
+    if not np.all(new_min <= new_max):
+        raise ValueError(
+            f"Expected new_min to be less than or equal to new_max, got {new_min} and {new_max}"
+        )
+    if not np.all(box.low <= box.high):
+        raise ValueError(
+            f"Expected box.low to be less than or equal to box.high, got {box.low} and {box.high}"
+        )
 
     # Imagine the x-axis between the old Box and the y-axis being the new Box
     # float128 is not available everywhere

--- a/gymnasium/wrappers/vector/common.py
+++ b/gymnasium/wrappers/vector/common.py
@@ -97,7 +97,10 @@ class RecordEpisodeStatistics(VectorWrapper):
             )
             self._autoreset_mode = AutoresetMode.NEXT_STEP
         else:
-            assert isinstance(self.env.metadata["autoreset_mode"], AutoresetMode)
+            if not isinstance(self.env.metadata["autoreset_mode"], AutoresetMode):
+                raise TypeError(
+                    f"Expected env.metadata['autoreset_mode'] to be an AutoresetMode, got {type(self.env.metadata['autoreset_mode'])}"
+                )
             self._autoreset_mode = self.env.metadata["autoreset_mode"]
 
         self.episode_count = 0
@@ -121,18 +124,22 @@ class RecordEpisodeStatistics(VectorWrapper):
 
         if options is not None and "reset_mask" in options:
             reset_mask = options.pop("reset_mask")
-            assert isinstance(reset_mask, np.ndarray), (
-                f"`options['reset_mask': mask]` must be a numpy array, got {type(reset_mask)}"
-            )
-            assert reset_mask.shape == (self.num_envs,), (
-                f"`options['reset_mask': mask]` must have shape `({self.num_envs},)`, got {reset_mask.shape}"
-            )
-            assert reset_mask.dtype == np.bool_, (
-                f"`options['reset_mask': mask]` must have `dtype=np.bool_`, got {reset_mask.dtype}"
-            )
-            assert np.any(reset_mask), (
-                f"`options['reset_mask': mask]` must contain a boolean array, got reset_mask={reset_mask}"
-            )
+            if not isinstance(reset_mask, np.ndarray):
+                raise TypeError(
+                    f"`options['reset_mask']` must be a numpy array, got {type(reset_mask)}"
+                )
+            if reset_mask.shape != (self.num_envs,):
+                raise ValueError(
+                    f"`options['reset_mask']` must have shape `({self.num_envs},)`, got {reset_mask.shape}"
+                )
+            if reset_mask.dtype != np.bool_:
+                raise TypeError(
+                    f"`options['reset_mask']` must have `dtype=np.bool_`, got {reset_mask.dtype}"
+                )
+            if not np.any(reset_mask):
+                raise ValueError(
+                    f"`options['reset_mask']` must contain a boolean array with at least one True value, got reset_mask={reset_mask}"
+                )
 
             self.episode_start_times[reset_mask] = time.perf_counter()
             self.episode_returns[reset_mask] = 0

--- a/gymnasium/wrappers/vector/rendering.py
+++ b/gymnasium/wrappers/vector/rendering.py
@@ -55,12 +55,14 @@ class HumanRendering(VectorWrapper, gym.utils.RecordConstructorArgs):
         self.window = None  # Has to be initialized before asserts, as self.window is used in auto close
         self.clock = None
 
-        assert self.env.render_mode in self.ACCEPTED_RENDER_MODES, (
-            f"Expected env.render_mode to be one of {self.ACCEPTED_RENDER_MODES} but got '{env.render_mode}'"
-        )
-        assert "render_fps" in self.env.metadata, (
-            "The base environment must specify 'render_fps' to be used with the HumanRendering wrapper"
-        )
+        if self.env.render_mode not in self.ACCEPTED_RENDER_MODES:
+            raise ValueError(
+                f"Expected env.render_mode to be one of {self.ACCEPTED_RENDER_MODES} but got '{self.env.render_mode}'"
+            )
+        if "render_fps" not in self.env.metadata:
+            raise ValueError(
+                "The base environment must specify 'render_fps' to be used with the HumanRendering wrapper"
+            )
 
         if "human" not in self.metadata["render_modes"]:
             self.metadata = deepcopy(self.env.metadata)

--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -83,7 +83,10 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
                 f"{self} is missing `autoreset_mode` data. Assuming that the vector environment it follows the `NextStep` autoreset api or autoreset is disabled. Read https://farama.org/Vector-Autoreset-Mode for more details."
             )
         else:
-            assert self.env.metadata["autoreset_mode"] in {AutoresetMode.NEXT_STEP}
+            if self.env.metadata["autoreset_mode"] not in {AutoresetMode.NEXT_STEP}:
+                raise ValueError(
+                    f"Expected env.metadata['autoreset_mode'] to be AutoresetMode.NEXT_STEP, got {self.env.metadata['autoreset_mode']}"
+                )
 
         new_single_space = Box(
             low=-np.inf,
@@ -119,11 +122,11 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         options: dict[str, Any] | None = None,
     ) -> tuple[np.ndarray, dict[str, Any]]:
         """Reset function for `NormalizeObservationWrapper` which is disabled for partial resets."""
-        assert (
-            options is None
-            or "reset_mask" not in options
-            or np.all(options["reset_mask"])
-        )
+        if options is not None and "reset_mask" in options:
+            if not np.all(options["reset_mask"]):
+                raise ValueError(
+                    "NormalizeObservation does not support partial resets. The 'reset_mask' must contain all True values."
+                )
         return super().reset(seed=seed, options=options)
 
     def observations(

--- a/gymnasium/wrappers/vector/vectorize_observation.py
+++ b/gymnasium/wrappers/vector/vectorize_observation.py
@@ -189,7 +189,10 @@ class VectorizeTransformObservation(VectorObservationWrapper):
             )
             self.autoreset_mode = AutoresetMode.NEXT_STEP
         else:
-            assert isinstance(env.metadata["autoreset_mode"], AutoresetMode)
+            if not isinstance(env.metadata["autoreset_mode"], AutoresetMode):
+                raise TypeError(
+                    f"Expected env.metadata['autoreset_mode'] to be an AutoresetMode, got {type(env.metadata['autoreset_mode'])}"
+                )
             self.autoreset_mode = env.metadata["autoreset_mode"]
 
         self.wrapper = wrapper(

--- a/tests/spaces/test_dict.py
+++ b/tests/spaces/test_dict.py
@@ -23,7 +23,7 @@ def test_dict_init():
         Dict({"a": Discrete(3)}, a=Box(0, 1))
 
     with pytest.raises(
-        AssertionError,
+        TypeError,
         match="Dict space element is not an instance of Space: key='b', space=Box",
     ):
         Dict(a=Discrete(2), b="Box")
@@ -145,7 +145,7 @@ def test_mapping():
     assert DICT_SPACE["a"] == b
 
     with pytest.raises(
-        AssertionError,
+        TypeError,
         match="Trying to set a to Dict space with value that is not a gymnasium space, actual type: <class 'int'>",
     ):
         DICT_SPACE["a"] = 5

--- a/tests/spaces/test_oneof.py
+++ b/tests/spaces/test_oneof.py
@@ -43,7 +43,7 @@ def test_oneof_seeds(spaces, seed):
     ],
 )
 def test_bad_oneof_calls(spaces_fn):
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         spaces_fn()
 
 

--- a/tests/spaces/test_tuple.py
+++ b/tests/spaces/test_tuple.py
@@ -82,7 +82,7 @@ def test_seeds(space, seed):
     ],
 )
 def test_bad_space_calls(space_fn):
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         space_fn()
 
 

--- a/tests/vector/test_observation_mode.py
+++ b/tests/vector/test_observation_mode.py
@@ -83,7 +83,7 @@ class TestVectorEnvObservationModes:
     def test_obs_mode_different_different_shapes(self, vector_env_fn, observation_mode):
         spaces = [Box(low=0, high=1, shape=(i + 1,)) for i in range(3)]
         with pytest.raises(
-            (AssertionError, RuntimeError),
+            (AssertionError, RuntimeError, ValueError),
             # match=re.escape(
             #     "Expected all Box.low shape to be equal, actually [(1,), (2,), (3,)]"
             # ),
@@ -109,7 +109,7 @@ class TestVectorEnvObservationModes:
         ]
 
         with pytest.raises(
-            (AssertionError, RuntimeError),
+            (AssertionError, RuntimeError, TypeError),
             # match=re.escape(
             #     "Expects all spaces to be the same shape, actual types: [<class 'gymnasium.spaces.box.Box'>, <class 'gymnasium.spaces.discrete.Discrete'>, <class 'gymnasium.spaces.dict.Dict'>]"
             # ),

--- a/tests/vector/test_sync_vector_env.py
+++ b/tests/vector/test_sync_vector_env.py
@@ -142,7 +142,7 @@ def test_check_spaces_sync_vector_env():
     # FrozenLake-v1 - Discrete(16), action_space: Discrete(4)
     env_fns[1] = make_env("FrozenLake-v1", 1)
     with pytest.raises(
-        AssertionError,
+        RuntimeError,
         match=re.escape(
             "SyncVectorEnv(..., observation_mode='same') however the sub-environments observation spaces are not equivalent."
         ),

--- a/tests/vector/test_vector_env.py
+++ b/tests/vector/test_vector_env.py
@@ -268,7 +268,7 @@ def test_partial_reset_failure(vectoriser):
     )
 
     # Test first reset using a mask
-    # with pytest.raises(AssertionError):
+    # with pytest.raises(ValueError):
     #     envs.reset(options={"reset_mask": np.array([True, True, False])})
 
     # Reset with all trues
@@ -276,44 +276,43 @@ def test_partial_reset_failure(vectoriser):
 
     # Reset with mask of an incorrect shape
     with pytest.raises(
-        AssertionError,
-        match=re.escape(
-            "`options['reset_mask': mask]` must have shape `(3,)`, got (1,)"
-        ),
+        ValueError,
+        match=re.escape("`options['reset_mask']` must have shape `(3,)`, got (1,)"),
     ):
         envs.reset(options={"reset_mask": np.array([True])})
+
     with pytest.raises(
-        AssertionError,
-        match=re.escape(
-            "options['reset_mask': mask]` must have shape `(3,)`, got (4,)"
-        ),
+        ValueError,
+        match=re.escape("`options['reset_mask']` must have shape `(3,)`, got (4,)"),
     ):
         envs.reset(options={"reset_mask": np.array([True, True, False, False])})
+
     with pytest.raises(
-        AssertionError,
-        match=re.escape(
-            "`options['reset_mask': mask]` must have shape `(3,)`, got (1, 3)"
-        ),
+        ValueError,
+        match=re.escape("`options['reset_mask']` must have shape `(3,)`, got (1, 3)"),
     ):
         envs.reset(options={"reset_mask": np.array([[True, True, True]])})
+
     with pytest.raises(
-        AssertionError,
+        ValueError,
         match=re.escape(
-            "`options['reset_mask': mask]` must contain a boolean array, got reset_mask=[False False False]"
+            "`options['reset_mask']` must contain a boolean array with at least one True value, got reset_mask=[False False False]"
         ),
     ):
         envs.reset(options={"reset_mask": np.array([False, False, False])})
+
     with pytest.raises(
-        AssertionError,
+        TypeError,
         match=re.escape(
-            "`options['reset_mask': mask]` must have `dtype=np.bool_`, got int64"
+            "`options['reset_mask']` must have `dtype=np.bool_`, got int64"
         ),
     ):
         envs.reset(options={"reset_mask": np.array([1, 1, 0])})
+
     with pytest.raises(
-        AssertionError,
+        TypeError,
         match=re.escape(
-            "`options['reset_mask': mask]` must have `dtype=np.bool_`, got float64"
+            "`options['reset_mask']` must have `dtype=np.bool_`, got float64"
         ),
     ):
         envs.reset(options={"reset_mask": np.array([1.0, 1.0, 0.0])})

--- a/tests/wrappers/test_atari_preprocessing.py
+++ b/tests/wrappers/test_atari_preprocessing.py
@@ -106,12 +106,13 @@ def test_screen_size():
     assert AtariPreprocessing(env, screen_size=(100, 120)).screen_size == (100, 120)
 
     with pytest.raises(
-        AssertionError, match="Expect the `screen_size` to be positive, actually: -1"
+        ValueError,
+        match="Expect the `screen_size` to be positive, actually: -1",
     ):
         AtariPreprocessing(env, screen_size=-1)
 
     with pytest.raises(
-        AssertionError,
+        ValueError,
         match=re.escape("Expect the `screen_size` to be positive, actually: (-1, 10)"),
     ):
         AtariPreprocessing(env, screen_size=(-1, 10))

--- a/tests/wrappers/test_human_rendering.py
+++ b/tests/wrappers/test_human_rendering.py
@@ -25,7 +25,7 @@ def test_human_rendering():
 
     env = gym.make("CartPole-v1", render_mode="human")
     with pytest.raises(
-        AssertionError,
+        ValueError,
         match=re.escape(
             "Expected env.render_mode to be one of ['rgb_array', 'rgb_array_list', 'depth_array', 'depth_array_list'] but got 'human'"
         ),

--- a/tests/wrappers/test_resize_observation.py
+++ b/tests/wrappers/test_resize_observation.py
@@ -61,15 +61,15 @@ def test_resize_shapes(shape: tuple[int, int]):
 def test_invalid_input():
     env = gym.make("CarRacing-v3")
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         ResizeObservation(env, ())
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         ResizeObservation(env, (1,))
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         ResizeObservation(env, (1, 1, 1, 1))
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         ResizeObservation(env, (-1, 1))
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         ResizeObservation(gym.make("CartPole-v1"), (1, 1))
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         ResizeObservation(gym.make("Blackjack-v1"), (1, 1))

--- a/tests/wrappers/test_time_limit.py
+++ b/tests/wrappers/test_time_limit.py
@@ -66,14 +66,14 @@ def test_max_episode_steps():
     assert TimeLimit(env, max_episode_steps=10).spec.max_episode_steps == 10
 
     with pytest.raises(
-        AssertionError,
+        (TypeError, ValueError),
         match="Expect the `max_episode_steps` to be positive, actually: -1",
     ):
         TimeLimit(env, max_episode_steps=-1)
 
     with pytest.raises(
-        AssertionError,
-        match="Expect the `max_episode_steps` to be positive, actually: None",
+        (TypeError, ValueError),
+        match="Expect the `max_episode_steps` to be an integer",
     ):
         TimeLimit(env, max_episode_steps=None)
 

--- a/tests/wrappers/vector/test_dict_info_to_list.py
+++ b/tests/wrappers/vector/test_dict_info_to_list.py
@@ -21,7 +21,7 @@ def test_usage_in_vector_env(env_id: str = "CartPole-v1", num_envs: int = 3):
 
     DictInfoToList(vector_env)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         DictInfoToList(env)
 
 

--- a/tests/wrappers/vector/test_human_rendering.py
+++ b/tests/wrappers/vector/test_human_rendering.py
@@ -36,7 +36,7 @@ def test_render_modes():
 
     # HumanRenderer on human renderer should not work
     with pytest.raises(
-        AssertionError,
+        ValueError,
         match=re.escape(
             "Expected env.render_mode to be one of ['rgb_array', 'rgb_array_list', 'depth_array', 'depth_array_list'] but got 'human'"
         ),


### PR DESCRIPTION
Closes #1614 

### Summary of Changes
This Pull Request replaces `assert` statements used for public API input validation inside initialization (`__init__`) and setup (`reset`) methods with explicit `TypeError` or `ValueError` raises.

### Why this is necessary
Standardizing these cold-path validations ensures that user-provided arguments are strictly validated even when running Python in optimized mode (`-O` or `PYTHONOPTIMIZE=1`), which strips assertions. 

Currently, the Gymnasium codebase exhibits internal inconsistency regarding API validation. For example, in `Discrete.__init__`, passing an invalid `n` (counts) triggers a silent `assert`, but passing an invalid `dtype` correctly raises a `TypeError`. Newer modules (such as `PassiveEnvChecker` and `DelayObservation`) already utilize explicit TypeErrors and ValueErrors. This PR unifies the rest of the codebase to that standard.

### Refactoring Scope & Performance Design
To safely improve codebase robustness without introducing any runtime performance overhead to high-throughput training loops, the scope of this refactor has been partitioned based on execution frequency:

1. **Cold Paths & API Boundaries (Updated to standard exceptions):**
   * **Constructors (`__init__`):** Standardized input validation to raise `TypeError` (for type/class/instance violations) and `ValueError` (for invalid shapes, sizes, or bounds) across:
     * `gymnasium/core.py` (the base `Wrapper` class)
     * Core observation and action spaces under `spaces/` (`dict.py`, `discrete.py`, `graph.py`, `multi_binary.py`, `multi_discrete.py`, `oneof.py`, `sequence.py`, `text.py`, `tuple.py`)
     * Vector environments under `vector/` (`vector_env.py`, `sync_vector_env.py`, `async_vector_env.py`)
     * Single-agent wrappers under `wrappers/` and vectorized wrappers under `wrappers/vector/`
   * **Initialization Helpers:** Utility functions called strictly during space/vector setup, such as `rescale_box` in `wrappers/utils.py` and `batch_differing_spaces` in `vector/utils/space_utils.py`.
   * **Setup Boundaries (`reset`):** Vectorized resets (such as `envs.reset(options={"reset_mask": ...})`) are called very infrequently compared to step loops. We converted `reset_mask` shape, type, and value checks to explicit exceptions to fail fast on invalid reset configurations.

2. **Hot Paths (Left untouched as `assert`):**
   * To guarantee zero performance regression, all performance-sensitive assertions evaluated during agent-environment interaction have been left completely untouched.
   * This includes assertions in `step()`, `sample()`, `contains()`, and `concatenate()`, as well as multi-processing memory-sharing routines in `vector/utils/shared_memory.py`. These checks will continue to be safely compiled away in production with `python -O`.

3. **Diagnostics (Left untouched as `assert`):**
   * Left all `assert` statements untouched in `env_checker.py`, `env_match.py`, and `passive_env_checker.py`, as these are diagnostic developer suites where raising `AssertionError` is the standard Python pattern for test suites.

---

### Bonus Bug Fixes in `utils/env_match.py`

While auditing the utilities to support this refactor, I identified and resolved two silent logical bugs inside `gymnasium/utils/env_match.py`:
1. **Spelling Mismatch (`keys-equivalence`):** The `info_comparison` parameter was validated to accept `"keys-equivalence"`, but the evaluation branches checked for the misspelled string `"keys-equivalance"` (with an "a"). This caused info key comparisons to be silently skipped under valid configurations.
2. **Bound Method Evaluation:** The `skip_render` assignment checked `env_b.unwrapped.render` (the bound method object itself) against `[None, "human"]` instead of checking the configuration string attribute `env_b.unwrapped.render_mode`. This caused render-skipping logic for environment B to fail to resolve correctly.

---

### Testing & Verification
* Modernized the test assertions across `tests/spaces/`, `tests/wrappers/`, and `tests/vector/` (updating tests from expecting `AssertionError` to expecting `TypeError`, `ValueError`, or `RuntimeError` to match the new API contracts).
* Verified the changes locally; all 3,645 tests pass successfully.