### PR TITLE
Fix integer overflow in Discrete.contains for small dtypes (int8/uint8)

### DIFF
--- a/gymnasium/spaces/discrete.py
+++ b/gymnasium/spaces/discrete.py
@@ -210,7 +210,9 @@ class Discrete(Space[_IntegerT_co], Generic[_IntegerT_co]):
         else:
             return False
 
-        value_is_in = bool(self.start <= as_np < self.start + self.n)
+        value_is_in = bool(
+            int(self.start) <= int(as_np) < int(self.start) + int(self.n)
+        )
 
         return value_is_in and np.can_cast(as_np.dtype, self.dtype)
 

--- a/tests/spaces/test_discrete.py
+++ b/tests/spaces/test_discrete.py
@@ -166,6 +166,24 @@ def test_contains(element, dtype, expected_is_in):
 
 
 @pytest.mark.parametrize(
+    "n, start, dtype, element",
+    [
+        (3, 125, np.int8, 125),
+        (3, 125, np.int8, 127),
+        (6, 250, np.uint8, 250),
+        (6, 250, np.uint8, 255),
+    ],
+)
+def test_contains_small_dtype_no_overflow(n, start, dtype, element):
+    """The exclusive upper bound must not overflow the space dtype (e.g. int8/uint8)."""
+    space = Discrete(n, start=start, dtype=dtype)
+    assert space.contains(element)
+    assert space.contains(dtype(element))
+    for _ in range(50):
+        assert space.contains(space.sample())  # space must contain its own samples
+
+
+@pytest.mark.parametrize(
     "dtype",
     [
         None,


### PR DESCRIPTION
## What

`Discrete.contains` computes the exclusive upper bound of the valid range as `self.start + self.n`. Because `start` and `n` are stored as scalars of the space's own dtype, this addition is performed in that (possibly narrow) dtype. When the largest element of the space sits at the dtype's maximum, `start + n` overflows and wraps around, so the range check `as_np < self.start + self.n` becomes always-false and `contains` rejects every valid element.

This change performs the range comparison in arbitrary-precision Python ints (`int(self.start) <= int(as_np) < int(self.start) + int(self.n)`) so it can no longer overflow the space dtype. The dtype-castability guard (`np.can_cast(as_np.dtype, self.dtype)`) is unchanged.

## Why

The per-space `dtype` argument (added in #1467) makes it easy to construct spaces backed by small integer dtypes such as `np.int8` / `np.uint8`. For example:

```python
import numpy as np
from gymnasium.spaces import Discrete

space = Discrete(3, start=125, dtype=np.int8)  # elements {125, 126, 127}
space.contains(127)             # False -- but 127 is a valid element
space.contains(space.sample())  # False for every sample
```

Here `start + n == 128` overflows `int8` to `-128`, so the comparison `x < -128` is never satisfied and the space reports that it does not contain its own samples. The same happens for `Discrete(6, start=250, dtype=np.uint8)` (`250 + 6 == 256` wraps to `0`). Doing the comparison in Python ints fixes this without changing behavior for any non-overflowing case.

## Testing

Added `test_contains_small_dtype_no_overflow` to `tests/spaces/test_discrete.py`, parametrized over `int8`/`uint8` spaces whose largest element is at the dtype max. It asserts that `contains` accepts the boundary elements (as both Python `int` and numpy scalar) and that the space contains its own samples. These assertions fail before the change and pass after.

```
pytest tests/spaces/test_discrete.py -q
34 passed
```

The existing `test_contains` parametrization is unchanged and still passes.
