### PR TITLE
Add max_concurrency to AsyncVectorEnv to limit concurrent environment execution

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -9,7 +9,7 @@ import traceback
 from collections.abc import Callable, Iterable, Sequence
 from copy import deepcopy
 from enum import Enum
-from multiprocessing import Queue
+from multiprocessing import Queue, synchronize
 from multiprocessing.connection import Connection
 from multiprocessing.sharedctypes import SynchronizedArray
 from typing import Any, TypeAlias
@@ -111,6 +111,7 @@ class AsyncVectorEnv(VectorEnv):
     )
     observation_mode: str | Space
     autoreset_mode: AutoresetMode
+    max_concurrency: int | None
     num_envs: int
     metadata: dict[str, Any]
     render_mode: str | None
@@ -140,6 +141,7 @@ class AsyncVectorEnv(VectorEnv):
         ) = None,
         observation_mode: str | Space = "same",
         autoreset_mode: str | AutoresetMode = AutoresetMode.NEXT_STEP,
+        max_concurrency: int | None = None,
     ) -> None:
         """Vectorized environment that runs multiple environments in parallel.
 
@@ -160,6 +162,12 @@ class AsyncVectorEnv(VectorEnv):
                 warning, may raise unexpected errors. Passing a ``Tuple[Space, Space]`` object allows defining a custom ``single_observation_space`` and
                 ``observation_space``, warning, may raise unexpected errors.
             autoreset_mode: The Autoreset Mode used, see https://farama.org/Vector-Autoreset-Mode for more information.
+            max_concurrency: The maximum number of environments that can be executing (i.e. in ``reset`` or ``step``)
+                at any one time. If ``None`` (default), no limit is applied and all environments are executed in
+                parallel. When set, a shared semaphore limits how many worker processes can run an environment call
+                simultaneously, which can improve performance when the number of environments exceeds the number of
+                CPU cores (e.g. for physics simulators such as MuJoCo). Note that when using a custom ``worker``
+                with ``max_concurrency`` set, the worker must accept an additional ``semaphore`` argument.
 
         Warnings:
             worker is an advanced mode option. It provides a high degree of flexibility and a high chance
@@ -184,6 +192,12 @@ class AsyncVectorEnv(VectorEnv):
             if isinstance(autoreset_mode, AutoresetMode)
             else AutoresetMode(autoreset_mode)
         )
+        self.max_concurrency = max_concurrency
+
+        if max_concurrency is not None and max_concurrency < 1:
+            raise ValueError(
+                f"`max_concurrency` must be a positive integer or `None`, got {max_concurrency}."
+            )
 
         self.num_envs = len(env_fns)
 
@@ -252,21 +266,30 @@ class AsyncVectorEnv(VectorEnv):
         self.parent_pipes, self.processes = [], []
         self.error_queue = ctx.Queue()
         target = worker or _async_worker
+        # A shared semaphore to limit the number of environments executing at any one time
+        semaphore = (
+            ctx.BoundedSemaphore(max_concurrency)
+            if max_concurrency is not None
+            else None
+        )
         with clear_mpi_env_vars():
             for idx, env_fn in enumerate(self.env_fns):
                 parent_pipe, child_pipe = ctx.Pipe()
+                process_args = (
+                    idx,
+                    CloudpickleWrapper(env_fn),
+                    child_pipe,
+                    parent_pipe,
+                    _obs_buffer,
+                    self.error_queue,
+                    self.autoreset_mode,
+                )
+                if semaphore is not None:
+                    process_args = (*process_args, semaphore)
                 process = ctx.Process(  # ty:ignore[unresolved-attribute]
                     target=target,
                     name=f"Worker<{type(self).__name__}>-{idx}",
-                    args=(
-                        idx,
-                        CloudpickleWrapper(env_fn),
-                        child_pipe,
-                        parent_pipe,
-                        _obs_buffer,
-                        self.error_queue,
-                        self.autoreset_mode,
-                    ),
+                    args=process_args,
                 )
 
                 self.parent_pipes.append(parent_pipe)
@@ -778,6 +801,7 @@ def _async_worker(
     shared_memory: SynchronizedArray | dict[str, Any] | tuple[Any, ...],
     error_queue: Queue,
     autoreset_mode: AutoresetMode,
+    semaphore: synchronize.Semaphore | None = None,
 ) -> None:
     env = env_fn()
     observation_space = env.observation_space
@@ -791,23 +815,35 @@ def _async_worker(
         while True:
             command, data = pipe.recv()
 
-            if command == "reset":
-                observation, info = env.reset(**data)
-                if shared_memory:
-                    write_to_shared_memory(
-                        observation_space, index, observation, shared_memory
-                    )
-                    observation = None
-                    autoreset = False
-                pipe.send(((observation, info), True))
-            elif command == "reset-noop":
-                pipe.send(((observation, {}), True))
-            elif command == "step":
-                if autoreset_mode == AutoresetMode.NEXT_STEP:
-                    if autoreset:
-                        observation, info = env.reset()
-                        reward, terminated, truncated = 0, False, False
-                    else:
+            if semaphore is not None and command in ("reset", "step"):
+                semaphore.acquire()
+            try:
+                if command == "reset":
+                    observation, info = env.reset(**data)
+                    if shared_memory:
+                        write_to_shared_memory(
+                            observation_space, index, observation, shared_memory
+                        )
+                        observation = None
+                        autoreset = False
+                    pipe.send(((observation, info), True))
+                elif command == "reset-noop":
+                    pipe.send(((observation, {}), True))
+                elif command == "step":
+                    if autoreset_mode == AutoresetMode.NEXT_STEP:
+                        if autoreset:
+                            observation, info = env.reset()
+                            reward, terminated, truncated = 0, False, False
+                        else:
+                            (
+                                observation,
+                                reward,
+                                terminated,
+                                truncated,
+                                info,
+                            ) = env.step(data)
+                        autoreset = terminated or truncated
+                    elif autoreset_mode == AutoresetMode.SAME_STEP:
                         (
                             observation,
                             reward,
@@ -815,85 +851,82 @@ def _async_worker(
                             truncated,
                             info,
                         ) = env.step(data)
-                    autoreset = terminated or truncated
-                elif autoreset_mode == AutoresetMode.SAME_STEP:
-                    (
-                        observation,
-                        reward,
-                        terminated,
-                        truncated,
-                        info,
-                    ) = env.step(data)
 
-                    if terminated or truncated:
-                        reset_observation, reset_info = env.reset()
+                        if terminated or truncated:
+                            reset_observation, reset_info = env.reset()
 
-                        info = {
-                            "final_info": info,
-                            "final_obs": observation,
-                            **reset_info,
-                        }
-                        observation = reset_observation
-                elif autoreset_mode == AutoresetMode.DISABLED:
-                    assert autoreset is False
-                    (
-                        observation,
-                        reward,
-                        terminated,
-                        truncated,
-                        info,
-                    ) = env.step(data)
-                else:
-                    raise ValueError(f"Unexpected autoreset_mode: {autoreset_mode}")
+                            info = {
+                                "final_info": info,
+                                "final_obs": observation,
+                                **reset_info,
+                            }
+                            observation = reset_observation
+                    elif autoreset_mode == AutoresetMode.DISABLED:
+                        assert autoreset is False
+                        (
+                            observation,
+                            reward,
+                            terminated,
+                            truncated,
+                            info,
+                        ) = env.step(data)
+                    else:
+                        raise ValueError(f"Unexpected autoreset_mode: {autoreset_mode}")
 
-                if shared_memory:
-                    write_to_shared_memory(
-                        observation_space, index, observation, shared_memory
+                    if shared_memory:
+                        write_to_shared_memory(
+                            observation_space, index, observation, shared_memory
+                        )
+                        observation = None
+
+                    pipe.send(
+                        ((observation, reward, terminated, truncated, info), True)
                     )
-                    observation = None
+                elif command == "close":
+                    pipe.send((None, True))
+                    break
+                elif command == "_call":
+                    name, args, kwargs = data
+                    if name in ["reset", "step", "close", "_setattr", "_check_spaces"]:
+                        raise ValueError(
+                            f"Trying to call function `{name}` with `call`, use `{name}` directly instead."
+                        )
 
-                pipe.send(((observation, reward, terminated, truncated, info), True))
-            elif command == "close":
-                pipe.send((None, True))
-                break
-            elif command == "_call":
-                name, args, kwargs = data
-                if name in ["reset", "step", "close", "_setattr", "_check_spaces"]:
-                    raise ValueError(
-                        f"Trying to call function `{name}` with `call`, use `{name}` directly instead."
-                    )
+                    attr = env.get_wrapper_attr(name)
+                    if callable(attr):
+                        pipe.send((attr(*args, **kwargs), True))
+                    else:
+                        pipe.send((attr, True))
+                elif command == "_setattr":
+                    name, value = data
+                    env.set_wrapper_attr(name, value)
+                    pipe.send((None, True))
+                elif command == "_check_spaces":
+                    obs_mode, single_obs_space, single_action_space = data
 
-                attr = env.get_wrapper_attr(name)
-                if callable(attr):
-                    pipe.send((attr(*args, **kwargs), True))
-                else:
-                    pipe.send((attr, True))
-            elif command == "_setattr":
-                name, value = data
-                env.set_wrapper_attr(name, value)
-                pipe.send((None, True))
-            elif command == "_check_spaces":
-                obs_mode, single_obs_space, single_action_space = data
-
-                pipe.send(
-                    (
+                    pipe.send(
                         (
                             (
-                                single_obs_space == observation_space
-                                if obs_mode == "same"
-                                else is_space_dtype_shape_equiv(
-                                    single_obs_space, observation_space
-                                )
+                                (
+                                    single_obs_space == observation_space
+                                    if obs_mode == "same"
+                                    else is_space_dtype_shape_equiv(
+                                        single_obs_space, observation_space
+                                    )
+                                ),
+                                single_action_space == action_space,
                             ),
-                            single_action_space == action_space,
-                        ),
-                        True,
+                            True,
+                        )
                     )
-                )
-            else:
-                raise RuntimeError(
-                    f"Received unknown command `{command}`. Must be one of [`reset`, `step`, `close`, `_call`, `_setattr`, `_check_spaces`]."
-                )
+                else:
+                    raise RuntimeError(
+                        f"Received unknown command `{command}`. Must be one of [`reset`, `step`, `close`, `_call`, `_setattr`, `_check_spaces`]."
+                    )
+            finally:
+                if semaphore is not None and command in ("reset", "step"):
+                    semaphore.release()
+
     except (KeyboardInterrupt, Exception):
         error_type, error_message, _ = sys.exc_info()
         trace = traceback.format_exc()

--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import multiprocessing
 import sys
 import time
@@ -156,7 +157,7 @@ class AsyncVectorEnv(VectorEnv):
                 the head process quits. However, ``daemon=True`` prevents subprocesses to spawn children,
                 so for some environments you may want to have it set to ``False``.
             worker: If set, then use that worker in a subprocess instead of a default one.
-                Can be useful to override some inner vector env logic, for instance, how resets on termination or truncation are handled.
+                Can be useful to override some inner vector env logic, for instance, how resets on termination or truncation are handled. See ``_async_worker`` for the expected signature.
             observation_mode: Defines how environment observation spaces should be batched. 'same' defines that there should be ``n`` copies of identical spaces.
                 'different' defines that there can be multiple observation spaces with different parameters though requires the same shape and dtype,
                 warning, may raise unexpected errors. Passing a ``Tuple[Space, Space]`` object allows defining a custom ``single_observation_space`` and
@@ -166,8 +167,9 @@ class AsyncVectorEnv(VectorEnv):
                 at any one time. If ``None`` (default), no limit is applied and all environments are executed in
                 parallel. When set, a shared semaphore limits how many worker processes can run an environment call
                 simultaneously, which can improve performance when the number of environments exceeds the number of
-                CPU cores (e.g. for physics simulators such as MuJoCo). Note that when using a custom ``worker``
-                with ``max_concurrency`` set, the worker must accept an additional ``semaphore`` argument.
+                CPU cores (e.g. for physics simulators such as MuJoCo). The limit applies only to ``reset``
+                and ``step``; every other call (:meth:`render`, :meth:`call`, :meth:`get_attr` and
+                :meth:`set_attr`) runs in all sub-environments simultaneously.
 
         Warnings:
             worker is an advanced mode option. It provides a high degree of flexibility and a high chance
@@ -179,6 +181,8 @@ class AsyncVectorEnv(VectorEnv):
                 (or, by default, the observation space of the first sub-environment).
             ValueError: If observation_space is a custom space (i.e. not a default space in Gym,
                 such as gymnasium.spaces.Box, gymnasium.spaces.Discrete, or gymnasium.spaces.Dict) and shared_memory is True.
+            ValueError: If ``max_concurrency`` is not a positive integer, or if a custom ``worker`` does not
+                accept the ``semaphore`` keyword argument.
         """
         self.env_fns = env_fns
         self.shared_memory = shared_memory
