### PR TITLE
Add external environment Ignis

### DIFF
--- a/docs/environments/third_party_environments.md
+++ b/docs/environments/third_party_environments.md
@@ -131,6 +131,13 @@ goal-RL ([Gymnasium-Robotics](https://robotics.farama.org/)).
 
   A Gymnasium-compatible wildfire simulation environment that models fire spread using physics-based dynamics and incorporates helicopter firefighting strategies. It's built on real terrain data, including land cover and elevation, and supports customizable observation and reward wrappers.
 
+- [Ignis: 3D Structural & Wildfire Fire Suppression](https://github.com/Tyronita/ignis)
+
+  ![Gymnasium version dependency](https://img.shields.io/badge/Gymnasium-v1.0.0-blue)
+  ![GitHub stars](https://img.shields.io/github/stars/Tyronita/ignis)
+
+  A Gymnasium environment for fire suppression that extends cellular-automaton wildfire RL to 3D indoor / structural fire. A single JSON scene config (geometry, obstacles, materials, ignition, budgets) defines the world; `Ignis-Indoor-v0` operates zoned ceiling sprinklers to contain a fire spreading through a 3D voxel building, while `Ignis-Wildfire-v0` is a 2D wildfire air-tanker variant. It is pure-NumPy and CPU-only, ships CEM and PPO baselines, and includes evacuation and safe-building-design tooling.
+
 ### Game environments
 *Board Games, Video Games and all other interactive entertainment mediums.*
 


### PR DESCRIPTION
Adds **Ignis** to the *Environmental / Climate* third-party environments list (alphabetically after FirecastRL).

Ignis is a Gymnasium environment for **fire suppression** that extends cellular-automaton wildfire RL to **3D indoor / structural fire**:

- `Ignis-Indoor-v0` — an agent operates zoned ceiling sprinklers to contain a fire spreading through a 3D voxel building (rooms, walls, doors, materials, buoyancy).
- `Ignis-Wildfire-v0` — a 2D wildfire air-tanker variant.

Details:
- Pure **NumPy, CPU-only**; `pip install`-able (`pyproject.toml`) and auto-registers via a `gymnasium.envs` entry point.
- **Gymnasium 1.0 compatible**; passes `stable_baselines3.common.env_checker.check_env`.
- Standard `Discrete` action / `Box` observation; **CEM and PPO** baselines included; a greedy oracle solves it (100%).
- Repo: https://github.com/Tyronita/ignis

Followed the template and instructions in the file. Happy to reach out on Discord as suggested — opening the PR here as the docs instruct.
