### PR TITLE
Fix default_camera_config not affecting rendered output

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -742,6 +742,14 @@ class MujocoRenderer:
                 mujoco.mjtObj.mjOBJ_CAMERA,
                 camera_name,
             )
+
+            # If a model camera was resolved (camera_id != -1), using it as a
+            # FIXED camera ignores any user-provided default_camera_config values
+            # (distance, elevation, etc.). Force FREE camera so that the config
+            # takes effect, and rely on default_camera_config (e.g. trackbodyid)
+            # for tracking behaviour.
+            if no_camera_specified and self.camera_id != -1:
+                self.camera_id = -1
         else:
             self.camera_id = camera_id
 


### PR DESCRIPTION
Fixes #1141

## Root Cause

When no `camera_id` or `camera_name` is explicitly specified, `MujocoRenderer.__init__` defaults to looking up a camera named `"track"` in the model. All standard MuJoCo model files include a camera named `"track"`, so `mj_name2id` returns a valid camera index (0). This causes `OffScreenViewer.render()` to set the camera type to `mjCAMERA_FIXED`.

With FIXED camera mode, user-provided camera config values (distance, elevation, azimuth, lookat) set via `_set_cam_config()` are silently ignored by `mjv_updateScene`, because FIXED cameras use the model's camera definition instead.

## Fix

Force `camera_id = -1` (FREE camera mode) when no camera was explicitly requested by the user. This makes `default_camera_config` values actually take effect. Explicit `camera_id`/`camera_name` still work correctly (FIXED camera is used). Environments should specify `trackbodyid` in their `default_camera_config` if tracking is desired.

## Test Plan

```python
import gymnasium as gym
import numpy as np

env1 = gym.make('Humanoid-v5', render_mode='rgb_array',
                 default_camera_config={'distance': 4.0, 'elevation': -20})
env2 = gym.make('Humanoid-v5', render_mode='rgb_array',
                 default_camera_config={'distance': 50.0, 'elevation': -20})

img1 = env1.reset()[0]; img1 = env1.render()
img2 = env2.reset()[0]; img2 = env2.render()

# Before fix: images nearly identical (mean diff ~3)
# After fix: images significantly different (mean diff ~65)
diff = np.abs(img1.astype(float) - img2.astype(float)).mean()
print(f'Mean pixel difference: {diff}')  # ~65 after fix
```