@@ -192,12 +196,27 @@ class AsyncVectorEnv(VectorEnv):
             if isinstance(autoreset_mode, AutoresetMode)
             else AutoresetMode(autoreset_mode)
         )
+        if max_concurrency is not None:
+            if not isinstance(max_concurrency, (int, np.integer)):
+                raise ValueError(
+                    f"`max_concurrency` must be an integer or None, got {type(max_concurrency)}."
+                )
+            if max_concurrency < 1:
+                raise ValueError(
+                    f"`max_concurrency` must be a positive or None, got {max_concurrency}."
+                )
         self.max_concurrency = max_concurrency
 
-        if max_concurrency is not None and max_concurrency < 1:
-            raise ValueError(
-                f"`max_concurrency` must be a positive integer or `None`, got {max_concurrency}."
-            )
+        if worker is not None:
+            # Checked here as, otherwise, the worker fails with a `TypeError` in the subprocess that the
+            # main process only sees as a bare `EOFError` from the closed pipe.
+            try:
+                inspect.signature(worker).bind(*(None,) * 8)
+            except TypeError as e:
+                raise ValueError(
+                    f"A custom `worker` must accept 8 arguments. Got the signature {inspect.signature(worker)} "
+                    f"which should match {inspect.signature(_async_worker)}."
+                ) from e
 
         self.num_envs = len(env_fns)
 
