### PR TITLE
Fix create_shared_memory for dtypes without an array module typecode (float16)

### DIFF
--- a/gymnasium/vector/utils/shared_memory.py
+++ b/gymnasium/vector/utils/shared_memory.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import multiprocessing as mp
+from array import typecodes
 from collections.abc import Mapping
-from ctypes import c_bool, c_int32, c_int64
+from ctypes import c_bool, c_int32, c_int64, c_uint8
 from functools import singledispatch
 from multiprocessing.sharedctypes import SynchronizedArray
 from types import ModuleType
@@ -81,10 +82,16 @@ def _create_base_shared_memory(
 ) -> SynchronizedArray[Any]:
     assert space.dtype is not None
     assert space.shape is not None
+    size = n * int(np.prod(space.shape))
     dtype = space.dtype.char
-    if dtype in "?":
-        dtype = c_bool
-    return ctx.Array(dtype, n * int(np.prod(space.shape)))
+    if dtype == "?":
+        return ctx.Array(c_bool, size)
+    elif dtype in typecodes:
+        return ctx.Array(dtype, size)
+    else:
+        # Some dtypes (e.g. float16) have no `array` typecode, allocate the equivalent
+        # number of bytes as read / write reinterpret the raw buffer with `space.dtype`.
+        return ctx.Array(c_uint8, size * space.dtype.itemsize)
 
 
 @create_shared_memory.register(Tuple)

--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -349,6 +349,24 @@ def test_custom_space_async_vector_env_shared_memory():
         env.close(terminate=True)
 
 
+def test_float16_async_vector_env_shared_memory():
+    """Test observation dtypes without an `array` typecode (e.g. float16) with shared memory."""
+    obs_space = Box(low=-1.0, high=1.0, shape=(3,), dtype=np.float16)
+    envs = AsyncVectorEnv(
+        [lambda: GenericTestEnv(observation_space=obs_space)] * 2, shared_memory=True
+    )
+
+    observations, _ = envs.reset(seed=0)
+    assert observations.dtype == np.float16
+    assert observations.shape == (2, 3)
+
+    observations, *_ = envs.step(envs.action_space.sample())
+    assert observations.dtype == np.float16
+    assert observations.shape == (2, 3)
+
+    envs.close()
+
+
 def raise_error_reset(self, seed, options):
     super(GenericTestEnv, self).reset(seed=seed, options=options)
     if seed == 1:

--- a/tests/vector/utils/test_shared_memory.py
+++ b/tests/vector/utils/test_shared_memory.py
@@ -3,10 +3,12 @@
 import multiprocessing as mp
 import re
 
+import numpy as np
 import pytest
 
 from gymnasium import Space
 from gymnasium.error import CustomSpaceError
+from gymnasium.spaces import Box
 from gymnasium.utils.env_checker import data_equivalence
 from gymnasium.vector.utils import (
     batch_space,
@@ -52,6 +54,33 @@ def test_shared_memory_create_read_write(space, num, ctx):
     for read_sample, sample in zip(
         iterate(batched_space, read_samples), samples, strict=True
     ):
+        assert data_equivalence(read_sample, sample)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [np.float16] + ([np.float128] if hasattr(np, "float128") else []),
+    ids=lambda dtype: np.dtype(dtype).name,
+)
+def test_shared_memory_no_array_typecode_dtypes(dtype):
+    """Test dtypes without an `array` module typecode (e.g. float16) roundtrip through shared memory."""
+    space = Box(low=-1.0, high=1.0, shape=(2, 3), dtype=dtype)
+    num = 8
+
+    shared_memory = create_shared_memory(space, n=num)
+
+    # `Box.sample` does not support float128, generate the samples directly
+    rng = np.random.default_rng(seed=123)
+    samples = [
+        rng.uniform(-1.0, 1.0, size=space.shape).astype(dtype) for _ in range(num)
+    ]
+    for i, sample in enumerate(samples):
+        write_to_shared_memory(space, i, sample, shared_memory)
+
+    read_samples = read_from_shared_memory(space, shared_memory, n=num)
+    assert read_samples.dtype == dtype
+    assert read_samples.shape == (num,) + space.shape
+    for read_sample, sample in zip(read_samples, samples, strict=True):
         assert data_equivalence(read_sample, sample)
 
 


### PR DESCRIPTION
Supersedes #1625, rebased onto `main` as requested by @pseudo-rnd-thoughts. Content is unchanged; only the base is.

## What

`create_shared_memory` for `Box`/`Discrete`/`MultiDiscrete` spaces passes the numpy dtype's single-character code straight to `ctx.Array`. That only works for dtypes whose character happens to be a valid `array` module typecode. For dtypes without one — most notably `np.float16` (`'e'`) — `multiprocessing` raises `TypeError: this type has no size`, so `AsyncVectorEnv(..., shared_memory=True)` cannot be constructed at all for float16 observation spaces.

This change keeps the existing path for dtypes with a valid typecode and falls back to allocating the equivalent number of bytes (`c_uint8`, `size * itemsize`) otherwise. The fallback is transparent to the read/write side: `read_from_shared_memory` and `write_to_shared_memory` already reinterpret the raw buffer via `np.frombuffer(..., dtype=space.dtype)`, so only the allocation needed fixing.

## Why

float16 observation spaces are a natural choice for memory-heavy image/embedding observations, but vectorizing them with shared memory currently fails on construction:

```python
import numpy as np
from gymnasium.spaces import Box
from gymnasium.vector.utils import create_shared_memory

create_shared_memory(Box(-1, 1, (3,), dtype=np.float16), n=2)
# TypeError: this type has no size
```

The same error surfaces from `AsyncVectorEnv([...], shared_memory=True)` for any env whose (possibly nested) observation space contains a float16 leaf. The existing special case for bool (`'?'` → `c_bool`) is this same problem solved for one specific dtype; the fallback generalizes it to every dtype the `array` module doesn't cover (float16, complex dtypes, and float128 on platforms that have it).

## Testing

Added `test_shared_memory_no_array_typecode_dtypes` to `tests/vector/utils/test_shared_memory.py`, parametrized over float16 (and float128 where available), asserting that samples written to shared memory round-trip with the correct dtype, shape, and values. Also added `test_float16_async_vector_env_shared_memory` to `tests/vector/test_async_vector_env.py` exercising the end-to-end `AsyncVectorEnv` reset/step path with `shared_memory=True`. Both fail with the `TypeError` above before the change and pass after.

```
pytest tests/vector/utils/test_shared_memory.py tests/vector/test_async_vector_env.py -q
223 passed, 66 skipped
```

`pre-commit run --files gymnasium/vector/utils/shared_memory.py tests/vector/test_async_vector_env.py tests/vector/utils/test_shared_memory.py` passes.

