### PR TITLE
Fix AsyncVectorEnv crash on autoreset with non-scalar rewards

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -512,11 +512,29 @@ class AsyncVectorEnv(VectorEnv):
             )
 
         self._state = AsyncState.DEFAULT
+
+        # Build these the way `SyncVectorEnv` does -- preallocate, then assign
+        # per sub-environment -- rather than `np.array(list_of_values)`.
+        # On an autoreset step the worker substitutes the scalars `0`, `False`,
+        # `False`, so a list-based conversion sees a mix of those scalars and
+        # whatever the environment actually returns. If an environment returns a
+        # single-element array reward (shape `(1,)`), that list is inhomogeneous
+        # and NumPy raises, even though `SyncVectorEnv` accepts the same
+        # environment. Per-index assignment coerces each value identically to
+        # `SyncVectorEnv`, so both vector backends now behave the same.
+        rewards_arr = np.zeros((self.num_envs,), dtype=np.float64)
+        terminations_arr = np.zeros((self.num_envs,), dtype=np.bool_)
+        truncations_arr = np.zeros((self.num_envs,), dtype=np.bool_)
+        for i in range(self.num_envs):
+            rewards_arr[i] = rewards[i]
+            terminations_arr[i] = terminations[i]
+            truncations_arr[i] = truncations[i]
+
         return (
             deepcopy(self.observations) if self.copy else self.observations,
-            np.array(rewards, dtype=np.float64),
-            np.array(terminations, dtype=np.bool_),
-            np.array(truncations, dtype=np.bool_),
+            rewards_arr,
+            terminations_arr,
+            truncations_arr,
             infos,
         )
 

--- a/tests/vector/test_autoreset_mode.py
+++ b/tests/vector/test_autoreset_mode.py
@@ -341,3 +341,67 @@ def test_same_step_final_obs(obs_space):
     obs, rewards, terminations, truncations, info = envs.step([1, 2, 3])
     assert info["final_obs"][1] in envs.single_observation_space
     assert info["final_obs"][2] in envs.single_observation_space
+
+
+def single_element_reward_reset(
+    self: GenericTestEnv, seed: int | None = None, options: dict | None = None
+):
+    super(GenericTestEnv, self).reset(seed=seed)
+
+    self.count = 0
+    return self.count, {}
+
+
+def single_element_reward_step(self: GenericTestEnv, action: int):
+    self.count += 1
+    # A reward of shape (1,) rather than a bare scalar. `SyncVectorEnv` assigns
+    # this into its preallocated reward buffer without complaint, so
+    # `AsyncVectorEnv` must accept it too.
+    reward = np.array([1.0], dtype=np.float32)
+    return self.count, reward, self.count >= self.max_count, False, {}
+
+
+@pytest.mark.parametrize(
+    "vectoriser",
+    [
+        SyncVectorEnv,
+        AsyncVectorEnv,
+        partial(AsyncVectorEnv, shared_memory=False),
+    ],
+    ids=["Sync", "Async(shared_memory=True)", "Async(shared_memory=False)"],
+)
+def test_autoreset_next_step_non_scalar_reward(vectoriser):
+    """Environments returning a shape-(1,) reward must survive an autoreset step.
+
+    On an autoreset step the worker substitutes the scalar `0` for the reward.
+    Building the batch with `np.array([...])` then mixes a shape-(1,) array with
+    a scalar, which NumPy rejects as inhomogeneous -- so `AsyncVectorEnv` raised
+    while `SyncVectorEnv`, which assigns per index, did not.
+
+    Regression test for #1445.
+    """
+    envs = vectoriser(
+        [
+            lambda: GenericTestEnv(
+                action_space=Discrete(5),
+                observation_space=Discrete(5),
+                reset_func=single_element_reward_reset,
+                step_func=single_element_reward_step,
+            )
+            for _ in range(2)
+        ],
+        autoreset_mode=AutoresetMode.NEXT_STEP,
+    )
+    # Staggered horizons, so one sub-env autoresets while the other steps.
+    envs.set_attr("max_count", [2, 3])
+    envs.reset(seed=0)
+
+    for _ in range(4):
+        _, reward, terminated, truncated, _ = envs.step(envs.action_space.sample())
+
+        assert reward.shape == (2,), reward.shape
+        assert reward.dtype == np.float64, reward.dtype
+        assert terminated.shape == (2,) and terminated.dtype == np.bool_
+        assert truncated.shape == (2,) and truncated.dtype == np.bool_
+
+    envs.close()


### PR DESCRIPTION
Closes #1445.

## The bug

On a `NEXT_STEP` autoreset, `_async_worker` substitutes scalars for the environment's return values:

```python
reward, terminated, truncated = 0, False, False
```

`step_wait` then batches the per-env results with `np.array(rewards, dtype=np.float64)`. If an environment returns a reward of shape `(1,)` rather than a bare scalar, that list contains a shape-`(1,)` array *and* a Python `int`, which NumPy rejects:

```
ValueError: setting an array element with a sequence. The requested array has an
inhomogeneous shape after 1 dimensions.
```

## Why this looks like a bug rather than a restriction

`SyncVectorEnv` does **not** have this problem. It assigns into a preallocated buffer (`self._rewards[i] = ...`), so each value is coerced independently and a shape-`(1,)` reward is accepted. The same environment therefore works under `SyncVectorEnv` and crashes under `AsyncVectorEnv`:

| reward returned by env | `SyncVectorEnv` | `AsyncVectorEnv` (before) |
|---|---|---|
| 0-d array | works | works |
| **shape `(1,)`** | **works** | **`ValueError`** |
| shape `(2,)` | fails | fails |

Reproduced on `main` at 1.3.0, both `shared_memory=True` and `False`.

## The fix

Build the reward, termination and truncation batches the way `SyncVectorEnv` does — preallocate, then assign per sub-environment — so the two backends agree by construction.

## Scope

This deliberately does **not** add support for genuinely multi-element rewards: a shape-`(2,)` reward still raises under both backends, exactly as before. Making that work would be an API change rather than a bug fix, so it seemed out of scope here.

## Testing

Added `test_autoreset_next_step_non_scalar_reward` to `tests/vector/test_autoreset_mode.py`, parametrized over `Sync` / `Async(shared_memory=True)` / `Async(shared_memory=False)` in the style of the surrounding tests.

Without the fix it **fails on both Async variants and passes on Sync**, which is precisely the divergence being corrected.

`tests/vector/` is otherwise unaffected: 1448 passing. Five tests fail both with and without this change — they need Box2D and a rendering backend that aren't installed locally, and three of them are in `test_sync_vector_env.py`, which this change does not touch.

`pre-commit` (ruff check + ruff format) is clean.

---

*Disclosure: this fix was developed with AI assistance. The diagnosis, patch and test were reviewed before submission, and I'm happy to explain or revise any part of it.*
