### PR TITLE
Fix registration of wrapper class entry points

### DIFF
--- a/gymnasium/envs/registration.py
+++ b/gymnasium/envs/registration.py
@@ -7,7 +7,6 @@ import copy
 import dataclasses
 import difflib
 import importlib
-import importlib.metadata as metadata
 import json
 import re
 from collections import defaultdict
@@ -472,7 +471,7 @@ def _check_metadata(testing_metadata: dict[str, Any]) -> None:
     """Check the metadata of an environment."""
     if not isinstance(testing_metadata, dict):
         raise error.InvalidMetadata(
-            f"Expect the environment metadata to be dict, actual type: {type(metadata)}"
+            f"Expect the environment metadata to be dict, actual type: {type(testing_metadata)}"
         )
 
     render_modes = testing_metadata.get("render_modes")
@@ -700,8 +699,11 @@ def make(
     # Determine if to use the rendering
     render_modes: list[str] | None = None
     if hasattr(env_creator, "metadata"):
-        _check_metadata(env_creator.metadata)
-        render_modes = env_creator.metadata.get("render_modes")
+        env_creator_metadata = env_creator.metadata
+        # Wrapper classes expose metadata through an instance property.
+        if not isinstance(env_creator_metadata, property):
+            _check_metadata(env_creator_metadata)
+            render_modes = env_creator_metadata.get("render_modes")
     render_mode = env_spec_kwargs.get("render_mode")
     apply_human_rendering = False
     apply_render_collection = False

--- a/tests/envs/registration/test_make_vec.py
+++ b/tests/envs/registration/test_make_vec.py
@@ -15,6 +15,19 @@ from gymnasium.wrappers import TimeLimit, TransformObservation
 from tests.wrappers.utils import has_wrapper
 
 
+class RegisteredWrapper(gym.Wrapper):
+    """Wrapper used as a registry entry point."""
+
+    def __init__(self):
+        super().__init__(CartPoleEnv())
+
+
+class InvalidMetadataEnv(CartPoleEnv):
+    """Environment with invalid class metadata."""
+
+    metadata = []
+
+
 def test_make_vec_env_id():
     """Ensure that the `gym.make_vec` creates the right environment."""
     env = gym.make_vec("CartPole-v1")
@@ -165,6 +178,36 @@ def test_make_vec_wrappers():
     assert all(has_wrapper(sub_env, TransformObservation) for sub_env in env.envs)
 
     env.close()
+
+
+def test_make_vec_wrapper_entry_point():
+    """Test that an environment entry point can be a wrapper class."""
+    gym.register("RegisteredWrapper-v0", entry_point=RegisteredWrapper)
+    envs = None
+    try:
+        envs = gym.make_vec(
+            "RegisteredWrapper-v0", num_envs=2, vectorization_mode="sync"
+        )
+        assert all(has_wrapper(env, RegisteredWrapper) for env in envs.envs)
+    finally:
+        if envs is not None:
+            envs.close()
+        gym.registry.pop("RegisteredWrapper-v0", None)
+
+
+def test_make_vec_invalid_entry_point_metadata():
+    """Test that invalid class metadata reports its actual type."""
+    gym.register("InvalidMetadata-v0", entry_point=InvalidMetadataEnv)
+    try:
+        with pytest.raises(
+            error.InvalidMetadata,
+            match=re.escape(
+                "Expect the environment metadata to be dict, actual type: <class 'list'>"
+            ),
+        ):
+            gym.make_vec("InvalidMetadata-v0", vectorization_mode="sync")
+    finally:
+        gym.registry.pop("InvalidMetadata-v0", None)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Registered environment entry points can be `gymnasium.Wrapper` subclasses. Their class-level `metadata` attribute is an instance property that delegates to the wrapped environment, but `make()` currently validates that property object as if it were a concrete metadata dictionary. As a result, both `make()` and `make_vec()` reject valid wrapper entry points before constructing them.

This change skips only instance-property metadata during pre-construction inspection. Concrete class metadata is still validated normally. It also corrects the invalid-metadata diagnostic, which currently reports the imported `metadata` module's type instead of the invalid value's type.

Regression tests verify that `make_vec()` can create multiple environments from a registered wrapper class and that a concrete invalid metadata value is still rejected with the correct type.

Fixes #967

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have run the `pre-commit` checks on the changed files
- [x] I have commented the descriptor handling that is not immediately obvious
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective and preserve invalid-metadata validation
- [x] New and existing registration unit tests pass locally

# Testing

```
pre-commit run --files gymnasium/envs/registration.py tests/envs/registration/test_make_vec.py
pytest -q tests/envs/registration/test_make_vec.py
pytest -q tests/envs/registration
pytest -q
```

The focused suites report 41 passed and 107 passed, respectively. The complete suite reports 4,390 passed and 146 skipped. Two MuJoCo Humanoid velocity tests fail on exact equality at approximately 1e-16; both failures reproduce on an unmodified `main` worktree in the same environment.
