### PR TITLE
perf(utils): reduce benchmark timing calls

### DIFF
--- a/gymnasium/utils/performance.py
+++ b/gymnasium/utils/performance.py
@@ -41,8 +41,8 @@ def benchmark_step(
         if terminal or truncated:
             env.reset()
 
-        if time.time() - start > target_duration:
-            end = time.time()
+        end = time.time()
+        if end - start > target_duration:
             break
 
     length = end - start
@@ -71,8 +71,8 @@ def benchmark_init(
         env = env_lambda()
         env.reset(seed=seed)
 
-        if time.time() - start > target_duration:
-            end = time.time()
+        end = time.time()
+        if end - start > target_duration:
             break
     length = end - start
 
@@ -96,8 +96,8 @@ def benchmark_render(env: gymnasium.Env, target_duration: int = 5) -> float:
         renders += 1
         env.render()
 
-        if time.time() - start > target_duration:
-            end = time.time()
+        end = time.time()
+        if end - start > target_duration:
             break
     length = end - start
 


### PR DESCRIPTION
A very minor fix, proposed by copliot

## Summary

- Read the clock once per loop iteration in `benchmark_step`, `benchmark_init`, and `benchmark_render`.
- Reuse that timestamp for both the duration check and final throughput calculation.

## Rationale

Each benchmark previously called `time.time()` twice on its final iteration. The extra call adds avoidable overhead to timing-sensitive loops and makes the reported elapsed time differ from the timestamp used to stop the benchmark.

This is a focused follow-up to the same review finding in #1640, kept separate so that PR remains scoped to the new vector benchmark.

## Impact

There are no API changes. Each benchmark performs one fewer clock read on its final iteration.

## Validation

- `pytest -q tests/utils` (`107 passed, 1 skipped`)
- `ruff check gymnasium/utils/performance.py`
- `ruff format --check gymnasium/utils/performance.py`
- `git diff --check`