@@ -275,21 +294,19 @@ class AsyncVectorEnv(VectorEnv):
         with clear_mpi_env_vars():
             for idx, env_fn in enumerate(self.env_fns):
                 parent_pipe, child_pipe = ctx.Pipe()
-                process_args = (
-                    idx,
-                    CloudpickleWrapper(env_fn),
-                    child_pipe,
-                    parent_pipe,
-                    _obs_buffer,
-                    self.error_queue,
-                    self.autoreset_mode,
-                )
-                if semaphore is not None:
-                    process_args = (*process_args, semaphore)
                 process = ctx.Process(  # ty:ignore[unresolved-attribute]
                     target=target,
                     name=f"Worker<{type(self).__name__}>-{idx}",
-                    args=process_args,
+                    args=(
+                        idx,
+                        CloudpickleWrapper(env_fn),
+                        child_pipe,
+                        parent_pipe,
+                        _obs_buffer,
+                        self.error_queue,
+                        self.autoreset_mode,
+                        semaphore,
+                    ),
                 )
 
                 self.parent_pipes.append(parent_pipe)
@@ -801,7 +818,7 @@ def _async_worker(
     shared_memory: SynchronizedArray | dict[str, Any] | tuple[Any, ...],
     error_queue: Queue,
     autoreset_mode: AutoresetMode,
-    semaphore: synchronize.Semaphore | None = None,
+    semaphore: synchronize.Semaphore | None,
 ) -> None:
     env = env_fn()
     observation_space = env.observation_space
