### PR TITLE
Add tests for performance utilities

### DIFF
--- a/tests/utils/test_performance.py
+++ b/tests/utils/test_performance.py
@@ -1,0 +1,42 @@
+from unittest.mock import Mock, call
+
+import pytest
+
+from gymnasium.utils import performance
+
+
+def mock_time(monkeypatch):
+    timestamps = iter([0.0, 0.0, 1.0, 1.0])
+    monkeypatch.setattr(performance.time, "time", lambda: next(timestamps, 1.0))
+
+
+@pytest.mark.parametrize(("terminated", "truncated"), [(True, False), (False, True)])
+def test_benchmark_step_resets_finished_env(monkeypatch, terminated, truncated):
+    env = Mock()
+    env.step.side_effect = [
+        (None, 0.0, False, False, {}),
+        (None, 0.0, terminated, truncated, {}),
+    ]
+    mock_time(monkeypatch)
+
+    assert performance.benchmark_step(env, target_duration=0, seed=123) == 2
+    assert env.reset.call_args_list == [call(seed=123), call()]
+    assert env.action_space.sample.call_count == 3
+
+
+def test_benchmark_init(monkeypatch):
+    envs = [Mock(), Mock()]
+    env_lambda = Mock(side_effect=envs)
+    mock_time(monkeypatch)
+
+    assert performance.benchmark_init(env_lambda, target_duration=0, seed=123) == 2
+    for env in envs:
+        env.reset.assert_called_once_with(seed=123)
+
+
+def test_benchmark_render(monkeypatch):
+    env = Mock()
+    mock_time(monkeypatch)
+
+    assert performance.benchmark_render(env, target_duration=0) == 2
+    assert env.render.call_count == 2


### PR DESCRIPTION
this PR is 100% certified GPT slop, but it is useful to prevent any weird regressions

## Summary

- add deterministic tests for `benchmark_step`, `benchmark_init`, and `benchmark_render`
- verify throughput counting, seed propagation, finished-environment resets, and helper call counts
- cover both terminated and truncated step results

## Why

The existing performance utilities had no automated tests. Mocking the clock keeps the coverage fast and deterministic while catching regressions in their control flow.

## Validation

- `pytest -q tests/utils/test_performance.py` (4 passed)
- `ruff check tests/utils/test_performance.py`
- `ruff format --check tests/utils/test_performance.py`
