### PR TITLE
Fix CarRacing HUD score overflow from float formatting

### DIFF
--- a/gymnasium/envs/box2d/car_racing.py
+++ b/gymnasium/envs/box2d/car_racing.py
@@ -637,7 +637,7 @@ class CarRacing(gym.Env, EzPickle):
         self._render_indicators(WINDOW_W, WINDOW_H)
 
         font = pygame.font.Font(pygame.font.get_default_font(), 42)
-        text = font.render(f"{self.reward:04}", True, (255, 255, 255), (0, 0, 0))
+        text = font.render(f"{self.reward:04.0f}", True, (255, 255, 255), (0, 0, 0))
         text_rect = text.get_rect()
         text_rect.center = (60, WINDOW_H - WINDOW_H * 2.5 / 40.0)
         self.surf.blit(text, text_rect)


### PR DESCRIPTION
## Summary

The CarRacing HUD formatted `self.reward` with `f"{self.reward:04}"`, which only sets a minimum width and still prints full float decimals, overflowing the bottom-left score.

Use `f"{self.reward:04.0f}"` so the score renders as a fixed-width integer field (matching the demo gif).

## Test plan

- [x] Format sanity: `f"{23.59:04.0f}" == "0024"`
- [ ] Manual render with `render_mode="human"` if pygame available

Fixes #1638.