### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   build-wheels:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:
@@ -34,6 +36,8 @@ jobs:
         path: dist
 
   publish:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs:
     - build-wheels


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Gymnasium/security/code-scanning/1](https://github.com/Farama-Foundation/Gymnasium/security/code-scanning/1)

Add explicit `permissions` blocks so each job gets only what it needs:

- `build-wheels`: `contents: read` (sufficient for checkout and build/artifact steps).
- `publish`: `contents: read` (sufficient for downloading artifact and running PyPI publish action with external secret).

Best single fix without changing behavior: add job-level `permissions` under each job in `.github/workflows/pypi-publish.yml`. This avoids accidentally over/under-permissioning across jobs and documents intent clearly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
