### PR TITLE
Fix vector envs mutating the sub-environment's class-level metadata when setting autoreset_mode

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -192,7 +192,8 @@ class AsyncVectorEnv(VectorEnv):
         dummy_env = env_fns[0]()
 
         # As we support `make_vec(spec)` then we can't include a `spec = dummy_env.spec` as this doesn't guarantee we can actual recreate the vector env.
-        self.metadata = dummy_env.metadata
+        # Copy the metadata such that we don't modify the sub-environment's (class-level) metadata
+        self.metadata = dict(dummy_env.metadata)
         self.metadata["autoreset_mode"] = self.autoreset_mode
         self.render_mode = dummy_env.render_mode
 

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -111,7 +111,8 @@ class SyncVectorEnv(VectorEnv):
         # Define core attributes using the sub-environments
         # As we support `make_vec(spec)` then we can't include a `spec = self.envs[0].spec` as this doesn't guarantee we can actual recreate the vector env.
         self.num_envs = len(self.envs)
-        self.metadata = self.envs[0].metadata
+        # Copy the metadata such that we don't modify the sub-environment's (class-level) metadata
+        self.metadata = dict(self.envs[0].metadata)
         self.metadata["autoreset_mode"] = self.autoreset_mode
         self.render_mode = self.envs[0].render_mode
 

--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -13,7 +13,7 @@ from gymnasium.error import (
     NoAsyncCallError,
 )
 from gymnasium.spaces import Box, Discrete, MultiDiscrete, Tuple
-from gymnasium.vector import AsyncVectorEnv
+from gymnasium.vector import AsyncVectorEnv, AutoresetMode
 from tests.testing_env import GenericTestEnv
 from tests.vector.testing_utils import (
     CustomSpace,
@@ -31,6 +31,26 @@ def test_create_async_vector_env(shared_memory):
     env = AsyncVectorEnv(env_fns, shared_memory=shared_memory)
     assert env.num_envs == 8
     env.close()
+
+
+def test_metadata_async_vector_env():
+    """Tests that the vector env's metadata doesn't mutate the sub-environment's (class-level) metadata."""
+    envs_1 = AsyncVectorEnv(
+        [make_env("CartPole-v1", 0)], autoreset_mode=AutoresetMode.NEXT_STEP
+    )
+    envs_2 = AsyncVectorEnv(
+        [make_env("CartPole-v1", 1)], autoreset_mode=AutoresetMode.SAME_STEP
+    )
+
+    assert envs_1.metadata["autoreset_mode"] == AutoresetMode.NEXT_STEP
+    assert envs_2.metadata["autoreset_mode"] == AutoresetMode.SAME_STEP
+
+    env = make_env("CartPole-v1", 0)()
+    assert "autoreset_mode" not in env.metadata
+
+    env.close()
+    envs_1.close()
+    envs_2.close()
 
 
 @pytest.mark.parametrize("shared_memory", [True, False])

--- a/tests/vector/test_sync_vector_env.py
+++ b/tests/vector/test_sync_vector_env.py
@@ -7,7 +7,7 @@ import pytest
 
 from gymnasium.envs.registration import EnvSpec
 from gymnasium.spaces import Box, Discrete, MultiDiscrete, Tuple
-from gymnasium.vector import SyncVectorEnv
+from gymnasium.vector import AutoresetMode, SyncVectorEnv
 from tests.envs.utils import all_testing_env_specs
 from tests.vector.testing_utils import (
     CustomSpace,
@@ -24,6 +24,23 @@ def test_create_sync_vector_env():
     env.close()
 
     assert env.num_envs == 8
+
+
+def test_metadata_sync_vector_env():
+    """Tests that the vector env's metadata doesn't mutate the sub-environment's (class-level) metadata."""
+    envs_1 = SyncVectorEnv(
+        [make_env("CartPole-v1", 0)], autoreset_mode=AutoresetMode.NEXT_STEP
+    )
+    envs_2 = SyncVectorEnv(
+        [make_env("CartPole-v1", 1)], autoreset_mode=AutoresetMode.SAME_STEP
+    )
+
+    assert envs_1.metadata["autoreset_mode"] == AutoresetMode.NEXT_STEP
+    assert envs_2.metadata["autoreset_mode"] == AutoresetMode.SAME_STEP
+    assert "autoreset_mode" not in envs_1.envs[0].metadata
+
+    envs_1.close()
+    envs_2.close()
 
 
 def test_reset_sync_vector_env():


### PR DESCRIPTION
## What

`SyncVectorEnv` and `AsyncVectorEnv` take a reference to the first sub-environment's `metadata` dict and then write `autoreset_mode` into it. For nearly all environments `metadata` is a class attribute, so this mutates the class-level dict shared by every instance of that environment class:

```python
import gymnasium as gym
from gymnasium.vector import SyncVectorEnv, AutoresetMode

envs = SyncVectorEnv(
    [lambda: gym.make("CartPole-v1")], autoreset_mode=AutoresetMode.SAME_STEP
)
env = gym.make("CartPole-v1")
env.metadata["autoreset_mode"]  # AutoresetMode.SAME_STEP -- leaked from the vector env
```

Beyond leaking a vector-only key into plain environments, two vector envs over the same environment class end up sharing one dict, so the second constructor's `autoreset_mode` silently overwrites the first's `metadata["autoreset_mode"]`.

This change copies the dict (`self.metadata = dict(...)`) before inserting `autoreset_mode`, in both vector env classes.

## Why

`metadata["autoreset_mode"]` is documented as the way to detect a vector env's autoreset behavior (and wrappers/training loops read it), so two vector envs with different modes reporting the same value is actively misleading. The class-level mutation also survives closing the vector env, affecting unrelated code in the same process.

## Testing

Added `test_metadata_sync_vector_env` / `test_metadata_async_vector_env`, which construct two vector envs over `CartPole-v1` with different autoreset modes and assert that each reports its own mode and that the sub-environment's metadata is untouched. Both fail before the change and pass after.

```
pytest tests/vector/test_sync_vector_env.py tests/vector/test_async_vector_env.py -q
55 passed
```

(The one remaining local failure, `test_sync_vector_env_seed`, needs Box2D which isn't installed here -- unrelated to this change.)
