### PR TITLE
Save correct constructor kwargs in AddRenderObservation (spec reconstruction TypeError)

### DIFF
--- a/gymnasium/wrappers/transform_observation.py
+++ b/gymnasium/wrappers/transform_observation.py
@@ -703,8 +703,8 @@ class AddRenderObservation(
         """
         gym.utils.RecordConstructorArgs.__init__(
             self,
-            pixels_only=render_only,
-            pixels_key=render_key,
+            render_only=render_only,
+            render_key=render_key,
             obs_key=obs_key,
         )
 

--- a/tests/wrappers/test_add_render_observation.py
+++ b/tests/wrappers/test_add_render_observation.py
@@ -94,3 +94,28 @@ def test_single_array_observation(pixels_only):
     # assert rendered_obs.shape == (height, width, 3)
     assert rendered_obs.ndim == 3
     assert rendered_obs.dtype == np.uint8
+
+
+def test_record_constructor_args_roundtrip():
+    """Saved constructor args must match the wrapper's own parameter names.
+
+    ``RecordConstructorArgs`` stores these kwargs into the env spec, and
+    reconstructing a wrapped env splats them back into ``__init__``. If the
+    saved names differ from the parameters, that reconstruction raises
+    ``TypeError``.
+    """
+
+    def make_env():
+        return GenericTestEnv(
+            observation_space=spaces.Box(shape=(2,), low=-1, high=1, dtype=np.float32),
+            render_mode="rgb_array",
+            render_func=image_render_func,
+        )
+
+    wrapped_env = AddRenderObservation(make_env(), render_only=True)
+
+    saved_kwargs = wrapped_env._saved_kwargs
+    assert set(saved_kwargs) == {"render_only", "render_key", "obs_key"}
+
+    # Reconstruction (as performed from the env spec) must not raise.
+    AddRenderObservation(make_env(), **saved_kwargs)


### PR DESCRIPTION
## Summary

`AddRenderObservation.__init__` accepts `render_only` / `render_key` / `obs_key`, but records **stale** keyword names (`pixels_only` / `pixels_key`, left over from the former `PixelObservationWrapper`) via `RecordConstructorArgs`:

```python
def __init__(self, env, render_only=True, render_key="pixels", obs_key="state"):
    gym.utils.RecordConstructorArgs.__init__(
        self,
        pixels_only=render_only,   # <-- should be render_only=render_only
        pixels_key=render_key,     # <-- should be render_key=render_key
        obs_key=obs_key,
    )
```

## Impact

`RecordConstructorArgs` stores these kwargs, and they end up on the env spec (`WrapperSpec.kwargs`). When a wrapped env is reconstructed from its spec, the kwargs are splatted back into `__init__` (`registration.py`: `load_env_creator(...)(env=env, **wrapper_spec.kwargs)`). Because the saved names don't match the parameters, reconstruction raises:

```
TypeError: AddRenderObservation.__init__() got an unexpected keyword argument 'pixels_only'
```

Every sibling wrapper in this module records with matching names (e.g. `GrayscaleObservation` → `keep_dim=keep_dim`), confirming this is a rename slip rather than intent.

## Fix

Record the actual parameter names:

```diff
-            pixels_only=render_only,
-            pixels_key=render_key,
+            render_only=render_only,
+            render_key=render_key,
```

## Tests

Added `test_record_constructor_args_roundtrip`, which builds the wrapper and reconstructs it from its saved constructor args. It fails on the previous behavior (`TypeError` / wrong saved names) and passes with the fix. Full `tests/wrappers/test_add_render_observation.py` passes (5 tests).
