### PR TITLE
Reject invalid gamma and epsilon in the normalize wrappers

### DIFF
--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -18,6 +18,7 @@ import numpy as np
 import gymnasium as gym
 import gymnasium.spaces as spaces
 from gymnasium.core import ActType, ObsType, WrapperActType, WrapperObsType
+from gymnasium.error import InvalidBound
 from gymnasium.spaces import Box, Dict, Tuple
 from gymnasium.vector.utils import batch_space, concatenate, create_empty_array
 from gymnasium.wrappers.utils import RunningMeanStd, create_zero_array
@@ -508,7 +509,18 @@ class NormalizeObservation(
         Args:
             env (Env): The environment to apply the wrapper
             epsilon: A stability parameter that is used when scaling the observations.
+
+        Raises:
+            InvalidBound: If ``epsilon`` is not strictly positive.
         """
+        # `epsilon` is added under the square root to keep the division away from
+        # zero, so a non-positive value defeats its purpose and, once it exceeds
+        # the variance, silently turns every normalized observation into NaN.
+        if epsilon <= 0:
+            raise InvalidBound(
+                f"`epsilon` should be strictly positive. Received {epsilon}"
+            )
+
         gym.utils.RecordConstructorArgs.__init__(self, epsilon=epsilon)
         gym.ObservationWrapper.__init__(self, env)
 

--- a/gymnasium/wrappers/stateful_reward.py
+++ b/gymnasium/wrappers/stateful_reward.py
@@ -11,6 +11,7 @@ import numpy as np
 
 import gymnasium as gym
 from gymnasium.core import ActType, ObsType
+from gymnasium.error import InvalidBound
 from gymnasium.wrappers.utils import RunningMeanStd
 
 __all__ = ["NormalizeReward"]
@@ -85,7 +86,25 @@ class NormalizeReward(
             env (env): The environment to apply the wrapper
             epsilon (float): A stability parameter
             gamma (float): The discount factor that is used in the exponential moving average.
+
+        Raises:
+            InvalidBound: If ``gamma`` is outside ``[0, 1]``, or if ``epsilon`` is not strictly positive.
         """
+        # The exponential moving average multiplies the accumulator by `gamma` on
+        # every step, so a value above one makes it diverge instead of converging,
+        # and a negative one alternates its sign.
+        if not 0 <= gamma <= 1:
+            raise InvalidBound(
+                f"`gamma` should be in the interval [0, 1]. Received {gamma}"
+            )
+        # `epsilon` is added under the square root to keep the division away from
+        # zero, so a non-positive value defeats its purpose and, once it exceeds
+        # the variance, silently turns every normalized reward into NaN.
+        if epsilon <= 0:
+            raise InvalidBound(
+                f"`epsilon` should be strictly positive. Received {epsilon}"
+            )
+
         gym.utils.RecordConstructorArgs.__init__(self, gamma=gamma, epsilon=epsilon)
         gym.Wrapper.__init__(self, env)
 

--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -10,6 +10,7 @@ from typing import Any
 import numpy as np
 
 import gymnasium as gym
+from gymnasium.error import InvalidBound
 from gymnasium.logger import warn
 from gymnasium.spaces import Box
 from gymnasium.vector.utils import batch_space
@@ -74,7 +75,18 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
         Args:
             env (Env): The environment to apply the wrapper
             epsilon: A stability parameter that is used when scaling the observations.
+
+        Raises:
+            InvalidBound: If ``epsilon`` is not strictly positive.
         """
+        # `epsilon` is added under the square root to keep the division away from
+        # zero, so a non-positive value defeats its purpose and, once it exceeds
+        # the variance, silently turns every normalized observation into NaN.
+        if epsilon <= 0:
+            raise InvalidBound(
+                f"`epsilon` should be strictly positive. Received {epsilon}"
+            )
+
         gym.utils.RecordConstructorArgs.__init__(self, epsilon=epsilon)
         VectorObservationWrapper.__init__(self, env)
 

--- a/gymnasium/wrappers/vector/stateful_reward.py
+++ b/gymnasium/wrappers/vector/stateful_reward.py
@@ -10,6 +10,7 @@ from typing import Any
 import numpy as np
 
 import gymnasium as gym
+from gymnasium.error import InvalidBound
 from gymnasium.vector.vector_env import VectorEnv, VectorWrapper
 from gymnasium.wrappers.utils import RunningMeanStd
 
@@ -82,7 +83,25 @@ class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
             env (env): The environment to apply the wrapper
             epsilon (float): A stability parameter
             gamma (float): The discount factor that is used in the exponential moving average.
+
+        Raises:
+            InvalidBound: If ``gamma`` is outside ``[0, 1]``, or if ``epsilon`` is not strictly positive.
         """
+        # The exponential moving average multiplies the accumulator by `gamma` on
+        # every step, so a value above one makes it diverge instead of converging,
+        # and a negative one alternates its sign.
+        if not 0 <= gamma <= 1:
+            raise InvalidBound(
+                f"`gamma` should be in the interval [0, 1]. Received {gamma}"
+            )
+        # `epsilon` is added under the square root to keep the division away from
+        # zero, so a non-positive value defeats its purpose and, once it exceeds
+        # the variance, silently turns every normalized reward into NaN.
+        if epsilon <= 0:
+            raise InvalidBound(
+                f"`epsilon` should be strictly positive. Received {epsilon}"
+            )
+
         gym.utils.RecordConstructorArgs.__init__(self, gamma=gamma, epsilon=epsilon)
         VectorWrapper.__init__(self, env)
 

--- a/tests/wrappers/test_normalize_observation.py
+++ b/tests/wrappers/test_normalize_observation.py
@@ -1,9 +1,11 @@
 """Test suite for NormalizeObservation wrapper."""
 
 import numpy as np
+import pytest
 
 import gymnasium as gym
 from gymnasium import spaces, wrappers
+from gymnasium.error import InvalidBound
 from gymnasium.wrappers import NormalizeObservation
 from tests.testing_env import GenericTestEnv
 
@@ -75,3 +77,19 @@ def test_normalize_obs_with_vector():
 
     envs = gym.vector.SyncVectorEnv([thunk for _ in range(4)])
     obs, _ = envs.reset()
+
+
+@pytest.mark.parametrize("epsilon", [0.0, -1e-8, -1.0])
+def test_non_positive_epsilon_is_rejected(epsilon):
+    """``epsilon`` sits under a square root; once it exceeds the variance the result is NaN.
+
+    Left unchecked, the wrapper keeps running and silently returns NaN observations
+    rather than reporting that its stability parameter cannot stabilise anything.
+    """
+    with pytest.raises(InvalidBound, match="`epsilon` should be strictly positive"):
+        NormalizeObservation(GenericTestEnv(), epsilon=epsilon)
+
+
+@pytest.mark.parametrize("epsilon", [1e-8, 1e-4, 1.0])
+def test_positive_epsilon_is_accepted(epsilon):
+    assert NormalizeObservation(GenericTestEnv(), epsilon=epsilon).epsilon == epsilon

--- a/tests/wrappers/test_normalize_reward.py
+++ b/tests/wrappers/test_normalize_reward.py
@@ -1,9 +1,11 @@
 """Test suite for NormalizeReward wrapper."""
 
 import numpy as np
+import pytest
 
 import gymnasium as gym
 from gymnasium.core import ActType
+from gymnasium.error import InvalidBound
 from gymnasium.wrappers import NormalizeReward
 from tests.testing_env import GenericTestEnv
 
@@ -81,3 +83,27 @@ def test_normalize_return():
         np.mean([2 + 1 * env.gamma, 1]),  # [second return, first return]
         decimal=4,
     )
