### PR TITLE
Fix AsyncVectorEnv NEXT_STEP autoreset reward/done dtypes

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -806,7 +806,11 @@ def _async_worker(
                 if autoreset_mode == AutoresetMode.NEXT_STEP:
                     if autoreset:
                         observation, info = env.reset()
-                        reward, terminated, truncated = 0, False, False
+                        # Use numpy scalars so step_wait can stack rewards / done flags
+                        # when only some workers are in the autoreset path (issue #1445).
+                        reward = np.float64(0.0)
+                        terminated = np.bool_(False)
+                        truncated = np.bool_(False)
                     else:
                         (
                             observation,

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -51,6 +51,39 @@ _StepResult: TypeAlias = tuple[
 ]
 
 
+def _batch_rewards(rewards: list[Any]) -> npt.NDArray[np.float64]:
+    """Stack per-env rewards, broadcasting autoreset scalar zeros onto array rewards.
+
+    ``NEXT_STEP`` autoreset returns a scalar zero reward while other workers may
+    still return ndarray rewards (including length-1 vectors). A plain
+    ``np.array(rewards, dtype=np.float64)`` then fails with an inhomogeneous-shape
+    error (see issue #1445). When every non-scalar reward shares one shape, scalar
+    placeholders are expanded to zeros of that shape before stacking.
+    """
+    target_shape: tuple[int, ...] | None = None
+    for reward in rewards:
+        arr = np.asarray(reward)
+        if arr.ndim >= 1:
+            if target_shape is None:
+                target_shape = arr.shape
+            elif arr.shape != target_shape:
+                # Divergent vector rewards: fall back and let NumPy raise.
+                target_shape = None
+                break
+
+    if target_shape is not None:
+        normalized: list[np.ndarray] = []
+        for reward in rewards:
+            arr = np.asarray(reward, dtype=np.float64)
+            if arr.ndim == 0:
+                normalized.append(np.zeros(target_shape, dtype=np.float64))
+            else:
+                normalized.append(np.asarray(arr, dtype=np.float64))
+        return np.stack(normalized, axis=0)
+
+    return np.asarray(rewards, dtype=np.float64)
+
+
 class AsyncState(Enum):
     """The AsyncVectorEnv possible states given the different actions."""
 
@@ -514,7 +547,7 @@ class AsyncVectorEnv(VectorEnv):
         self._state = AsyncState.DEFAULT
         return (
             deepcopy(self.observations) if self.copy else self.observations,
-            np.array(rewards, dtype=np.float64),
+            _batch_rewards(rewards),
             np.array(terminations, dtype=np.bool_),
             np.array(truncations, dtype=np.bool_),
             infos,
@@ -806,8 +839,9 @@ def _async_worker(
                 if autoreset_mode == AutoresetMode.NEXT_STEP:
                     if autoreset:
                         observation, info = env.reset()
-                        # Use numpy scalars so step_wait can stack rewards / done flags
-                        # when only some workers are in the autoreset path (issue #1445).
+                        # Scalar zero placeholder. ``step_wait`` broadcasts this to the
+                        # other workers' reward shape when they return ndarray rewards
+                        # (issue #1445 / array-vs-scalar autoreset mix).
                         reward = np.float64(0.0)
                         terminated = np.bool_(False)
                         truncated = np.bool_(False)

--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -474,14 +474,81 @@ def test_async_vector_subenv_error():
     )
 
 
-@pytest.mark.parametrize("shared_memory", [True, False])
-def test_async_vector_env_next_step_autoreset_homogeneous_types(shared_memory):
-    """Autoreset path must return numpy-compatible reward/done types (issue #1445).
+def _make_array_reward_env(episode_length: int):
+    """Env whose reward is a length-1 float32 vector (reproduces issue #1445)."""
 
-    When only some workers take the NEXT_STEP autoreset branch, mixing Python
-    ints/bools with numpy scalars from normal steps made np.array(...) raise
-    due to inhomogeneous sequences.
+    def _thunk():
+        step_count = {"n": 0}
+
+        def reset_func(self, *, seed=None, options=None):
+            super(GenericTestEnv, self).reset(seed=seed)
+            step_count["n"] = 0
+            return np.zeros(self.observation_space.shape, dtype=np.float32), {}
+
+        def step_func(self, action):
+            step_count["n"] += 1
+            terminated = step_count["n"] >= episode_length
+            # 1-d array reward: mixes with autoreset scalar 0 and broke stacking.
+            reward = np.array([1.0], dtype=np.float32)
+            obs = np.zeros(self.observation_space.shape, dtype=np.float32)
+            return obs, reward, terminated, False, {}
+
+        return GenericTestEnv(
+            action_space=Discrete(2),
+            observation_space=Box(
+                low=-1.0, high=1.0, shape=(2,), dtype=np.float32
+            ),
+            reset_func=reset_func,
+            step_func=step_func,
+        )
+
+    return _thunk
+
+
+@pytest.mark.parametrize("shared_memory", [True, False])
+def test_async_vector_env_next_step_autoreset_array_reward(shared_memory):
+    """NEXT_STEP autoreset must stack when some rewards are ndarray (issue #1445).
+
+    On main, workers that autoreset return a scalar 0 reward while siblings still
+    return length-1 float32 arrays. ``np.array(rewards, dtype=float64)`` then raises
+    ValueError (inhomogeneous shape). This test fails on main and passes with the fix.
     """
+    # Stagger episode lengths so only a subset of workers autoreset each step.
+    env_fns = [_make_array_reward_env(ep_len) for ep_len in (2, 3, 4, 5)]
+    envs = AsyncVectorEnv(
+        env_fns,
+        shared_memory=shared_memory,
+        autoreset_mode=AutoresetMode.NEXT_STEP,
+    )
+    try:
+        envs.reset(seed=0)
+        saw_mixed_autoreset = False
+        for _ in range(20):
+            _obs, rewards, terminations, truncations, _infos = envs.step(
+                envs.action_space.sample()
+            )
+            assert isinstance(rewards, np.ndarray)
+            assert rewards.dtype == np.float64
+            # Batched shape: (num_envs, reward_dim)
+            assert rewards.shape == (4, 1)
+            assert isinstance(terminations, np.ndarray)
+            assert terminations.dtype == np.bool_
+            assert terminations.shape == (4,)
+            assert isinstance(truncations, np.ndarray)
+            assert truncations.dtype == np.bool_
+            assert truncations.shape == (4,)
+            # Autoreset zero-reward rows appear as all-zeros after a done.
+            if np.any(rewards == 0.0):
+                saw_mixed_autoreset = True
+                break
+        assert saw_mixed_autoreset, "expected at least one autoreset zero-reward step"
+    finally:
+        envs.close()
+
+
+@pytest.mark.parametrize("shared_memory", [True, False])
+def test_async_vector_env_next_step_autoreset_scalar_reward(shared_memory):
+    """Scalar rewards still batch to shape (num_envs,) under NEXT_STEP autoreset."""
     env_fns = [make_env("CartPole-v1", i) for i in range(4)]
     envs = AsyncVectorEnv(
         env_fns,
@@ -490,22 +557,19 @@ def test_async_vector_env_next_step_autoreset_homogeneous_types(shared_memory):
     )
     try:
         envs.reset(seed=0)
-        # Drive until at least one env ends so the next step uses the autoreset branch.
         for _ in range(500):
-            actions = envs.action_space.sample()
-            _obs, rewards, terminations, truncations, _infos = envs.step(actions)
+            _obs, rewards, terminations, truncations, _infos = envs.step(
+                envs.action_space.sample()
+            )
             assert isinstance(rewards, np.ndarray)
             assert rewards.dtype == np.float64
-            assert isinstance(terminations, np.ndarray)
-            assert terminations.dtype == np.bool_
-            assert isinstance(truncations, np.ndarray)
-            assert truncations.dtype == np.bool_
+            assert rewards.shape == (4,)
+            assert terminations.shape == (4,)
+            assert truncations.shape == (4,)
             if np.any(terminations) or np.any(truncations):
-                # Next step forces the autoreset worker path for ended envs.
                 _obs, rewards, terminations, truncations, _infos = envs.step(
                     envs.action_space.sample()
                 )
-                assert isinstance(rewards, np.ndarray)
                 assert rewards.shape == (4,)
                 assert terminations.shape == (4,)
                 assert truncations.shape == (4,)

--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -495,9 +495,7 @@ def _make_array_reward_env(episode_length: int):
 
         return GenericTestEnv(
             action_space=Discrete(2),
-            observation_space=Box(
-                low=-1.0, high=1.0, shape=(2,), dtype=np.float32
-            ),
+            observation_space=Box(low=-1.0, high=1.0, shape=(2,), dtype=np.float32),
             reset_func=reset_func,
             step_func=step_func,
         )

--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -472,3 +472,45 @@ def test_async_vector_subenv_error():
         caught_warnings[4].message.args[0]
         == "\x1b[31mERROR: Raising the last exception back to the main process.\x1b[0m"
     )
+
+
+@pytest.mark.parametrize("shared_memory", [True, False])
+def test_async_vector_env_next_step_autoreset_homogeneous_types(shared_memory):
+    """Autoreset path must return numpy-compatible reward/done types (issue #1445).
+
+    When only some workers take the NEXT_STEP autoreset branch, mixing Python
+    ints/bools with numpy scalars from normal steps made np.array(...) raise
+    due to inhomogeneous sequences.
+    """
+    env_fns = [make_env("CartPole-v1", i) for i in range(4)]
+    envs = AsyncVectorEnv(
+        env_fns,
+        shared_memory=shared_memory,
+        autoreset_mode=AutoresetMode.NEXT_STEP,
+    )
+    try:
+        envs.reset(seed=0)
+        # Drive until at least one env ends so the next step uses the autoreset branch.
+        for _ in range(500):
+            actions = envs.action_space.sample()
+            _obs, rewards, terminations, truncations, _infos = envs.step(actions)
+            assert isinstance(rewards, np.ndarray)
+            assert rewards.dtype == np.float64
+            assert isinstance(terminations, np.ndarray)
+            assert terminations.dtype == np.bool_
+            assert isinstance(truncations, np.ndarray)
+            assert truncations.dtype == np.bool_
+            if np.any(terminations) or np.any(truncations):
+                # Next step forces the autoreset worker path for ended envs.
+                _obs, rewards, terminations, truncations, _infos = envs.step(
+                    envs.action_space.sample()
+                )
+                assert isinstance(rewards, np.ndarray)
+                assert rewards.shape == (4,)
+                assert terminations.shape == (4,)
+                assert truncations.shape == (4,)
+                break
+        else:
+            pytest.fail("CartPole did not terminate within 500 steps for any env")
+    finally:
+        envs.close()


### PR DESCRIPTION
## Description

In `AsyncVectorEnv` with `AutoresetMode.NEXT_STEP`, workers that are autoresetting return a **scalar** zero reward while siblings may still return **ndarray** rewards (for example length-1 `float32` vectors from custom envs).

`step_wait` then did `np.array(rewards, dtype=np.float64)`, which raises:

```text
ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape ...
```

This is the failure reported in #1445. (Standard CartPole scalar rewards already stack on main; they do **not** reproduce the issue.)

**Fix:** batch rewards through `_batch_rewards()`, which broadcasts autoreset scalar zeros onto the shared non-scalar reward shape before stacking.

## Related Issue

Fixes #1445

## How Has This Been Tested?

- `tests/vector/test_async_vector_env.py::test_async_vector_env_next_step_autoreset_array_reward` (shared_memory True/False)
  - **Fails on current main** with the inhomogeneous-shape `ValueError`
  - **Passes with this PR**
- `tests/vector/test_async_vector_env.py::test_async_vector_env_next_step_autoreset_scalar_reward` — CartPole scalar smoke test
- Local numpy 2.3.x / macOS arm64 / Python 3.13

## Checklist

- [x] I have commented my code where helpful
- [x] I have added tests that prove my fix is effective (red on main, green here)
- [x] New and existing unit tests pass locally with my changes (aside from pre-existing pygame-missing render/call tests in this environment)