@@ -815,7 +832,8 @@ def _async_worker(
         while True:
             command, data = pipe.recv()
 
-            if semaphore is not None and command in ("reset", "step"):
+            permit_held = semaphore is not None and command in ("reset", "step")
+            if permit_held:
                 semaphore.acquire()
             try:
                 if command == "reset":
@@ -826,6 +844,12 @@ def _async_worker(
                         )
                         observation = None
                         autoreset = False
+
+                    # release before `send`, which blocks until the main process reads the pipe
+                    if permit_held:
+                        permit_held = False
+                        semaphore.release()
+
                     pipe.send(((observation, info), True))
                 elif command == "reset-noop":
                     pipe.send(((observation, {}), True))
@@ -879,6 +903,11 @@ def _async_worker(
                         )
                         observation = None
 
+                    # release before `send`, which blocks until the main process reads the pipe
+                    if permit_held:
+                        permit_held = False
+                        semaphore.release()
+
                     pipe.send(
                         ((observation, reward, terminated, truncated, info), True)
                     )
@@ -924,7 +953,7 @@ def _async_worker(
                         f"Received unknown command `{command}`. Must be one of [`reset`, `step`, `close`, `_call`, `_setattr`, `_check_spaces`]."
                     )
             finally:
-                if semaphore is not None and command in ("reset", "step"):
+                if permit_held:
                     semaphore.release()
 
     except (KeyboardInterrupt, Exception):

--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -1,6 +1,8 @@
 """Test the `SyncVectorEnv` implementation."""
 
+import multiprocessing
 import re
+import time
 import warnings
 from multiprocessing import TimeoutError
 
@@ -472,3 +474,81 @@ def test_async_vector_subenv_error():
         caught_warnings[4].message.args[0]
         == "\x1b[31mERROR: Raising the last exception back to the main process.\x1b[0m"
     )
