### PR TITLE
Record the constructor arguments missing from five wrappers

### DIFF
--- a/gymnasium/wrappers/common.py
+++ b/gymnasium/wrappers/common.py
@@ -496,7 +496,9 @@ class RecordEpisodeStatistics(
             buffer_length: The size of the buffers :attr:`return_queue`, :attr:`length_queue` and :attr:`time_queue`
             stats_key: The info key for the episode statistics
         """
-        gym.utils.RecordConstructorArgs.__init__(self)
+        gym.utils.RecordConstructorArgs.__init__(
+            self, buffer_length=buffer_length, stats_key=stats_key
+        )
         gym.Wrapper.__init__(self, env)
 
         self._stats_key = stats_key

--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -271,7 +271,9 @@ class RecordVideo(
             step_trigger=step_trigger,
             video_length=video_length,
             name_prefix=name_prefix,
+            fps=fps,
             disable_logger=disable_logger,
+            gc_trigger=gc_trigger,
         )
         gym.Wrapper.__init__(self, env)
 

--- a/gymnasium/wrappers/stateful_action.py
+++ b/gymnasium/wrappers/stateful_action.py
@@ -64,33 +64,40 @@ class StickyAction(
                 f"`repeat_action_probability` should be in the interval [0,1). Received {repeat_action_probability}"
             )
 
+        # The pair of bounds that the number of repeats is drawn from.
+        # `repeat_action_duration` keeps the value the caller gave, which is what
+        # `RecordConstructorArgs` stores for the env spec.
         if isinstance(repeat_action_duration, int):
-            repeat_action_duration = (repeat_action_duration, repeat_action_duration)
+            duration_range = (repeat_action_duration, repeat_action_duration)
+        else:
+            duration_range = repeat_action_duration
 
-        if not isinstance(repeat_action_duration, tuple):
+        if not isinstance(duration_range, tuple):
             raise ValueError(
-                f"`repeat_action_duration` should be either an integer or a tuple. Received {repeat_action_duration}"
+                f"`repeat_action_duration` should be either an integer or a tuple. Received {duration_range}"
             )
-        elif len(repeat_action_duration) != 2:
+        elif len(duration_range) != 2:
             raise ValueError(
-                f"`repeat_action_duration` should be a tuple or a list of two integers. Received {repeat_action_duration}"
+                f"`repeat_action_duration` should be a tuple or a list of two integers. Received {duration_range}"
             )
-        elif repeat_action_duration[0] > repeat_action_duration[1]:
+        elif duration_range[0] > duration_range[1]:
             raise InvalidBound(
-                f"`repeat_action_duration` is not a valid bound. Received {repeat_action_duration}"
+                f"`repeat_action_duration` is not a valid bound. Received {duration_range}"
             )
-        elif np.any(np.array(repeat_action_duration) < 1):
+        elif np.any(np.array(duration_range) < 1):
             raise ValueError(
-                f"`repeat_action_duration` should be larger or equal than 1. Received {repeat_action_duration}"
+                f"`repeat_action_duration` should be larger or equal than 1. Received {duration_range}"
             )
 
         gym.utils.RecordConstructorArgs.__init__(
-            self, repeat_action_probability=repeat_action_probability
+            self,
+            repeat_action_probability=repeat_action_probability,
+            repeat_action_duration=repeat_action_duration,
         )
         gym.ActionWrapper.__init__(self, env)
 
         self.repeat_action_probability = repeat_action_probability
-        self.repeat_action_duration_range = repeat_action_duration
+        self.repeat_action_duration_range = duration_range
 
         self.last_action: ActType | None = None
         self.is_sticky_actions: bool = False  # if sticky actions are taken

--- a/gymnasium/wrappers/transform_action.py
+++ b/gymnasium/wrappers/transform_action.py
@@ -274,7 +274,9 @@ class DiscretizeAction(
             )
 
         self.multidiscrete = multidiscrete
-        gym.utils.RecordConstructorArgs.__init__(self, bins=bins)
+        gym.utils.RecordConstructorArgs.__init__(
+            self, bins=bins, multidiscrete=multidiscrete
+        )
         gym.ActionWrapper.__init__(self, env)
 
         if isinstance(bins, int):

--- a/gymnasium/wrappers/transform_observation.py
+++ b/gymnasium/wrappers/transform_observation.py
@@ -836,7 +836,9 @@ class DiscretizeObservation(
             )
 
         self.multidiscrete = multidiscrete
-        gym.utils.RecordConstructorArgs.__init__(self, bins=bins)
+        gym.utils.RecordConstructorArgs.__init__(
+            self, bins=bins, multidiscrete=multidiscrete
+        )
         gym.ObservationWrapper.__init__(self, env)
 
         if isinstance(bins, int):

--- a/tests/wrappers/test_record_constructor_args.py
+++ b/tests/wrappers/test_record_constructor_args.py
@@ -1,0 +1,103 @@
+"""Test suite for the constructor arguments that wrappers save for `Wrapper.spec`."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+import pytest
+
+import gymnasium as gym
+from gymnasium.utils import RecordConstructorArgs
+
+# `vector` is the sub-module of vector wrappers, not a wrapper. Vector wrappers are
+# excluded because `VectorWrapper.spec` forwards the spec of the wrapped environment
+# rather than adding a `WrapperSpec`.
+WRAPPER_NAMES = [name for name in gym.wrappers.__all__ if name != "vector"]
+
+
+def recorded_argument_names(wrapper: type) -> set[str]:
+    """The keyword names that `wrapper.__init__` passes on to `RecordConstructorArgs.__init__`."""
+    tree = ast.parse(textwrap.dedent(inspect.getsource(wrapper.__init__)))
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "__init__"
+            and "RecordConstructorArgs" in ast.unparse(node.func)
+        ):
+            return {
+                keyword.arg
+                for keyword in node.keywords
+                if keyword.arg != "_disable_deepcopy"
+            }
+
+    raise AssertionError(
+        f"{wrapper.__name__}.__init__ does not call RecordConstructorArgs.__init__"
+    )
+
+
+def constructor_argument_names(wrapper: type) -> set[str]:
+    """The named parameters of `wrapper.__init__`, other than `self` and the wrapped environment."""
+    parameters = inspect.signature(wrapper.__init__).parameters
+    return {
+        name
+        for name, parameter in parameters.items()
+        if name not in ("self", "env")
+        and parameter.kind not in (parameter.VAR_POSITIONAL, parameter.VAR_KEYWORD)
+    }
+
+
+@pytest.mark.parametrize(
+    "wrapper_name",
+    [
+        (
+            pytest.param(
+                name,
+                marks=pytest.mark.xfail(
+                    strict=True,
+                    reason="Array API namespaces are modules, which RecordConstructorArgs cannot deepcopy",
+                ),
+            )
+            if name == "ArrayConversion"
+            else name
+        )
+        for name in WRAPPER_NAMES
+    ],
+)
+def test_wrappers_record_every_constructor_argument(wrapper_name: str):
+    """Every constructor argument of a wrapper is passed on to `RecordConstructorArgs`.
+
+    `Wrapper.spec` puts the saved arguments into a `WrapperSpec`, and `gym.make`
+    splats them back into the constructor when an environment is rebuilt from its
+    spec. An argument that is never recorded is dropped by that round trip, and an
+    argument recorded under a name the constructor does not take raises `TypeError`.
+    """
+    try:
+        wrapper = getattr(gym.wrappers, wrapper_name)
+    except gym.error.DependencyNotInstalled as e:
+        pytest.skip(str(e))
+
+    # JaxToNumpy, JaxToTorch and NumpyToTorch never call RecordConstructorArgs,
+    # so there is nothing here to compare against their signatures. Not
+    # recording an argument and not recording at all are separate gaps.
+    if not issubclass(wrapper, RecordConstructorArgs):
+        pytest.skip(f"{wrapper_name} does not record its constructor arguments at all")
+
+    assert recorded_argument_names(wrapper) == constructor_argument_names(wrapper)
+
+
+def test_env_spec_roundtrip_keeps_wrapper_arguments():
+    """An environment rebuilt from its spec is wrapped with the arguments it was given."""
+    env = gym.wrappers.DiscretizeAction(
+        gym.make("Pendulum-v1"), bins=2, multidiscrete=True
+    )
+    assert gym.make(env.spec).action_space == env.action_space
+
+    env = gym.wrappers.RecordEpisodeStatistics(
+        gym.make("CartPole-v1"), buffer_length=17, stats_key="my_stats"
+    )
+    rebuilt = gym.make(env.spec)
+    assert rebuilt._stats_key == env._stats_key
+    assert rebuilt.time_queue.maxlen == env.time_queue.maxlen