+
+
+@pytest.mark.parametrize("gamma", [-1.0, -0.01, 1.01, 2.0, 99])
+def test_gamma_outside_unit_interval_is_rejected(gamma):
+    """The accumulator is multiplied by ``gamma`` every step, so a value outside [0, 1] diverges.
+
+    Left unchecked, ``gamma=99`` (a plausible typo for ``0.99``) drives the accumulator
+    to infinity and every normalized reward to NaN, without raising anything.
+    """
+    with pytest.raises(InvalidBound, match="`gamma` should be in the interval"):
+        NormalizeReward(GenericTestEnv(), gamma=gamma)
+
+
+@pytest.mark.parametrize("gamma", [0.0, 0.5, 0.99, 1.0])
+def test_gamma_inside_unit_interval_is_accepted(gamma):
+    """Both endpoints are meaningful: 0 keeps only the immediate reward, 1 is undiscounted."""
+    assert NormalizeReward(GenericTestEnv(), gamma=gamma).gamma == gamma
+
+
+@pytest.mark.parametrize("epsilon", [0.0, -1e-8, -1.0])
+def test_non_positive_epsilon_is_rejected(epsilon):
+    """``epsilon`` sits under a square root; once it exceeds the variance the result is NaN."""
+    with pytest.raises(InvalidBound, match="`epsilon` should be strictly positive"):
+        NormalizeReward(GenericTestEnv(), epsilon=epsilon)

--- a/tests/wrappers/vector/test_normalize_observation.py
+++ b/tests/wrappers/vector/test_normalize_observation.py
@@ -1,8 +1,10 @@
 """Test suite for vector NormalizeObservation wrapper."""
 
 import numpy as np
+import pytest
 
 from gymnasium import spaces, wrappers
+from gymnasium.error import InvalidBound
 from gymnasium.vector import SyncVectorEnv
 from tests.testing_env import GenericTestEnv
 
@@ -115,3 +117,12 @@ def test_observation_space_and_dtype():
 
     obs, *_ = vec_env.step(vec_env.action_space.sample())
     assert obs.dtype == np.float32
+
+
+@pytest.mark.parametrize("epsilon", [0.0, -1e-8, -1.0])
+def test_non_positive_epsilon_is_rejected(epsilon):
+    """Matches the same check on the non-vector wrapper, which shares this scaling."""
+    vec_env = SyncVectorEnv([create_env])
+    with pytest.raises(InvalidBound, match="`epsilon` should be strictly positive"):
+        wrappers.vector.NormalizeObservation(vec_env, epsilon=epsilon)
+    vec_env.close()