+
+
+def test_max_concurrency_async_vector_env():
+    """Tests that `max_concurrency` limits the number of environments executing at any one time."""
+    with multiprocessing.Manager() as manager:
+        active_count = manager.Value("i", 0)
+        max_active = manager.Value("i", 0)
+        lock = manager.Lock()
+
+        def counting_step_func(self, action):
+            with lock:
+                active_count.value += 1
+                if active_count.value > max_active.value:
+                    max_active.value = active_count.value
+            time.sleep(0.1)
+            with lock:
+                active_count.value -= 1
+            return self.observation_space.sample(), 0.0, False, False, {}
+
+        envs = AsyncVectorEnv(
+            [lambda: GenericTestEnv(step_func=counting_step_func) for _ in range(4)],
+            max_concurrency=2,
+        )
+        envs.reset()
+        envs.step(envs.action_space.sample())
+        envs.close()
+
+        assert max_active.value <= 2
+        assert max_active.value > 1
+
+
+def test_max_concurrency_one_async_vector_env():
+    """Tests that `max_concurrency=1` fully serializes environment execution."""
+    with multiprocessing.Manager() as manager:
+        active_count = manager.Value("i", 0)
+        max_active = manager.Value("i", 0)
+        lock = manager.Lock()
+
+        def counting_step_func(self, action):
+            with lock:
+                active_count.value += 1
+                if active_count.value > max_active.value:
+                    max_active.value = active_count.value
+            time.sleep(0.05)
+            with lock:
+                active_count.value -= 1
+            return self.observation_space.sample(), 0.0, False, False, {}
+
+        envs = AsyncVectorEnv(
+            [lambda: GenericTestEnv(step_func=counting_step_func) for _ in range(4)],
+            max_concurrency=1,
+        )
+        envs.reset()
+        envs.step(envs.action_space.sample())
+        envs.close()
+
+        assert max_active.value == 1
+
+
+@pytest.mark.parametrize("max_concurrency", [0, -1, -10])
+def test_invalid_max_concurrency_async_vector_env(max_concurrency):
+    """Tests that invalid `max_concurrency` values raise a `ValueError`."""
+    with pytest.raises(ValueError):
+        AsyncVectorEnv(
+            [lambda: GenericTestEnv() for _ in range(2)],
+            max_concurrency=max_concurrency,
+        )
+
+
+def test_max_concurrency_greater_than_num_envs():
+    """Tests that `max_concurrency` greater than the number of environments works."""
+    envs = AsyncVectorEnv(
+        [lambda: GenericTestEnv() for _ in range(2)],
+        max_concurrency=4,
+    )
+    envs.reset()
+    envs.step(envs.action_space.sample())
+    envs.close()