### PR DESCRIPTION
### The defect

Five wrappers leave constructor arguments out of `RecordConstructorArgs`. `Wrapper.spec` puts the
recorded arguments into a `WrapperSpec` and `gym.make` splats them back in, so an environment
rebuilt from its own spec comes back with the defaults in their place:

```python
env = DiscretizeAction(base, bins=2, multidiscrete=True)
gym.make(env.spec).action_space   # MultiDiscrete([2]) becomes Discrete(2)

env = RecordEpisodeStatistics(base, stats_key="my_stats")
gym.make(env.spec)                # writes to info["episode"] again
```

Same for `DiscretizeObservation`, `RecordVideo` and `StickyAction`.

Nothing raises. The rebuilt environment is quietly a different environment, which is the same shape
as #1658 in `AddRenderObservation`.

`StickyAction` needs more than one line. Recording the post-widening value would put a tuple in the
spec even where the caller passed an int, and `EnvSpec.from_json` returns a list, which the
constructor rejects. The value the caller gave is kept for the record; the widened pair is used
internally.

### The test

Walks `gymnasium.wrappers.__all__`, parses each `__init__` with `ast`, finds the
`RecordConstructorArgs.__init__` call and compares its keyword names against the signature. It adds
a round trip through `EnvSpec` too, because the existing one in
`tests/envs/registration/test_env_spec.py` builds a stack of two wrappers that both already record
everything, so it could not have caught any of this.

Reverting the five sources and keeping the tests gives 6 failures: one per wrapper, plus the round
trip.

### Left alone

Running that walk over the whole package rather than `__all__` leaves three classes standing, which
invites the obvious question. `ArrayConversion`, in both the plain and vector namespaces, takes four
Array API namespaces, and those are modules, which `RecordConstructorArgs` cannot deepcopy; it sits
in the new test as `xfail(strict=True)` so it fails loudly the day somebody finds a different answer
for it. `gymnasium/wrappers/vector/rendering.py::RecordVideo` has a plain gap of the kind fixed
here, but `VectorWrapper.spec` returns `self.env.spec` unchanged and never builds a `WrapperSpec`,
so nothing reads those arguments back and there is no round trip to break.

### Validation

`tests/wrappers`: 429 passed, 16 skipped, 1 xfailed. The 12 failures are
`test_human_rendering.py::test_num_envs_screen_size` with `Ant-v4`, identical name for name on an
untouched `main`, where the same run gives 393 passed and the same 12.
