### PR TITLE
Fix vector RecordEpisodeStatistics reporting wrong stats with SAME_STEP autoreset

### DIFF
--- a/gymnasium/wrappers/vector/common.py
+++ b/gymnasium/wrappers/vector/common.py
@@ -175,15 +175,24 @@ class RecordEpisodeStatistics(VectorWrapper):
             f"`vector.RecordEpisodeStatistics` requires `info` type to be `dict`, its actual type is {type(infos)}. This may be due to usage of other wrappers in the wrong order."
         )
 
-        self.episode_returns[self.prev_dones] = 0
-        self.episode_returns[np.logical_not(self.prev_dones)] += rewards[
-            np.logical_not(self.prev_dones)
-        ]
+        if self._autoreset_mode == AutoresetMode.SAME_STEP:
+            # Sub-environments reset within the same step as they terminate or
+            # truncate, therefore, every step counts towards an episode.
+            self.episode_returns += rewards
+            self.episode_lengths += 1
+        else:
+            # For `NEXT_STEP` autoreset, the step after a termination or
+            # truncation resets the sub-environment and doesn't count towards
+            # the next episode's statistics.
+            self.episode_returns[self.prev_dones] = 0
+            self.episode_returns[np.logical_not(self.prev_dones)] += rewards[
+                np.logical_not(self.prev_dones)
+            ]
 
-        self.episode_lengths[self.prev_dones] = 0
-        self.episode_lengths[~self.prev_dones] += 1
+            self.episode_lengths[self.prev_dones] = 0
+            self.episode_lengths[~self.prev_dones] += 1
 
-        self.episode_start_times[self.prev_dones] = time.perf_counter()
+            self.episode_start_times[self.prev_dones] = time.perf_counter()
 
         self.prev_dones = dones = np.logical_or(terminations, truncations)
         num_dones = np.sum(dones)
@@ -209,6 +218,13 @@ class RecordEpisodeStatistics(VectorWrapper):
                 self.time_queue.extend(episode_time_length[i])
                 self.return_queue.extend(self.episode_returns[i])
                 self.length_queue.extend(self.episode_lengths[i])
+
+            if self._autoreset_mode == AutoresetMode.SAME_STEP:
+                # The done sub-environments have already been reset, restart
+                # their statistics immediately rather than on the next step.
+                self.episode_returns[dones] = 0
+                self.episode_lengths[dones] = 0
+                self.episode_start_times[dones] = time.perf_counter()
 
         return (
             observations,

--- a/tests/wrappers/vector/test_record_episode_statistics.py
+++ b/tests/wrappers/vector/test_record_episode_statistics.py
@@ -1,8 +1,10 @@
+import numpy as np
 import pytest
 
 import gymnasium as gym
 from gymnasium.utils.env_checker import data_equivalence
-from gymnasium.vector import VectorEnv
+from gymnasium.vector import AutoresetMode, SyncVectorEnv, VectorEnv
+from tests.testing_env import GenericTestEnv
 
 
 @pytest.mark.parametrize("num_envs", (1, 3))
@@ -71,3 +73,53 @@ def test_record_episode_statistics(num_envs, env_id="CartPole-v1", num_steps=100
 
     wrapper_vector_env.close()
     vector_wrapper_env.close()
+
+
+@pytest.mark.parametrize("autoreset_mode", list(AutoresetMode))
+def test_episode_statistics_with_autoreset_mode(
+    autoreset_mode, num_envs=2, episode_length=3, num_steps=25
+):
+    """Check that the recorded statistics are correct for all autoreset modes using fixed-length episodes."""
+
+    def reset_func(self, seed=None, options=None):
+        self.timestep = 0
+        return self.observation_space.sample(), {}
+
+    def step_func(self, action):
+        self.timestep += 1
+        return (
+            self.observation_space.sample(),
+            1.0,
+            self.timestep >= episode_length,
+            False,
+            {},
+        )
+
+    envs = gym.wrappers.vector.RecordEpisodeStatistics(
+        SyncVectorEnv(
+            [
+                lambda: GenericTestEnv(reset_func=reset_func, step_func=step_func)
+                for _ in range(num_envs)
+            ],
+            autoreset_mode=autoreset_mode,
+        )
+    )
+
+    envs.reset(seed=123)
+    for _ in range(num_steps):
+        actions = envs.action_space.sample()
+        _, _, terminations, truncations, infos = envs.step(actions)
+
+        dones = np.logical_or(terminations, truncations)
+        if np.any(dones):
+            assert "episode" in infos
+            assert np.all(infos["episode"]["r"][dones] == episode_length)
+            assert np.all(infos["episode"]["l"][dones] == episode_length)
+
+            if autoreset_mode == AutoresetMode.DISABLED:
+                envs.reset(options={"reset_mask": np.copy(dones)})
+
+    assert envs.episode_count > num_envs
+    assert np.all(np.array(envs.return_queue) == episode_length)
+    assert np.all(np.array(envs.length_queue) == episode_length)
+    envs.close()


### PR DESCRIPTION
# Description

`vector.RecordEpisodeStatistics` reports wrong returns and lengths when the vector env uses `AutoresetMode.SAME_STEP`. The accumulation logic assumes `NEXT_STEP` semantics: it uses `prev_dones` to skip the step after a termination/truncation (the reset step) and to clear the accumulators. Under `SAME_STEP`, the sub-environment resets within the terminating step itself, so the following step is a real first step of the new episode -- masking it out both drops that step's reward/length and clears the accumulators one step too late.

The effect is that only the first episode of each sub-environment is reported correctly and every subsequent episode is under-reported by one step. Reproducible with a fixed 3-step, reward-1-per-step episode:

```python
envs = gym.wrappers.vector.RecordEpisodeStatistics(
    SyncVectorEnv([make_env] * 2, autoreset_mode=AutoresetMode.SAME_STEP)
)
envs.reset(seed=123)
# first done:      infos["episode"]["r"] == [3. 3.], "l" == [3 3]   (correct)
# every one after: infos["episode"]["r"] == [2. 2.], "l" == [2 2]   (should be 3)
```

The wrapper already reads `env.autoreset_mode` in `reset` to decide when to clear statistics, but `step` ignored it. This change branches on the mode in `step`: for `SAME_STEP`, every step counts towards an episode (no `prev_dones` masking) and the accumulators for done sub-environments are cleared at the end of the same step, right after their statistics are recorded. `NEXT_STEP` and `DISABLED` behavior is unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added `test_episode_statistics_with_autoreset_mode` to `tests/wrappers/vector/test_record_episode_statistics.py`, parametrized over all three `AutoresetMode`s, using a fixed-length `GenericTestEnv` so the exact expected return/length is known. It runs 25 steps (several episodes per sub-environment) and asserts every reported `r`/`l` equals the true episode length, including everything accumulated in `return_queue`/`length_queue`. The `SAME_STEP` case fails before this change and passes after; `NEXT_STEP` and `DISABLED` pass before and after.

```
pytest tests/wrappers/vector/test_record_episode_statistics.py -q
5 passed
```

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
