### PR TITLE
Fix integer overflow in MultiDiscrete.contains for negative starts and small dtypes

### DIFF
--- a/gymnasium/spaces/multi_discrete.py
+++ b/gymnasium/spaces/multi_discrete.py
@@ -251,14 +251,15 @@ class MultiDiscrete(Space[NDArray[_IntegerT_co]], Generic[_IntegerT_co]):
         if isinstance(x, Sequence):
             x = np.array(x)  # Promote list to array for contains check
 
-        # if nvec is uint32 and space dtype is uint32, then 0 <= x < self.nvec guarantees that x
-        # is within correct bounds for space dtype (even though x does not have to be unsigned)
+        # `x - self.start` can overflow the space dtype and wrap around (e.g. for int8 or a
+        # negative start), so compare against the largest element instead; for a valid space,
+        # `start + (nvec - 1)` always fits the dtype and comparisons never overflow
         return bool(
             isinstance(x, np.ndarray)
             and x.shape == self.shape
             and np.can_cast(x.dtype, self.dtype)
             and np.all(self.start <= x)
-            and np.all(x - self.start < self.nvec)
+            and np.all(x <= self.start + (self.nvec - 1))
         )
 
     def to_jsonable(

--- a/tests/spaces/test_multidiscrete.py
+++ b/tests/spaces/test_multidiscrete.py
@@ -181,6 +181,30 @@ def test_multidiscrete_start_contains():
     assert [13, 23, 34] not in space
 
 
+@pytest.mark.parametrize(
+    "nvec, start, dtype, element, expected_is_in",
+    [
+        # int8 space covering [-100, 19], `x - start` wraps for large x
+        ([120], [-100], np.int8, [19], True),
+        ([120], [-100], np.int8, [20], False),
+        ([120], [-100], np.int8, [50], False),
+        ([120], [-100], np.int8, [127], False),
+        # spaces ending exactly at the dtype's maximum value
+        ([3], [125], np.int8, [127], True),
+        ([6], [250], np.uint8, [255], True),
+        # default int64 dtype with negative start, `x - start` wraps for large x
+        ([5], [-10], np.int64, [-6], True),
+        ([5], [-10], np.int64, [np.iinfo(np.int64).max], False),
+    ],
+)
+def test_contains_no_overflow(nvec, start, dtype, element, expected_is_in):
+    """The upper-bound check must not overflow the space dtype (e.g. int8 or negative start)."""
+    space = MultiDiscrete(nvec, start=start, dtype=dtype)
+    assert space.contains(np.array(element, dtype=dtype)) == expected_is_in
+    for _ in range(50):
+        assert space.contains(space.sample())  # space must contain its own samples
+
+
 def test_multidiscrete_equality():
     # Check if two spaces are equivalent.
     space_a = MultiDiscrete(nvec=[2, 3, 4], start=[0, 0, 1])


### PR DESCRIPTION
## What

`MultiDiscrete.contains` checks the upper bound with `x - self.start < self.nvec`. The subtraction is performed in the space's own dtype, so whenever the true difference exceeds the dtype's maximum (a negative `start`, or a small dtype such as `int8`), `x - start` wraps around to a negative value, the `< nvec` comparison trivially passes, and `contains` accepts elements far outside the space.

This is the `MultiDiscrete` counterpart of #1616 (`Discrete.contains`). The fix compares against the largest element instead: `x <= self.start + (self.nvec - 1)`. For any valid space `start + (nvec - 1)` is an element of the space and therefore always fits the dtype, so the comparison can no longer overflow. The rest of the check (shape, `np.can_cast`, lower bound) is unchanged.

## Why

Out-of-range elements are reported as contained, including with the default `int64` dtype:

```python
import numpy as np
from gymnasium.spaces import MultiDiscrete

space = MultiDiscrete([5], start=[-10])              # elements {-10, ..., -6}
space.contains(np.array([np.iinfo(np.int64).max]))   # True

space = MultiDiscrete([120], start=[-100], dtype=np.int8)  # elements {-100, ..., 19}
space.contains(np.array([50], dtype=np.int8))               # True
space.contains(np.array([127], dtype=np.int8))              # True
```

In the first case `int64_max - (-10)` overflows to a negative value, which is `< 5`, so the check passes. In the second, `50 - (-100) == 150` wraps `int8` to `-106 < 120`. The old comment justified the subtraction for unsigned dtypes and non-negative starts, but it doesn't hold in general now that spaces can have negative starts and narrow dtypes.

Note the naive fix `x < self.start + self.nvec` would reintroduce the #1616 overflow for spaces ending at the dtype max (e.g. `MultiDiscrete([3], start=[125], dtype=np.int8)`, where `125 + 3` wraps `int8`), which is why the bound is computed as `start + (nvec - 1)`.

## Testing

Added `test_contains_no_overflow` to `tests/spaces/test_multidiscrete.py`: the out-of-range cases above fail before this change and pass after; the dtype-boundary cases (`int8` space ending at 127, `uint8` at 255) guard the new bound computation against the `start + nvec` overflow; and every parametrization asserts the space contains its own samples.

```
pytest tests/spaces/test_multidiscrete.py tests/spaces/test_spaces.py -q
578 passed
```

`pre-commit run --files gymnasium/spaces/multi_discrete.py tests/spaces/test_multidiscrete.py` passes.