--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -485,7 +485,7 @@ def custom_semaphore_worker(
     shared_memory,
     error_queue,
     autoreset_mode,
-    semaphore
+    semaphore,
 ):
     """A custom worker with the signature expected by `AsyncVectorEnv`."""
     _async_worker(
@@ -561,7 +561,6 @@ def test_max_concurrency_one_async_vector_env():
         assert max_active.value == 1
 
 
-
 @pytest.mark.parametrize("max_concurrency", [2.5, "2", 2.0])
 def test_non_integer_max_concurrency_async_vector_env(max_concurrency):
     """Tests that non-integer `max_concurrency` values are rejected rather than silently misused.
@@ -590,8 +589,6 @@ def test_invalid_max_concurrency_async_vector_env(max_concurrency):
         )
 
 
-
-
 @pytest.mark.parametrize("max_concurrency", [None, 2])
 def test_incompatible_custom_worker(max_concurrency):
     """Tests that a custom `worker` not accepting the `semaphore` argument is rejected upfront.
@@ -611,9 +608,7 @@ def test_incompatible_custom_worker(max_concurrency):
     ):
         pass
 
-    with pytest.raises(
-        ValueError, match="A custom `worker` must accept 8 arguments"
-    ):
+    with pytest.raises(ValueError, match="A custom `worker` must accept 8 arguments"):
         AsyncVectorEnv(
             [lambda: GenericTestEnv() for _ in range(2)],
             worker=custom_worker,

--- a/tests/vector/test_async_vector_env.py
+++ b/tests/vector/test_async_vector_env.py
@@ -16,6 +16,7 @@ from gymnasium.error import (
 )
 from gymnasium.spaces import Box, Discrete, MultiDiscrete, Tuple
 from gymnasium.vector import AsyncVectorEnv, AutoresetMode
+from gymnasium.vector.async_vector_env import _async_worker
 from tests.testing_env import GenericTestEnv
 from tests.vector.testing_utils import (
     CustomSpace,
@@ -476,19 +477,45 @@ def test_async_vector_subenv_error():
     )
 
 
+def custom_semaphore_worker(
+    index,
+    env_fn,
+    pipe,
+    parent_pipe,
+    shared_memory,
+    error_queue,
+    autoreset_mode,
+    semaphore
+):
+    """A custom worker with the signature expected by `AsyncVectorEnv`."""
+    _async_worker(
+        index,
+        env_fn,
+        pipe,
+        parent_pipe,
+        shared_memory,
+        error_queue,
+        autoreset_mode,
+        semaphore=semaphore,
+    )
+
+
 def test_max_concurrency_async_vector_env():
     """Tests that `max_concurrency` limits the number of environments executing at any one time."""
     with multiprocessing.Manager() as manager:
         active_count = manager.Value("i", 0)
         max_active = manager.Value("i", 0)
         lock = manager.Lock()
+        # Two environments must be executing simultaneously to get past the barrier, so the
+        # exact concurrency is asserted rather than relying on the two happening to overlap.
+        barrier = manager.Barrier(2)
 
         def counting_step_func(self, action):
             with lock:
                 active_count.value += 1
                 if active_count.value > max_active.value:
                     max_active.value = active_count.value
-            time.sleep(0.1)
+            barrier.wait(timeout=30)
             with lock:
                 active_count.value -= 1
             return self.observation_space.sample(), 0.0, False, False, {}
@@ -497,12 +524,13 @@ def test_max_concurrency_async_vector_env():
             [lambda: GenericTestEnv(step_func=counting_step_func) for _ in range(4)],
             max_concurrency=2,
         )
