### PR TITLE
Reject a min action equal to the max action in RescaleAction

### DIFF
--- a/gymnasium/wrappers/transform_action.py
+++ b/gymnasium/wrappers/transform_action.py
@@ -14,6 +14,7 @@ import numpy as np
 
 import gymnasium as gym
 from gymnasium.core import ActType, ObsType, WrapperActType
+from gymnasium.error import InvalidBound
 from gymnasium.spaces import Box, Discrete, MultiDiscrete, Space
 
 __all__ = ["TransformAction", "ClipAction", "RescaleAction"]
@@ -167,6 +168,9 @@ class RescaleAction(
             env (Env): The environment to wrap
             min_action (float, int or np.ndarray): The min values for each action. This may be a numpy array or a scalar.
             max_action (float, int or np.ndarray): The max values for each action. This may be a numpy array or a scalar.
+
+        Raises:
+            InvalidBound: If a component of ``min_action`` equals the matching component of ``max_action``.
         """
         if not isinstance(env.action_space, Box):
             raise TypeError(
@@ -178,6 +182,14 @@ class RescaleAction(
         )
 
         act_space, _, func = rescale_box(env.action_space, min_action, max_action)
+        # The wrapper applies the inverse of the rescaling, and a component that is
+        # rescaled onto a single point has no inverse.
+        if np.any(act_space.low == act_space.high):
+            raise InvalidBound(
+                f"Min action ({min_action}) must be strictly smaller than max action "
+                f"({max_action}), the rescaling has no inverse where they are equal"
+            )
+
         TransformAction.__init__(
             self,
             env=env,

--- a/tests/wrappers/test_rescale_action.py
+++ b/tests/wrappers/test_rescale_action.py
@@ -1,7 +1,9 @@
 """Test suite for RescaleAction wrapper."""
 
 import numpy as np
+import pytest
 
+from gymnasium.error import InvalidBound
 from gymnasium.spaces import Box
 from gymnasium.wrappers import RescaleAction
 from tests.testing_env import GenericTestEnv
@@ -46,3 +48,30 @@ def test_rescale_action_wrapper():
 
         _, _, _, _, info = wrapped_env.step(sample_action)
         assert np.all(info["action"] == expected_action)
+
+
+def test_rescale_action_equal_bounds():
+    """Test that a min action equal to the max action is rejected.
+
+    The wrapper maps an action from the rescaled space back to the action space of
+    the environment, and that map is the inverse of the rescaling. A component whose
+    min equals its max collapses to a constant, which has no inverse, so every action
+    on that component would come out as `nan`.
+    """
+    env = GenericTestEnv(
+        step_func=record_action_step,
+        action_space=Box(
+            np.array([0, 1], dtype=np.float32), np.array([1, 3], dtype=np.float32)
+        ),
+    )
+
+    with pytest.raises(InvalidBound):
+        RescaleAction(env, min_action=np.float32(0), max_action=np.float32(0))
+
+    # only one of the two components is degenerate
+    with pytest.raises(InvalidBound):
+        RescaleAction(
+            env,
+            min_action=np.array([-1, 2], dtype=np.float32),
+            max_action=np.array([1, 2], dtype=np.float32),
+        )


### PR DESCRIPTION
### The defect

`RescaleAction` applies the inverse of the affine map that `rescale_box` builds. A component whose
new min equals its new max is rescaled onto a single point, so the gradient is zero and the inverse
divides by it.

```python
env = RescaleAction(base, 0.0, 0.0)   # builds without complaint
env.step(env.action_space.sample())   # every action is nan
```

Nothing checks the action on the way through, so the `nan` reaches the environment and only surfaces
later as a `nan` observation.

### The change

Raise `InvalidBound` at construction, which is what `ClipReward` raises for bounds it cannot use.

The check is `act_space.low == act_space.high` on the rescaled space, and exact equality is the
right test rather than a tolerance: bounds a denormal apart still have an inverse, an enormous one
but finite, while equal bounds have none at all. Zero gradient is the whole defect.

`RescaleObservation` keeps working with equal bounds. It applies the forward map, and a constant
inside its own observation space is well defined.

### The test

Two cases in `tests/wrappers/test_rescale_action.py`: equal scalar bounds, and one component of a
vector action equal while the others are fine. Reverting the source and keeping them gives one
failure.

### Validation

`tests/wrappers`: 394 passed, 13 skipped. The 12 failures are
`test_human_rendering.py::test_num_envs_screen_size` with `Ant-v4`, identical name for name on an
untouched `main`, where the same run gives 393 passed and the same 12.
