### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tutorial.yml
+++ b/.github/workflows/run-tutorial.yml
@@ -14,6 +14,9 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test-tutorials:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Gymnasium/security/code-scanning/3](https://github.com/Farama-Foundation/Gymnasium/security/code-scanning/3)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is least-privileged by default.  
Best single fix without changing functionality: define workflow-level permissions near the top of `.github/workflows/run-tutorial.yml` (after `on:` block, before `jobs:`) with `contents: read`. This satisfies CodeQL and keeps all current steps working (checkout/reading repo/artifact upload do not require write to repo contents).

No imports/dependencies/methods are needed; this is a YAML config-only change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
