### PR TITLE
Fix MujocoEnv shrinking XML-declared offscreen framebuffer

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -56,8 +56,11 @@ class MujocoEnv(gym.Env):
             frame_skip: Number of MuJoCo simulation steps per gym `step()`.
             observation_space: The observation space of the environment.
             render_mode: The `render_mode` used.
-            width: The width of the render window.
-            height: The height of the render window.
+            width: The width of the render window. The offscreen framebuffer is grown to
+                this size if the model XML declares a smaller one, but never shrunk below
+                the XML-declared size.
+            height: The height of the render window. Grown, but never shrunk, in the same
+                way as `width`.
             camera_id: The camera ID used.
             camera_name: The name of the camera used (can not be used in conjunction with `camera_id`).
             default_camera_config: configuration for rendering camera.
@@ -120,11 +123,7 @@ class MujocoEnv(gym.Env):
         """
         model = mujoco.MjModel.from_xml_path(self.fullpath)
         # MjrContext will copy model.vis.global_.off* to con.off*
-        # Only grow the offscreen framebuffer, never shrink it below the size
-        # the model's XML explicitly requested via `<visual><global offwidth=...
-        # offheight=.../></visual>`. This lets a user allocate a buffer larger
-        # than the render window/`width`/`height` (e.g. for a separate high-res
-        # `mujoco.Renderer`). See https://github.com/Farama-Foundation/Gymnasium/issues/1607
+        # Only grow the offscreen framebuffer, never shrink below the size of the model XML.
         model.vis.global_.offwidth = max(model.vis.global_.offwidth, self.width)
         model.vis.global_.offheight = max(model.vis.global_.offheight, self.height)
         data = mujoco.MjData(model)

--- a/gymnasium/envs/mujoco/mujoco_env.py
+++ b/gymnasium/envs/mujoco/mujoco_env.py
@@ -120,8 +120,13 @@ class MujocoEnv(gym.Env):
         """
         model = mujoco.MjModel.from_xml_path(self.fullpath)
         # MjrContext will copy model.vis.global_.off* to con.off*
-        model.vis.global_.offwidth = self.width
-        model.vis.global_.offheight = self.height
+        # Only grow the offscreen framebuffer, never shrink it below the size
+        # the model's XML explicitly requested via `<visual><global offwidth=...
+        # offheight=.../></visual>`. This lets a user allocate a buffer larger
+        # than the render window/`width`/`height` (e.g. for a separate high-res
+        # `mujoco.Renderer`). See https://github.com/Farama-Foundation/Gymnasium/issues/1607
+        model.vis.global_.offwidth = max(model.vis.global_.offwidth, self.width)
+        model.vis.global_.offheight = max(model.vis.global_.offheight, self.height)
         data = mujoco.MjData(model)
         return model, data
 

--- a/tests/envs/mujoco/test_mujoco_custom_env.py
+++ b/tests/envs/mujoco/test_mujoco_custom_env.py
@@ -131,3 +131,48 @@ def test_reset_info():
 
     _, info = env.reset()
     assert info["works"] is True
+
+
+OFFSCREEN_BUFFER_XML = """<mujoco model="offscreen_buffer_env">
+  <visual>
+    <global offwidth="1920" offheight="1080"/>
+  </visual>
+  <worldbody>
+    <geom type="plane" size="1 1 0.1"/>
+    <body name="torso" pos="0 0 1">
+      <joint name="slide" type="slide" axis="1 0 0"/>
+      <geom type="sphere" size="0.1"/>
+    </body>
+  </worldbody>
+  <actuator>
+    <motor joint="slide" ctrlrange="-1 1" ctrllimited="true"/>
+  </actuator>
+</mujoco>
+"""
+
+
+def test_offscreen_framebuffer_not_shrunk(tmp_path):
+    """Verify that an XML-declared offscreen framebuffer is not shrunk.
+
+    Regression test for https://github.com/Farama-Foundation/Gymnasium/issues/1607:
+    `MujocoEnv._initialize_simulation` used to unconditionally overwrite the
+    `offwidth`/`offheight` requested through `<visual><global .../></visual>`
+    with the (smaller) `width`/`height` render-window size, which broke a
+    user-supplied high-resolution `mujoco.Renderer`.
+    """
+    xml_path = tmp_path / "offscreen_buffer_env.xml"
+    xml_path.write_text(OFFSCREEN_BUFFER_XML)
+
+    # The XML requests a framebuffer larger than the default render window
+    # (480x480), so the XML-declared size must survive `__init__`.
+    env = PointEnv(xml_file=str(xml_path)).unwrapped
+    assert env.model.vis.global_.offwidth == 1920
+    assert env.model.vis.global_.offheight == 1080
+    env.close()
+
+    # When the requested render window is larger than the XML declaration, the
+    # larger window size wins so that on-screen rendering still fits the buffer.
+    env = PointEnv(xml_file=str(xml_path), width=2560, height=1440).unwrapped
+    assert env.model.vis.global_.offwidth == 2560
+    assert env.model.vis.global_.offheight == 1440
+    env.close()


### PR DESCRIPTION
# Description

`MujocoEnv._initialize_simulation()` unconditionally set the offscreen framebuffer size from the render-window size:

```python
model.vis.global_.offwidth = self.width    # self.width defaults to 480
model.vis.global_.offheight = self.height
```

This silently clobbered a larger buffer that a user had already declared in their model XML via `<visual><global offwidth="960" offheight="540"/></visual>`. A subsequent higher-resolution `mujoco.Renderer(model, width=960, height=540)` then failed with `ValueError: Image width 960 > framebuffer width 480`.

This changes the assignment to **grow, never shrink**, so the larger of the XML-declared size and the requested render window wins in both directions:

```python
model.vis.global_.offwidth = max(model.vis.global_.offwidth, self.width)
model.vis.global_.offheight = max(model.vis.global_.offheight, self.height)
```

- An XML-declared buffer larger than the render window survives (fixes the reported bug).
- A render window larger than the XML declaration still enlarges the buffer, so on-screen rendering continues to fit.

**Note:** For an env whose XML declares no `<global>` element, the offscreen buffer now keeps MuJoCo's compiled default (640×480) instead of being force-shrunk to 480×480. This is harmless — the rendered viewport is governed independently by `width`/`height` (`Ant-v5` still renders `(480, 480, 3)`) — but it is a change from the previous forced-480 behavior, so flagging it for reviewers.

Fixes #1607

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Not applicable (no visual change). Reproduction, headless via `MUJOCO_GL=egl`, using a custom env whose XML declares `offwidth=960 offheight=540`:

| | `model.vis.global_.offwidth/offheight` after `__init__` | `mujoco.Renderer(model, 960, 540)` |
| ------ | ----- | ----- |
| Before | `480 / 480` | raises `ValueError: Image width 960 > framebuffer width 480` |
| After  | `960 / 540` | succeeds → image shape `(540, 960, 3)` |

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — N/A (no docs reference `offwidth`/`offheight`)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`tests/envs/mujoco/`: 261 passed, 6 skipped)