-        envs.reset()
-        envs.step(envs.action_space.sample())
-        envs.close()
+        try:
+            envs.reset()
+            envs.step(envs.action_space.sample())
+        finally:
+            envs.close(terminate=True)
 
-        assert max_active.value <= 2
-        assert max_active.value > 1
+        assert max_active.value == 2
 
 
 def test_max_concurrency_one_async_vector_env():
@@ -533,14 +561,79 @@ def test_max_concurrency_one_async_vector_env():
         assert max_active.value == 1
 
 
-@pytest.mark.parametrize("max_concurrency", [0, -1, -10])
-def test_invalid_max_concurrency_async_vector_env(max_concurrency):
-    """Tests that invalid `max_concurrency` values raise a `ValueError`."""
-    with pytest.raises(ValueError):
+
+@pytest.mark.parametrize("max_concurrency", [2.5, "2", 2.0])
+def test_non_integer_max_concurrency_async_vector_env(max_concurrency):
+    """Tests that non-integer `max_concurrency` values are rejected rather than silently misused.
+
+    Without an upfront type check, `2.5` fails much later with an opaque `TypeError` from
+    `BoundedSemaphore` and `True` silently becomes `max_concurrency=1`.
+    """
+    with pytest.raises(
+        ValueError, match="`max_concurrency` must be an integer or None, got"
+    ):
         AsyncVectorEnv(
             [lambda: GenericTestEnv() for _ in range(2)],
             max_concurrency=max_concurrency,
         )
+
+
+@pytest.mark.parametrize("max_concurrency", [0, -1, -10])
+def test_invalid_max_concurrency_async_vector_env(max_concurrency):
+    """Tests that invalid `max_concurrency` values raise a `ValueError`."""
+    with pytest.raises(
+        ValueError, match="`max_concurrency` must be a positive or None, got"
+    ):
+        AsyncVectorEnv(
+            [lambda: GenericTestEnv() for _ in range(2)],
+            max_concurrency=max_concurrency,
+        )
+
+
+
+
+@pytest.mark.parametrize("max_concurrency", [None, 2])
+def test_incompatible_custom_worker(max_concurrency):
+    """Tests that a custom `worker` not accepting the `semaphore` argument is rejected upfront.
+
+    The semaphore is always passed to the worker, so otherwise the worker dies with a `TypeError` in
+    the subprocess that the main process only reports as a bare `EOFError`.
+    """
+
+    def custom_worker(
+        index,
+        env_fn,
+        pipe,
+        parent_pipe,
+        shared_memory,
+        error_queue,
+        autoreset_mode,
+    ):
+        pass
+
+    with pytest.raises(
+        ValueError, match="A custom `worker` must accept 8 arguments"
+    ):
+        AsyncVectorEnv(
+            [lambda: GenericTestEnv() for _ in range(2)],
+            worker=custom_worker,
+            max_concurrency=max_concurrency,
+        )
+
+
+@pytest.mark.parametrize("max_concurrency", [None, 2])
+def test_custom_worker_with_semaphore(max_concurrency):
+    """Tests that a custom `worker` with the expected signature works with and without `max_concurrency`."""
+    envs = AsyncVectorEnv(
+        [lambda: GenericTestEnv() for _ in range(4)],
+        worker=custom_semaphore_worker,
+        max_concurrency=max_concurrency,
+    )
+    try:
+        envs.reset()
+        envs.step(envs.action_space.sample())
+    finally:
+        envs.close()
 
 
 def test_max_concurrency_greater_than_num_envs():
