### PR TITLE
Fix vector NormalizeReward under SAME_STEP autoreset

### DIFF
--- a/gymnasium/wrappers/vector/stateful_reward.py
+++ b/gymnasium/wrappers/vector/stateful_reward.py
@@ -11,7 +11,7 @@ import numpy as np
 
 import gymnasium as gym
 from gymnasium.error import InvalidBound
-from gymnasium.vector.vector_env import VectorEnv, VectorWrapper
+from gymnasium.vector.vector_env import AutoresetMode, VectorEnv, VectorWrapper
 from gymnasium.wrappers.utils import RunningMeanStd
 
 __all__ = ["NormalizeReward"]
@@ -70,6 +70,7 @@ class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
     epsilon: float
     _update_running_mean: bool
     _prev_dones: np.ndarray[tuple[int], np.dtype[np.float32]]
+    _autoreset_mode: AutoresetMode
 
     def __init__(
         self,
@@ -111,6 +112,9 @@ class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
         self.epsilon = epsilon
         self._update_running_mean = True
         self._prev_dones = np.zeros((self.num_envs,), dtype=np.float32)
+        self._autoreset_mode = self.env.metadata.get(
+            "autoreset_mode", AutoresetMode.NEXT_STEP
+        )
 
     @property
     def update_running_mean(self) -> bool:
@@ -144,7 +148,13 @@ class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
     ]:
         """Steps through the environment, normalizing the reward returned."""
         obs, reward, terminated, truncated, info = super().step(actions)
-        active = ~self._prev_dones.astype(bool)
+        # SAME_STEP resets inside the terminating step, so the following step is
+        # already the first step of a new episode and must update statistics.
+        # NEXT_STEP / DISABLED still skip the autoreset step after a done.
+        if self._autoreset_mode == AutoresetMode.SAME_STEP:
+            active = np.ones((self.num_envs,), dtype=bool)
+        else:
+            active = ~self._prev_dones.astype(bool)
         self.accumulated_reward[active] = (
             self.accumulated_reward[active] * self.gamma * (1 - terminated[active])
             + reward[active]
@@ -152,6 +162,10 @@ class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
         if self._update_running_mean and np.any(active):
             self.return_rms.update(self.accumulated_reward[active])
         self._prev_dones = np.logical_or(terminated, truncated).astype(np.float32)
+        if self._autoreset_mode == AutoresetMode.SAME_STEP:
+            # The done sub-environments have already been reset; start a new
+            # return immediately rather than carrying the previous episode.
+            self.accumulated_reward[self._prev_dones.astype(bool)] = 0
         return (
             obs,
             reward / np.sqrt(self.return_rms.var + self.epsilon),

--- a/tests/wrappers/vector/test_normalize_reward.py
+++ b/tests/wrappers/vector/test_normalize_reward.py
@@ -6,7 +6,7 @@ import pytest
 from gymnasium import wrappers
 from gymnasium.core import ActType
 from gymnasium.error import InvalidBound
-from gymnasium.vector import SyncVectorEnv
+from gymnasium.vector import AutoresetMode, SyncVectorEnv
 from tests.testing_env import GenericTestEnv
 
 
@@ -112,3 +112,42 @@ def test_non_positive_epsilon_is_rejected(epsilon):
     with pytest.raises(InvalidBound, match="`epsilon` should be strictly positive"):
         wrappers.vector.NormalizeReward(vec_env, epsilon=epsilon)
     vec_env.close()
+
+
+def test_same_step_autoreset_updates_return_rms(n_envs=2, episode_length=4, n_steps=12):
+    """SAME_STEP first-after-done rewards must update return_rms and start a new return."""
+
+    def reset_func(self, seed=None, options=None):
+        self.timestep = 0
+        return self.observation_space.sample(), {}
+
+    def step_func(self, action):
+        self.timestep += 1
+        return (
+            self.observation_space.sample(),
+            1.0,
+            self.timestep >= episode_length,
+            False,
+            {},
+        )
+
+    env = wrappers.vector.NormalizeReward(
+        SyncVectorEnv(
+            [
+                lambda: GenericTestEnv(reset_func=reset_func, step_func=step_func)
+                for _ in range(n_envs)
+            ],
+            autoreset_mode=AutoresetMode.SAME_STEP,
+        )
+    )
+
+    env.reset(seed=123)
+    for _ in range(n_steps):
+        _, _, terminated, truncated, _ = env.step(env.action_space.sample())
+        dones = np.logical_or(terminated, truncated)
+        if np.any(dones):
+            assert np.all(env.accumulated_reward[dones] == 0)
+
+    # Every step is a real environment step under SAME_STEP.
+    assert np.isclose(env.return_rms.count, n_steps * n_envs)
+    env.close()


### PR DESCRIPTION
`vector.NormalizeReward` always skips sub-envs whose previous step terminated. That is correct for `NEXT_STEP`, where the following step is a dummy reset. Under `SAME_STEP` the env already reset inside the terminating step, so the next step is a real first step of the new episode.

The wrapper then:

1. Drops that first-step reward from `return_rms`.
2. Leaves the previous episode's return in `accumulated_reward`.

On a 4-step dummy, 12 steps, 2 envs, `return_rms.count` was 20 instead of 24.

When `autoreset_mode` is `SAME_STEP`, treat every step as active and zero `accumulated_reward` on the terminating step, the same way `RecordEpisodeStatistics` already does (#1624). `NEXT_STEP` is unchanged.

`pytest tests/wrappers/vector/test_normalize_reward.py` and the related vector wrapper / autoreset tests pass (86).
