### PR TITLE
Fix Box.contains raising OverflowError for out-of-dtype ints

### DIFF
--- a/gymnasium/spaces/box.py
+++ b/gymnasium/spaces/box.py
@@ -483,7 +483,7 @@ class Box(Space[NDArray[_ScalarT_co]]):
             gym.logger.warn("Casting input x to numpy array.")
             try:
                 x = np.asarray(x, dtype=self.dtype)
-            except (ValueError, TypeError):
+            except (ValueError, TypeError, OverflowError):
                 return False
 
         return bool(

--- a/tests/spaces/test_box.py
+++ b/tests/spaces/test_box.py
@@ -296,6 +296,28 @@ def test_contains_dtype():
 
 
 @pytest.mark.parametrize(
+    "dtype, element",
+    [
+        (np.int8, 300),
+        (np.int8, -300),
+        (np.uint8, -1),
+        (np.uint8, 300),
+        (np.int64, 10**20),
+    ],
+)
+def test_contains_out_of_dtype_range_returns_false(dtype, element):
+    """A value outside the space dtype's range is not a member, not an error.
+
+    Regression: ``Box.contains([300, 0])`` on an ``int8`` space cast the input
+    to the space's dtype before the membership check; on numpy 2.x that cast
+    raised ``OverflowError`` instead of returning ``False`` (companion to the
+    ``Discrete.contains`` fix in #1648).
+    """
+    space = Box(low=0, high=10, shape=(2,), dtype=dtype)
+    assert space.contains([element, 0]) is False
+
+
+@pytest.mark.parametrize(
     "low, high, shape",
     [
         (0, np.inf, (2,)),


### PR DESCRIPTION
# Description

`Box.contains(x)` raises `OverflowError` instead of returning `False` when `x` is a Python `int` (or list of ints) outside the range representable by the space's dtype:

```python
import numpy as np
from gymnasium.spaces import Box
Box(low=0, high=10, shape=(2,), dtype=np.int8).contains([300, 0])
# OverflowError: Python integer 300 out of bounds for int8
```

When `x` is not already an ndarray, `contains` normalizes it via `np.asarray(x, dtype=self.dtype)`. On numpy 2.x that cast raises `OverflowError` for out-of-dtype ints, which propagates instead of being treated as "not a member". Since a value that doesn't fit the space's dtype cannot be a member, `contains` should return `False`.

The fix adds `OverflowError` to the existing `except (ValueError, TypeError)` guard around the cast, and adds a regression test. This mirrors the just-merged #1648, which fixed the same input-cast overflow in `Discrete.contains`.

Verified: fails on `main` (`OverflowError` at `box.py:485`), passes with the fix; full `tests/spaces/test_box.py` green (116 passed) on Python 3.12 / numpy 2.5.2.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the `pre-commit` checks with `pre-commit run --all-files`
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---

<sub>Disclosure, for the record: Claude Code helped spot this and draft the fix/test; I reproduced and verified it myself.</sub>
