### PR TITLE
Fix incorrect argument examples in Mountain Car and Pendulum docs.

### DIFF
--- a/gymnasium/envs/classic_control/mountain_car.py
+++ b/gymnasium/envs/classic_control/mountain_car.py
@@ -87,11 +87,11 @@ class MountainCarEnv(gym.Env):
 
     ```python
     >>> import gymnasium as gym
-    >>> env = gym.make("MountainCar-v0", render_mode="rgb_array", goal_velocity=0.1)  # default goal_velocity=0
+    >>> env = gym.make("MountainCar-v0", render_mode="rgb_array", goal_velocity=0.05)  # default goal_velocity=0
     >>> env
     <TimeLimit<OrderEnforcing<PassiveEnvChecker<MountainCarEnv<MountainCar-v0>>>>>
-    >>> env.reset(seed=123, options={"x_init": np.pi/2, "y_init": 0.5})  # default x_init=np.pi, y_init=1.0
-    (array([-0.46352962,  0.        ], dtype=float32), {})
+    >>> env.reset(seed=123, options={"low": -0.7, "high": 0.5})  # default low=-0.6, high=-0.5
+    (array([0.11882224, 0.        ], dtype=float32), {})
 
     ```
 

--- a/gymnasium/envs/classic_control/pendulum.py
+++ b/gymnasium/envs/classic_control/pendulum.py
@@ -83,8 +83,8 @@ class PendulumEnv(gym.Env):
     >>> env = gym.make("Pendulum-v1", render_mode="rgb_array", g=9.81)  # default g=10.0
     >>> env
     <TimeLimit<OrderEnforcing<PassiveEnvChecker<PendulumEnv<Pendulum-v1>>>>>
-    >>> env.reset(seed=123, options={"low": -0.7, "high": 0.5})  # default low=-0.6, high=-0.5
-    (array([ 0.4123625 ,  0.91101986, -0.89235795], dtype=float32), {})
+    >>> env.reset(seed=123, options={"x_init": np.pi/2, "y_init": 0.5})  # default x_init=np.pi, y_init=1.0
+    (array([ 0.8403459 ,  0.54205054, -0.44617897], dtype=float32), {})
 
     ```
 


### PR DESCRIPTION
… (#1659)

# Description

Correct the Classic Control argument examples in the documents.

  - Use `low` and `high` for MountainCar reset bounds.
  - Use `x_init` and `y_init` for Pendulum reset bounds.
  - Replace MountainCar's unattainable `goal_velocity=0.1` with `goal_velocity=0.05`.
  - Update the seeded reset outputs. 

Motivation: improving documentation.

Dependencies required: None.

Fixes #1659 

## Type of change

Please delete options that are not relevant.

- [x] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots


| Before | After |
| ------ | ----- |
| <img width="857" height="150" alt="image" src="https://github.com/user-attachments/assets/2a7656a3-1bec-421e-a795-b5043d631867" /> | <img width="853" height="151" alt="image" src="https://github.com/user-attachments/assets/4b9e1885-9339-4c00-b1fe-48c1e5ed52e2" /> |
| <img width="801" height="146" alt="image" src="https://github.com/user-attachments/assets/59d91bfb-2f8a-494b-ba45-ac0e8771334b" /> | <img width="858" height="164" alt="image" src="https://github.com/user-attachments/assets/f806112b-84aa-4831-b3fd-eea778836cc8" /> |


<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