@@ -552,3 +645,29 @@ def test_max_concurrency_greater_than_num_envs():
     envs.reset()
     envs.step(envs.action_space.sample())
     envs.close()
+
+
+def test_max_concurrency_releases_before_pipe_send():
+    """Tests that a worker releases its `max_concurrency` permit before writing its result to the pipe.
+
+    The observation must be larger than the OS pipe buffer (~64 KB) for `send` to block, so this
+    only affects `shared_memory=False` (and any large `info`, e.g. `final_obs` under `SAME_STEP`).
+    """
+    envs = AsyncVectorEnv(
+        [
+            lambda: GenericTestEnv(
+                observation_space=Box(
+                    low=0, high=255, shape=(256, 256, 3), dtype=np.uint8
+                )
+            )
+            for _ in range(4)
+        ],
+        shared_memory=False,
+        max_concurrency=1,
+    )
+    try:
+        envs.reset_async()
+        obs, info = envs.reset_wait(timeout=10)
+        assert obs.shape == (4, 256, 256, 3)
+    finally:
+        envs.close(terminate=True)


### PR DESCRIPTION
# Description

Adds an optional `max_concurrency` parameter to `AsyncVectorEnv` that limits the number of environments executing (i.e. in `reset` or `step`) at any one time using a shared semaphore across the worker processes.

When the number of environments exceeds the number of CPU cores (e.g. physics simulators such as MuJoCo), running every environment simultaneously causes CPU oversubscription and degrades overall throughput. `max_concurrency` allows capping the number of concurrently-executing environments, which often improves wall-clock performance.

Fixes #1641

### Design

- `max_concurrency: int | None = None` – when `None` (default) behaviour is unchanged and all environments run in parallel.
- A shared `ctx.BoundedSemaphore(max_concurrency)` is passed to each worker **only** when `max_concurrency` is set, so the default worker call path and custom `worker` functions are unaffected (documented: a custom worker must accept an extra `semaphore` argument when the feature is used).
- The semaphore gates only `reset` and `step` commands – `close`/`_call`/`_setattr`/`_check_spaces`/`reset-noop` are not gated, so no deadlock or added latency for bookkeeping commands.
- `ValueError` is raised for `max_concurrency < 1`.
- Can be used through `gym.make_vec(..., vectorization_mode="async", vector_kwargs={"max_concurrency": N})`.

## Type of change

- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

- New tests in `tests/vector/test_async_vector_env.py`: `test_max_concurrency_async_vector_env` (limit respected), `test_max_concurrency_one_async_vector_env` (full serialization), `test_max_concurrency_greater_than_num_envs`, plus parametrized invalid-value tests.
- `python -m pytest tests/vector/test_async_vector_env.py -k max_concurrency`: **6 passed**
- Full `tests/vector` suite: 1454 passed, 6 failed (all pre-existing environment-dependency failures: pygame/Box2D not installed), 195 skipped. The 3 failures in `test_async_vector_env.py` itself reproduce identically on `main` without this change.
- Concurrency-cap timing evidence (4 envs, each `step` sleeps 0.2 s): unconstrained 0.20 s, `max_concurrency=2` 0.40 s, `max_concurrency=1` 0.80 s – confirming execution is genuinely serialized according to the cap.
- `ruff check` and `ruff format --check` clean; `ty check` reports only a pre-existing warning.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up) *(linters/formatters/type-checker verified locally)*
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation *(new parameter documented in the `AsyncVectorEnv` docstrings, which feed the API docs)*
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes *(remaining failures are pre-existing environment-dependency ones, identical on `main`)*
