### PR TITLE
Add WireHarness-MultiGripper-RL to third-party environments

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -370,6 +370,13 @@ goal-RL ([Gymnasium-Robotics](https://robotics.farama.org/)).
 
   MuJoCo-based Gymnasium environment for centralized multi-robot wire handling. A single policy controls five planar movers via a joint action space to navigate cable harnesses to target configurations on an assembly board without causing collisions.
 
+- [WireHarness-MultiGripper-RL: Multi-branch wire-harness picking with a multi-gripper in MuJoCo](https://github.com/KishanThummar007/WireHarness-MultiGripper-RL)
+
+  ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-%3E%3D1.0-blue)
+  ![GitHub stars](https://img.shields.io/github/stars/KishanThummar007/WireHarness-MultiGripper-RL)
+
+  MuJoCo-based Gymnasium environment with deformable cable physics for robotic wire-harness picking. A multi-gripper end-effector navigates a dense multi-branch harness to reach and grasp connector housings while minimizing induced wire stress and collisions.
+
 ### Telecommunication Systems environments
 *Interact and/or manage wireless and/or wired telecommunication systems.*
 - [mobile-env: Environments for coordination of wireless mobile networks](https://github.com/stefanbschneider/mobile-env)


### PR DESCRIPTION
# Description
Adds **WireHarness-MultiGripper-RL** to the third-party environments list, under Robotics.

It is a MuJoCo-based Gymnasium environment with deformable cable physics for robotic
wire-harness picking: a multi-gripper end-effector navigates a dense multi-branch harness
(10 cable branches, 200+ equality constraints) to reach and grasp connector housings while
minimizing induced wire stress and collisions.

The environment is public, pip-installable, uses the Gymnasium API (`gymnasium >= 1.0`),
passes `gymnasium.utils.env_checker.check_env`, and ships SAC/TD3 training examples.

Repository: https://github.com/KishanThummar007/WireHarness-MultiGripper-RL

Motivation: automotive wire-harness assembly is still largely manual because deformable,
multi-branch cables are hard to model and control. This environment provides an RL benchmark
for that task, complementing the existing WireHarness-MultiAgent-RL entry (which covers
multi-robot wire routing, while this one covers multi-gripper picking of connector housings).

Fixes # (n/a — documentation addition, no issue)

## Type of change
- [x] Documentation only change (no code changed)

### Screenshots
n/a — a single new list entry in `docs/environments/third_party_environments.md`.

# Checklist:
- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes