### PR TITLE
Report one error when RecordVideo cannot be constructed, not three

### DIFF
--- a/gymnasium/wrappers/rendering.py
+++ b/gymnasium/wrappers/rendering.py
@@ -279,8 +279,8 @@ class RecordVideo(
 
         if env.render_mode in {None, "human", "ansi"}:
             raise ValueError(
-                f"Render mode is {env.render_mode}, which is incompatible with RecordVideo.",
-                "Initialize your environment with a render_mode that returns an image, such as rgb_array.",
+                f"Render mode is {env.render_mode}, which is incompatible with RecordVideo. "
+                "Initialize your environment with a render_mode that returns an image, such as rgb_array."
             )
 
         if episode_trigger is None and step_trigger is None:
@@ -435,7 +435,11 @@ class RecordVideo(
 
     def __del__(self):
         """Warn the user in case last video wasn't saved."""
-        if len(self.recorded_frames) > 0:
+        # `__init__` can raise before `recorded_frames` is assigned, and `__del__`
+        # still runs on the half-built wrapper. Reading the attribute directly
+        # raised an AttributeError that Python reports as "Exception ignored in",
+        # on top of the error that actually stopped construction.
+        if getattr(self, "recorded_frames", None):
             logger.warn("Unable to save last video! Did you call close()?")
 
 

--- a/gymnasium/wrappers/vector/rendering.py
+++ b/gymnasium/wrappers/vector/rendering.py
@@ -307,8 +307,8 @@ class RecordVideo(
 
         if env.render_mode in {None, "human", "ansi"}:
             raise ValueError(
-                f"Render mode is {env.render_mode}, which is incompatible with RecordVideo.",
-                "Initialize your environment with a render_mode that returns an image, such as rgb_array.",
+                f"Render mode is {env.render_mode}, which is incompatible with RecordVideo. "
+                "Initialize your environment with a render_mode that returns an image, such as rgb_array."
             )
 
         if episode_trigger is None and step_trigger is None:
@@ -538,5 +538,9 @@ class RecordVideo(
 
     def __del__(self) -> None:
         """Warn the user in case last video wasn't saved."""
-        if len(self.recorded_frames) > 0:
+        # `__init__` can raise before `recorded_frames` is assigned, and `__del__`
+        # still runs on the half-built wrapper. Reading the attribute directly
+        # raised an AttributeError that Python reports as "Exception ignored in",
+        # on top of the error that actually stopped construction.
+        if getattr(self, "recorded_frames", None):
             logger.warn("Unable to save last video! Did you call close()?")

--- a/tests/wrappers/test_record_video.py
+++ b/tests/wrappers/test_record_video.py
@@ -183,3 +183,26 @@ def test_with_rgb_array_list(n_steps: int = 10):
 
     env.close()
     shutil.rmtree("videos")
+
+
+def test_incompatible_render_mode():
+    """Construction with a render mode that yields no image fails cleanly.
+
+    The message used to be split across two arguments of `ValueError`, so
+    `str(e)` printed a tuple and the sentence telling the user what to do
+    arrived quoted inside it. `__del__` then ran on the half-built wrapper and
+    raised an AttributeError of its own, which Python reports as an ignored
+    exception on top of the real one.
+    """
+    env = gym.make("CartPole-v1")  # render_mode is None
+
+    with pytest.raises(ValueError) as exc_info:
+        RecordVideo(env, "videos")
+
+    assert len(exc_info.value.args) == 1
+    assert "such as rgb_array" in str(exc_info.value)
+
+    env.close()
+
+    # `__del__` on a wrapper whose `__init__` never reached `recorded_frames`.
+    RecordVideo.__new__(RecordVideo).__del__()

--- a/tests/wrappers/vector/test_record_video.py
+++ b/tests/wrappers/vector/test_record_video.py
@@ -250,3 +250,26 @@ def test_record_video_step_returns_arrays_not_scalars():
         envs.close()
         if os.path.isdir("videos"):
             shutil.rmtree("videos")
+
+
+def test_incompatible_render_mode():
+    """Construction with a render mode that yields no image fails cleanly.
+
+    The message used to be split across two arguments of `ValueError`, so
+    `str(e)` printed a tuple and the sentence telling the user what to do
+    arrived quoted inside it. `__del__` then ran on the half-built wrapper and
+    raised an AttributeError of its own, which Python reports as an ignored
+    exception on top of the real one.
+    """
+    envs = gym.make_vec("CartPole-v1", num_envs=2)  # render_mode is None
+
+    with pytest.raises(ValueError) as exc_info:
+        RecordVideo(envs, "videos")
+
+    assert len(exc_info.value.args) == 1
+    assert "such as rgb_array" in str(exc_info.value)
+
+    envs.close()
+
+    # `__del__` on a wrapper whose `__init__` never reached `recorded_frames`.
+    RecordVideo.__new__(RecordVideo).__del__()


### PR DESCRIPTION
## Description

Constructing `RecordVideo` on an environment whose render mode yields no image
reports three errors where one was intended:

```python
>>> gym.wrappers.RecordVideo(gym.make("CartPole-v1"), "videos")
Exception ignored in: <function RecordVideo.__del__ at 0x...>
Traceback (most recent call last):
  File "gymnasium/wrappers/rendering.py", line 438, in __del__
    if len(self.recorded_frames) > 0:
AttributeError: 'RecordVideo' object has no attribute 'recorded_frames'
ValueError: ('Render mode is None, which is incompatible with RecordVideo.', 'Initialize your environment with a render_mode that returns an image, such as rgb_array.')
```

Two separate causes.

The message is split across two arguments of `ValueError` rather than
concatenated, so `str(e)` renders a tuple and the sentence that tells the
caller what to do arrives quoted inside it. The comma was meant to be string
concatenation.

`recorded_frames` is assigned further down `__init__`, after this check, so
`__del__` runs on a half-built wrapper and raises an `AttributeError` of its
own. Python reports that as an ignored exception, printed *before* the error
that actually stopped construction — the first thing the reader sees is
`recorded_frames`, which has nothing to do with what they got wrong.

`__del__` now tolerates a partially initialised wrapper. That covers every
failure path in `__init__` rather than this one alone: any exception raised
before the assignment left the same trailing noise.

Both the plain and the vector wrapper carry the same two lines, so both are
fixed here.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective

Added to both `tests/wrappers/test_record_video.py` and
`tests/wrappers/vector/test_record_video.py`: the exception carries a single
argument, the guidance is in the message, and `__del__` on a wrapper that
never reached `recorded_frames` does not raise. Both fail on `main` and pass
with this change; the two suites together go from 26 to 28 passing.
