### PR TITLE
Fix Box.sample never returning values near signed integer dtype limits

### DIFF
--- a/gymnasium/spaces/box.py
+++ b/gymnasium/spaces/box.py
@@ -463,7 +463,10 @@ class Box(Space[NDArray[_ScalarT_co]]):
         if np.issubdtype(self.dtype, np.integer):
             iinfo = np.iinfo(cast("np.dtype[np.integer]", self.dtype))
             dtype_min, dtype_max = iinfo.min, iinfo.max
-            if np.issubdtype(self.dtype, np.signedinteger):
+            if self.dtype == np.int64:
+                # float64 cannot exactly represent the int64 limits, so keep a
+                # margin to stay within the dtype range after the cast below
+                # (narrower signed dtypes are exactly representable in float64)
                 dtype_min += 2
                 dtype_max -= 2
             sample = sample.clip(min=dtype_min, max=dtype_max)

--- a/tests/spaces/test_box.py
+++ b/tests/spaces/test_box.py
@@ -277,6 +277,28 @@ def test_valid_low_high(low, high, dtype):
             raise Exception(warn)
 
 
+@pytest.mark.parametrize(
+    "dtype",
+    [np.int8, np.int16, np.int32, np.uint8],
+    ids=["int8", "int16", "int32", "uint8"],
+)
+def test_sample_dtype_edge_reachability(dtype):
+    """Tests that a bounded integer Box can sample every value in ``[low, high]``.
+
+    Regression test for the cast guard in ``Box.sample`` clipping signed
+    samples to ``[dtype_min + 2, dtype_max - 2]``, which made the values within
+    2 of a signed dtype's limits impossible to sample even though
+    ``contains`` accepts them (e.g. ``Box(125, 127, dtype=np.int8)`` could
+    only ever return 125).
+    """
+    info = np.iinfo(dtype)
+    for low, high in [(info.max - 2, info.max), (info.min, info.min + 2)]:
+        space = Box(low=low, high=high, dtype=dtype, seed=0)
+        expected = set(range(low, high + 1))
+        observed = {int(x) for _ in range(1000) for x in space.sample()}
+        assert observed == expected
+
+
 def test_contains_dtype():
     """Tests the Box contains function with different dtypes."""
     # Related Issues:


### PR DESCRIPTION
# Description

`Box.sample()` clips integer samples to the dtype's range before casting, but for every signed integer dtype it applied a `[dtype_min + 2, dtype_max - 2]` margin (introduced in #774). That margin only guards against float64's inexact representation of the **int64** limits — the same reason #774 added the int64-specific re-clip after the cast — while the int8/int16/int32 limits are exactly representable in float64. The margin therefore only truncated the sampled support:

```python
import numpy as np
from gymnasium.spaces import Box

space = Box(low=125, high=127, dtype=np.int8)
print([space.contains(np.array([v])) for v in (125, 126, 127)])
# [True, True, True]
space.seed(0)
print({int(v) for _ in range(3000) for v in space.sample()})
# {125} — 126 and 127 can never be sampled
```

A full-range `Box(-128, 127, dtype=np.int8)` can never sample `-128`, `-127`, `126` or `127` (only 252 of 256 values are reachable), while unsigned dtypes were exempt from the margin, so `Box(253, 255, dtype=np.uint8)` samples all three values — the asymmetry suggests an oversight rather than a distribution choice.

This restricts the margin to `np.int64`, mirroring the existing `if self.dtype == np.int64:` special case directly below it, so int64 behaviour is unchanged. Adds a parametrised regression test asserting that a bounded integer Box samples every value in `[low, high]` for int8/int16/int32, with uint8 as a control.

This restores the documented contract (docstring: "`[a, b]`: uniform distribution") and the invariant `test_valid_low_high` already asserts via `space.contains(sample)`; its parameter list just never used bounds near a signed dtype's limits.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Note: in my environment the `ty` hook reports the same 353 pre-existing diagnostics on unmodified `main` (missing optional dependencies); this diff adds no new `ty` diagnostics. ruff, ruff-format and pydocstyle pass.
