### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -14,6 +14,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build-wheels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Gymnasium/security/code-scanning/2](https://github.com/Farama-Foundation/Gymnasium/security/code-scanning/2)

Add explicit `permissions` to the workflow so token scope is intentionally constrained.  
Best fix without changing functionality: define a root-level `permissions` block with minimal read access needed by both jobs:

- `contents: read` for checkout/repository reads.
- `packages: read` as a safe minimal default often used for build/publish workflows.

This should be inserted in `.github/workflows/pypi-publish.yml` after the `on:` triggers (before `jobs:`), so it applies to all jobs unless overridden. No imports/dependencies/method changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
