### PR TITLE
Fix Text space accepting multi-character charset elements

### DIFF
--- a/gymnasium/spaces/text.py
+++ b/gymnasium/spaces/text.py
@@ -46,7 +46,11 @@ class Text(Space[str]):
             min_length (int): Minimum text length (in characters). Defaults to 1 to prevent empty strings.
             max_length (int): Maximum text length (in characters).
             charset (Union[set], str): Character set, defaults to the lower and upper english alphabet plus latin digits.
+                Each element must be a single character.
             seed: The seed for sampling from the space.
+
+        Raises:
+            ValueError: If any element of ``charset`` is not a single character.
         """
         if not np.issubdtype(type(min_length), np.integer):
             raise TypeError(
@@ -75,6 +79,16 @@ class Text(Space[str]):
         else:
             # Preserve the given ordering, dropping duplicate characters
             char_list = list(dict.fromkeys(charset))
+
+        # Each element of the charset must be a single character, otherwise `sample`
+        # concatenates multi-character elements and produces strings that are longer
+        # than `max_length` and that `contains` rejects.
+        invalid_chars = [char for char in char_list if len(char) != 1]
+        if invalid_chars:
+            raise ValueError(
+                "Expects all charset elements to be a single character, actual invalid "
+                f"elements: {invalid_chars}"
+            )
 
         self._char_set: frozenset[str] = frozenset(char_list)
         self._char_list: tuple[str, ...] = tuple(char_list)

--- a/tests/spaces/test_text.py
+++ b/tests/spaces/test_text.py
@@ -94,6 +94,38 @@ def test_charset_ordering():
     assert [space.character_index(c) for c in "dcba"] == [0, 1, 2, 3]
 
 
+def test_multi_character_charset_raises():
+    # GH 1317: charset elements longer than one character were accepted, and then
+    # `sample` concatenated whole elements, producing strings longer than
+    # `max_length` that `contains` rejected.
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Expects all charset elements to be a single character, actual invalid "
+            "elements: ['fly', 'sit', 'walk']"
+        ),
+    ):
+        Text(1, charset=frozenset(["sit", "walk", "fly"]))
+
+    # sequences keep their given order, so the reported elements follow it
+    with pytest.raises(
+        ValueError, match=re.escape("actual invalid elements: ['ab', 'cd']")
+    ):
+        Text(3, charset=["ab", "cd"])
+
+    # the empty string is not a character either
+    with pytest.raises(ValueError, match=re.escape("actual invalid elements: ['']")):
+        Text(3, charset=frozenset(["a", ""]))
+
+    # single-character charsets are unaffected and keep the Space contract
+    for charset in [frozenset("abc"), "abc"]:
+        space = Text(3, charset=charset)
+        for _ in range(10):
+            sample = space.sample()
+            assert space.contains(sample)
+            assert len(sample) <= space.max_length
+
+
 def test_deterministic_across_hash_seeds():
     """Seeded samples and flatten encodings must not depend on PYTHONHASHSEED.
 


### PR DESCRIPTION
# Description

`Text` validates its length bounds but never checks that each `charset` element is a single character. Because `sample` joins whole elements, a multi-character charset produces strings that are longer than `max_length` and that `contains` then rejects:

```python
>>> from gymnasium.spaces import Text
>>> space = Text(max_length=3, charset=frozenset(["ab", "cd"]))
>>> space.seed(0)
>>> sample = space.sample()
>>> sample
'cdcdcd'
>>> len(sample), space.max_length
(6, 3)
>>> space.contains(sample)
False
```

So `space.contains(space.sample())` is `False` — the invariant `tests/spaces/test_spaces.py::test_sample_contains` asserts for every registered space. It never fired because every `Text` space in `tests/spaces/utils.py` uses a single-character charset. The reporter's original case is the same defect with `max_length=1`, where the space additionally reprs as `Text(1, 1, charset=flysitwalk)`.

This PR raises a `ValueError` at construction rather than adding multi-character support, following your comment on #1317:

> The intention is that each element of the `charset` has length == 1.

That intention wasn't enforced or documented, so the only signal a user got was a sampled value their own space rejected. The empty string is rejected by the same check, since it also can't round-trip through `contains` when `min_length >= 1`. Single-character charsets, given either as a string or as a set, are unaffected — there's an assertion in the test covering that.

Fixes #1317

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Strictly speaking this turns three previously-silent constructions into errors: multi-character elements, and the empty string. Anything relying on that was already producing samples outside its own space, so I've treated it as a bug fix rather than a breaking change — happy to be corrected. Nothing in `gymnasium/` or `tests/` constructs a `Text` with a multi-character charset, so nothing in-tree changes behaviour.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Testing

`test_multi_character_charset_raises` in `tests/spaces/test_text.py` fails on `main` with `Failed: DID NOT RAISE ValueError` and passes with the change. It covers the set path, the sequence path (which reports elements in the given order), the empty string, and — to confirm the fix isn't over-broad — that single-character charsets still satisfy `contains(sample())` and the `max_length` bound.

`tests/spaces/` is green: 1332 passed. Across the wider suite I get 86 failures both with and without this change (byte-identical lists), all from optional dependencies missing locally — Box2D, pygame, moviepy — so none are related. `pre-commit run --all-files` passes clean, including `ty`.

One aside in case it's useful: running the `ty` hook leaves a `uv.lock` in the repo root, and it isn't in `.gitignore`, so it shows up as untracked after a `pre-commit run --all-files`.