--- a/tests/wrappers/vector/test_normalize_reward.py
+++ b/tests/wrappers/vector/test_normalize_reward.py
@@ -1,9 +1,11 @@
 """Test suite for vector NormalizeReward wrapper."""
 
 import numpy as np
+import pytest
 
 from gymnasium import wrappers
 from gymnasium.core import ActType
+from gymnasium.error import InvalidBound
 from gymnasium.vector import SyncVectorEnv
 from tests.testing_env import GenericTestEnv
 
@@ -92,4 +94,21 @@ def test_equivalence_with_wrapper(n_steps=50):
         vec_env.return_rms.var, per_env.envs[0].return_rms.var, rtol=1e-4
     )
     per_env.close()
+    vec_env.close()
+
+
+@pytest.mark.parametrize("gamma", [-1.0, 1.01, 2.0, 99])
+def test_gamma_outside_unit_interval_is_rejected(gamma):
+    """Matches the same check on the non-vector wrapper, which shares this accumulator."""
+    vec_env = SyncVectorEnv([thunk])
+    with pytest.raises(InvalidBound, match="`gamma` should be in the interval"):
+        wrappers.vector.NormalizeReward(vec_env, gamma=gamma)
+    vec_env.close()
+
+
+@pytest.mark.parametrize("epsilon", [0.0, -1e-8, -1.0])
+def test_non_positive_epsilon_is_rejected(epsilon):
+    vec_env = SyncVectorEnv([thunk])
+    with pytest.raises(InvalidBound, match="`epsilon` should be strictly positive"):
+        wrappers.vector.NormalizeReward(vec_env, epsilon=epsilon)
     vec_env.close()


### PR DESCRIPTION
## Summary

`NormalizeReward` and `NormalizeObservation` accept any value for their numeric parameters. Every neighbouring wrapper in the package validates its arguments — `StickyAction` and `AddWhiteNoise` raise `InvalidProbability`, `RescaleAction`, `ClipReward` and `RepeatAction` raise `InvalidBound`/`ValueError` — so these four classes are the gap in an otherwise consistent convention.

The failure mode is silence rather than an exception, which is what makes it worth fixing:

* `epsilon` is added under a square root, `np.sqrt(var + epsilon)`. It exists to keep the division away from zero, so a non-positive value defeats its own purpose, and once `|epsilon|` exceeds the running variance the root is taken of a negative number. The wrapper keeps running and returns NaN.
* `gamma` multiplies the discounted accumulator on every step. Above one the accumulator diverges instead of converging; below zero it alternates sign. `gamma=99` — a plausible typo for `0.99` — sends it to infinity.

Measured on `Pendulum-v1` before this change, with nothing raised at construction time:

| argument | result |
|---|---|
| `NormalizeObservation(epsilon=-1.0)` | 67.5% of returned observations are NaN |
| `NormalizeReward(gamma=99)` | accumulator reaches `-inf`, 145 of 300 rewards are NaN |
| `NormalizeReward(gamma=2.0)` | accumulator reaches `-1.7e+90` |
| `wrappers.vector.NormalizeReward(gamma=2.0)` | accumulator reaches `inf` |

A user who hits this sees an agent that will not learn, with no error pointing at the wrapper.

## Changes

Validation in the four affected constructors, in the style already used by `RescaleAction`, with the reason recorded as a comment and a `Raises:` entry added to each docstring:

* `gymnasium/wrappers/stateful_reward.py` — `NormalizeReward`: `0 <= gamma <= 1`, `epsilon > 0`
* `gymnasium/wrappers/stateful_observation.py` — `NormalizeObservation`: `epsilon > 0`
* `gymnasium/wrappers/vector/stateful_reward.py` — vector `NormalizeReward`: both
* `gymnasium/wrappers/vector/stateful_observation.py` — vector `NormalizeObservation`: `epsilon > 0`

Both endpoints of the `gamma` interval stay valid: `0` keeps only the immediate reward and `1` is the undiscounted return, and both are covered by a test so the bound is not tightened by accident later.

Regression tests were added to the four matching test files.

## Verification

`tests/wrappers` and `tests/vector` were run before and after the change and the set of failing tests is identical — 57 failures in both, all pre-existing and caused by `Box2D`/`MuJoCo`/`torch` not being installed in my environment, none of them in the affected files. The four touched test files pass in full (40 passed). `ruff check`, `ruff format` and `codespell` are clean on all eight files.

The behaviour above can be reproduced on the parent commit with:

```python
import numpy as np, gymnasium as gym
from gymnasium.wrappers import NormalizeObservation

env = NormalizeObservation(gym.make("Pendulum-v1"), epsilon=-1.0)  # no error
obs, _ = env.reset(seed=0)
for _ in range(200):
    obs, *_ = env.step(env.action_space.sample())
print(obs)  # [nan nan ...]
```
