### PR TITLE
Fix non-deterministic Text charset ordering under hash randomization

### DIFF
--- a/gymnasium/spaces/text.py
+++ b/gymnasium/spaces/text.py
@@ -68,12 +68,20 @@ class Text(Space[str]):
         self.min_length: int = int(min_length)
         self.max_length: int = int(max_length)
 
-        self._char_set: frozenset[str] = frozenset(charset)
-        self._char_list: tuple[str, ...] = tuple(charset)
+        if isinstance(charset, (set, frozenset)):
+            # Set iteration order depends on hash randomization (PYTHONHASHSEED),
+            # sort to keep sampling, masks and flattening consistent across processes.
+            char_list = sorted(charset)
+        else:
+            # Preserve the given ordering, dropping duplicate characters
+            char_list = list(dict.fromkeys(charset))
+
+        self._char_set: frozenset[str] = frozenset(char_list)
+        self._char_list: tuple[str, ...] = tuple(char_list)
         self._char_index: dict[str, np.int32] = {
-            val: np.int32(i) for i, val in enumerate(tuple(charset))
+            val: np.int32(i) for i, val in enumerate(char_list)
         }
-        self._char_str: str = "".join(sorted(tuple(charset)))
+        self._char_str: str = "".join(sorted(char_list))
 
         # As the shape is dynamic (between min_length and max_length) then None
         super().__init__(dtype=str, seed=seed)

--- a/tests/spaces/test_text.py
+++ b/tests/spaces/test_text.py
@@ -1,4 +1,7 @@
+import os
 import re
+import subprocess
+import sys
 
 import numpy as np
 import pytest
@@ -77,3 +80,41 @@ def test_sample_probability():
     sample = space.sample(probability=(2, np.array([0.5, 0.5, 0, 0], dtype=np.float64)))
     assert sample in space
     assert sample in ["aa", "bb", "ab", "ba"]
+
+
+def test_charset_ordering():
+    # set-based charsets have no inherent order so they are sorted
+    space = Text(5, charset=frozenset("dcba"))
+    assert space.character_list == ("a", "b", "c", "d")
+    assert [space.character_index(c) for c in "abcd"] == [0, 1, 2, 3]
+
+    # string charsets keep the given order, dropping duplicate characters
+    space = Text(5, charset="dcbad")
+    assert space.character_list == ("d", "c", "b", "a")
+    assert [space.character_index(c) for c in "dcba"] == [0, 1, 2, 3]
+
+
+def test_deterministic_across_hash_seeds():
+    """Seeded samples and flatten encodings must not depend on PYTHONHASHSEED.
+
+    The default charset is a frozenset whose iteration order changes with hash
+    randomization, so the character ordering must be normalized.
+    """
+    code = (
+        "from gymnasium.spaces import Text\n"
+        "from gymnasium.spaces.utils import flatten\n"
+        "space = Text(5, seed=42)\n"
+        "print(space.sample())\n"
+        "print(flatten(Text(5), 'abc').tolist())\n"
+    )
+    outputs = {
+        subprocess.run(
+            [sys.executable, "-c", code],
+            env={**os.environ, "PYTHONHASHSEED": str(hash_seed)},
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        for hash_seed in (1, 2)
+    }
+    assert len(outputs) == 1, f"Outputs differ across hash seeds: {outputs}"


### PR DESCRIPTION
# Description

`Text` builds its internal character list and index from raw set iteration order, and the default charset is a `frozenset` whose iteration order depends on `PYTHONHASHSEED`. So identically seeded `Text` spaces behave differently across processes: `sample()` returns different strings for the same seed, `flatten()`/`unflatten()` map characters to different integers, and positional entries in the sample/probability `mask` refer to different characters. Easy to see with the default charset:

```
$ PYTHONHASHSEED=1 python -c "from gymnasium.spaces import Text; print(Text(5, seed=42).sample())"
p
$ PYTHONHASHSEED=2 python -c "from gymnasium.spaces import Text; print(Text(5, seed=42).sample())"
s
```

This silently breaks seeded reproducibility for anything using `Text` across workers or reruns (hash randomization is on by default), and makes flattened `Text` observations inconsistent between processes.

The fix normalizes the ordering when the character list is built: set-based charsets are sorted, while string (or other ordered) charsets keep their given order with duplicate characters dropped, so `character_index` stays consistent with `character_list`. `charset` / `character_set` semantics are unchanged.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

Added two tests to `tests/spaces/test_text.py`: `test_charset_ordering` checks that set charsets come out sorted and string charsets keep their order with duplicates dropped, and `test_deterministic_across_hash_seeds` runs a seeded `sample()` and a `flatten()` in subprocesses under different `PYTHONHASHSEED` values and asserts identical output -- it fails before this change and passes after.

```
pytest tests/spaces -q
1083 passed
```

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
