### PR TITLE
Record ArrayConversion's constructor arguments

### DIFF
--- a/gymnasium/wrappers/array_conversion.py
+++ b/gymnasium/wrappers/array_conversion.py
@@ -203,7 +203,18 @@ class ArrayConversion(gym.Wrapper, gym.utils.RecordConstructorArgs):
             env_device: The device the environment is on
             target_device: The device on which Arrays should be returned
         """
-        gym.utils.RecordConstructorArgs.__init__(self)
+        # An Array API namespace is a module, and `deepcopy` cannot copy one, so
+        # the recording has to skip it. Without these four saved, `Wrapper.spec`
+        # carries no kwargs and `gym.make(env.spec)` raises `TypeError` for the
+        # two that have no default.
+        gym.utils.RecordConstructorArgs.__init__(
+            self,
+            _disable_deepcopy=True,
+            env_xp=env_xp,
+            target_xp=target_xp,
+            env_device=env_device,
+            target_device=target_device,
+        )
         gym.Wrapper.__init__(self, env)
 
         self._env_xp = module_namespace(env_xp)

--- a/gymnasium/wrappers/jax_to_numpy.py
+++ b/gymnasium/wrappers/jax_to_numpy.py
@@ -72,4 +72,8 @@ class JaxToNumpy(ArrayConversion):
             raise DependencyNotInstalled(
                 'Jax is not installed, run `pip install "gymnasium[jax]"`'
             )
+        # Recorded here rather than left to `ArrayConversion`, whose four
+        # arguments this constructor does not take. The first call wins, so
+        # the one below is ignored.
+        gym.utils.RecordConstructorArgs.__init__(self)
         super().__init__(env=env, env_xp=jnp, target_xp=np)

--- a/gymnasium/wrappers/jax_to_torch.py
+++ b/gymnasium/wrappers/jax_to_torch.py
@@ -85,6 +85,7 @@ class JaxToTorch(ArrayConversion):
             env: The Jax-based environment to wrap
             device: The device the torch Tensors should be moved to
         """
+        gym.utils.RecordConstructorArgs.__init__(self, device=device)
         super().__init__(env=env, env_xp=jnp, target_xp=torch, target_device=device)
 
         # TODO: Device was part of the public API, but should be removed in favor of _env_device and

--- a/gymnasium/wrappers/numpy_to_torch.py
+++ b/gymnasium/wrappers/numpy_to_torch.py
@@ -71,6 +71,7 @@ class NumpyToTorch(ArrayConversion):
             env: The NumPy-based environment to wrap
             device: The device the torch Tensors should be moved to
         """
+        gym.utils.RecordConstructorArgs.__init__(self, device=device)
         super().__init__(env=env, env_xp=np, target_xp=torch, target_device=device)
 
         self.device: Device | None = device

--- a/tests/wrappers/test_record_constructor_args.py
+++ b/tests/wrappers/test_record_constructor_args.py
@@ -49,23 +49,7 @@ def constructor_argument_names(wrapper: type) -> set[str]:
     }
 
 
-@pytest.mark.parametrize(
-    "wrapper_name",
-    [
-        (
-            pytest.param(
-                name,
-                marks=pytest.mark.xfail(
-                    strict=True,
-                    reason="Array API namespaces are modules, which RecordConstructorArgs cannot deepcopy",
-                ),
-            )
-            if name == "ArrayConversion"
-            else name
-        )
-        for name in WRAPPER_NAMES
-    ],
-)
+@pytest.mark.parametrize("wrapper_name", WRAPPER_NAMES)
 def test_wrappers_record_every_constructor_argument(wrapper_name: str):
     """Every constructor argument of a wrapper is passed on to `RecordConstructorArgs`.
 


### PR DESCRIPTION
# Description

`ArrayConversion` records none of its four constructor arguments, so an environment
wrapped in it cannot be rebuilt from its own spec:

```python
env = gym.wrappers.ArrayConversion(gym.make("CartPole-v1"), env_xp=np, target_xp=np)
env.spec.additional_wrappers[-1].kwargs
# {}
gym.make(env.spec)
# TypeError: ArrayConversion.__init__() missing 2 required positional arguments:
#   'env_xp' and 'target_xp'
```

It records nothing for a real reason: `RecordConstructorArgs` deepcopies what it saves and
`deepcopy` of a module raises `TypeError: cannot pickle 'module' object`. `_disable_deepcopy`
exists for this. Modules are singletons and a device handle is not mutated in place.

`JaxToNumpy`, `JaxToTorch` and `NumpyToTorch` subclass this and pass those four up through
`super().__init__`, so recording them on the parent records them against a subclass whose
signature does not take them. My first push did that and turned five jax-backed environment
tests red with `TypeError: JaxToNumpy.__init__() got an unexpected keyword argument 'env_xp'`.
Each converter records its own arguments first now, which `RecordConstructorArgs` keeps while
ignoring the parent's later call.

That also clears three failures inherited from #1664, where the same converters fail the new
test with "does not call RecordConstructorArgs.__init__": it reads each class's own
constructor and theirs never called it.

One consequence, plainly: a spec holding module objects will not serialise through
`EnvSpec.to_json`. That already applies to wrappers recording anything JSON cannot express,
and `TransformObservation` and `TransformReward` both raise
`TypeError: Object of type function is not JSON serializable` there today when given a lambda.
Trading a hard failure of `gym.make` for a limitation that already exists seemed the right way
round, but say so if you would rather the namespace were stored by name.

This sits on top of #1664 and the diff includes it, so it wants reading or merging after
that one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the `pre-commit` checks with `pre-commit run --all-files`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

jax and torch are absent on my machine, so the three converters skip locally and the
breakage above only showed on CI. The remaining `tests/wrappers/vector/test_human_rendering.py`
failures fail the same way on `main` here and are a local MuJoCo problem.
