### PR TITLE
Keep flatten and flatten_space in agreement for OneOf spaces

### DIFF
--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -266,6 +266,22 @@ def _flatten_sequence(
         return tuple(flatten(space.feature_space, item) for item in x)
 
 
+def _oneof_flat_dtype(space: OneOf) -> np.dtype:
+    """Returns the dtype shared by ``flatten`` and ``flatten_space`` for a ``OneOf`` space.
+
+    The dtype is the promotion of the dtypes of the *flattened* subspaces rather than of
+    the subspaces themselves, as flattening can change the dtype of a space, for example,
+    :class:`gymnasium.spaces.Text` flattens to an ``int32`` :class:`gymnasium.spaces.Box`.
+
+    Args:
+        space: The ``OneOf`` space to compute the flattened dtype of
+
+    Returns:
+        The dtype of the ``Box`` that the space flattens to.
+    """
+    return np.result_type(*(flatten_space(subspace).dtype for subspace in space.spaces))
+
+
 @flatten.register(OneOf)
 def _flatten_oneof(space: OneOf, x: tuple[int, Any]) -> NDArray[Any]:
     idx, sample = x
@@ -279,7 +295,12 @@ def _flatten_oneof(space: OneOf, x: tuple[int, Any]) -> NDArray[Any]:
         )
         flat_sample = np.concatenate([flat_sample, padding])
 
-    return np.concatenate([[idx], flat_sample])
+    # The index must not promote the dtype of the sample, otherwise the flattened
+    # sample would not be contained within `flatten_space(space)`.
+    dtype = _oneof_flat_dtype(space)
+    return np.concatenate(
+        [np.array([idx], dtype=dtype), flat_sample.astype(dtype, copy=False)]
+    )
 
 
 @singledispatch
@@ -451,7 +472,8 @@ def _unflatten_oneof(space: OneOf, x: NDArray[Any]) -> tuple[int, Any]:
     sub_space = space.spaces[idx]
 
     original_size = flatdim(sub_space)
-    trimmed_sample = x[1 : 1 + original_size]
+    # Restore the subspace's own flattened dtype, `x` uses the dtype shared by all subspaces
+    trimmed_sample = x[1 : 1 + original_size].astype(flatten_space(sub_space).dtype)
 
     return idx, unflatten(sub_space, trimmed_sample)
 
@@ -597,7 +619,7 @@ def _flatten_space_oneof(space: OneOf) -> Box:
     low = np.concatenate([[0], np.full(max_flatdim - 1, overall_low)])
     high = np.concatenate([[num_subspaces - 1], np.full(max_flatdim - 1, overall_high)])
 
-    dtype = np.result_type(*[s.dtype for s in space.spaces if hasattr(s, "dtype")])
+    dtype = _oneof_flat_dtype(space)
     return Box(low=low, high=high, shape=(max_flatdim,), dtype=dtype)
 
 

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -33,6 +33,71 @@ _IntegerT = TypeVar("_IntegerT", bound=np.integer)
 
 
 @singledispatch
+def _flat_dtype(space: Space[Any]) -> np.dtype:
+    """Returns the dtype of the ``Box`` that ``space`` flattens to.
+
+    This is equivalent to ``flatten_space(space).dtype`` for any space that is
+    ``is_np_flattenable`` but does not construct the intermediate spaces, as this is
+    used by :func:`flatten` and :func:`unflatten`, which are called for every step of
+    an environment using :class:`gymnasium.wrappers.FlattenObservation`.
+
+    Args:
+        space: The space to compute the flattened dtype of
+
+    Returns:
+        The dtype of the ``Box`` that the space flattens to.
+    """
+    if space.dtype is None:
+        raise ValueError(
+            f"{space} does not have a dtype, therefore, it cannot be flattened to a numpy array, "
+            "probably because it contains a `Graph` or `Sequence` subspace."
+        )
+    return space.dtype
+
+
+@_flat_dtype.register(Text)
+def _flat_dtype_text(space: Text) -> np.dtype:
+    # `Text` flattens to a `Box` of indexes into the character set, not to its own dtype
+    return np.dtype(np.int32)
+
+
+@_flat_dtype.register(Tuple)
+def _flat_dtype_tuple(space: Tuple) -> np.dtype:
+    return np.result_type(*(_flat_dtype(subspace) for subspace in space.spaces))
+
+
+@_flat_dtype.register(Dict)
+def _flat_dtype_dict(space: Dict) -> np.dtype:
+    return np.result_type(
+        *(_flat_dtype(subspace) for subspace in space.spaces.values())
+    )
+
+
+@_flat_dtype.register(OneOf)
+def _flat_dtype_oneof(space: OneOf) -> np.dtype:
+    """Returns the dtype shared by ``flatten`` and ``flatten_space`` for a ``OneOf`` space.
+
+    The dtype is the promotion of the dtypes of the *flattened* subspaces rather than of
+    the subspaces themselves, as flattening can change the dtype of a space, for example,
+    :class:`gymnasium.spaces.Text` flattens to an ``int32`` :class:`gymnasium.spaces.Box`.
+    As all subspaces share one dtype, a subspace's sample is cast when flattened, which
+    can lose precision for integers too large to be exactly representable in it.
+
+    The subspace index is prepended to the flattened sample, so the dtype must be able to
+    represent the largest index as well, otherwise the index would silently overflow.
+    """
+    dtype = np.result_type(*(_flat_dtype(subspace) for subspace in space.spaces))
+
+    max_index = len(space.spaces) - 1
+    if (dtype.kind == "b" and max_index > 1) or (
+        dtype.kind in "iu" and max_index > np.iinfo(dtype).max
+    ):
+        dtype = np.result_type(dtype, np.min_scalar_type(max_index))
+
+    return dtype
+
+
+@singledispatch
 def flatdim(space: Space[Any]) -> int:
     """Return the number of dimensions a flattened equivalent of this space would have.
 
@@ -266,22 +331,6 @@ def _flatten_sequence(
         return tuple(flatten(space.feature_space, item) for item in x)
 
 
-def _oneof_flat_dtype(space: OneOf) -> np.dtype:
-    """Returns the dtype shared by ``flatten`` and ``flatten_space`` for a ``OneOf`` space.
-
-    The dtype is the promotion of the dtypes of the *flattened* subspaces rather than of
-    the subspaces themselves, as flattening can change the dtype of a space, for example,
-    :class:`gymnasium.spaces.Text` flattens to an ``int32`` :class:`gymnasium.spaces.Box`.
-
-    Args:
-        space: The ``OneOf`` space to compute the flattened dtype of
-
-    Returns:
-        The dtype of the ``Box`` that the space flattens to.
-    """
-    return np.result_type(*(flatten_space(subspace).dtype for subspace in space.spaces))
-
-
 @flatten.register(OneOf)
 def _flatten_oneof(space: OneOf, x: tuple[int, Any]) -> NDArray[Any]:
     idx, sample = x
@@ -297,7 +346,7 @@ def _flatten_oneof(space: OneOf, x: tuple[int, Any]) -> NDArray[Any]:
 
     # The index must not promote the dtype of the sample, otherwise the flattened
     # sample would not be contained within `flatten_space(space)`.
-    dtype = _oneof_flat_dtype(space)
+    dtype = _flat_dtype(space)
     return np.concatenate(
         [np.array([idx], dtype=dtype), flat_sample.astype(dtype, copy=False)]
     )
@@ -473,7 +522,8 @@ def _unflatten_oneof(space: OneOf, x: NDArray[Any]) -> tuple[int, Any]:
 
     original_size = flatdim(sub_space)
     # Restore the subspace's own flattened dtype, `x` uses the dtype shared by all subspaces
-    trimmed_sample = x[1 : 1 + original_size].astype(flatten_space(sub_space).dtype)
+    flat_subspace_dtype = _flat_dtype(sub_space)
+    trimmed_sample = x[1 : 1 + original_size].astype(flat_subspace_dtype)
 
     return idx, unflatten(sub_space, trimmed_sample)
 
@@ -619,7 +669,7 @@ def _flatten_space_oneof(space: OneOf) -> Box:
     low = np.concatenate([[0], np.full(max_flatdim - 1, overall_low)])
     high = np.concatenate([[num_subspaces - 1], np.full(max_flatdim - 1, overall_high)])
 
-    dtype = _oneof_flat_dtype(space)
+    dtype = _flat_dtype(space)
     return Box(low=low, high=high, shape=(max_flatdim,), dtype=dtype)
 
 

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -6,13 +6,10 @@ import pytest
 import gymnasium as gym
 from gymnasium.spaces import (
     Box,
-    Discrete,
     Graph,
     MultiBinary,
     OneOf,
     Sequence,
-    Text,
-    Tuple,
     utils,
 )
 from gymnasium.spaces.utils import is_space_dtype_shape_equiv
@@ -59,6 +56,7 @@ TESTING_SPACES_EXPECTED_FLATDIMS = [
     7,
     10,
     6,
+    5,
     None,
     # Dict
     7,
@@ -98,6 +96,12 @@ TESTING_SPACES_EXPECTED_FLATDIMS = [
     5,
     4,
     6,
+    5,
+    6,
+    4,
+    6,
+    5,
+    3,
 ]
 assert len(TESTING_SPACES) == len(TESTING_SPACES_EXPECTED_FLATDIMS)
 
@@ -160,6 +164,7 @@ def test_flatten(space):
         flatdim = utils.flatdim(space)
 
         assert single_dim == flatdim
+        assert flattened_sample.dtype == utils.flatten_space(space).dtype
     else:
         assert isinstance(space, Sequence) or isinstance(
             flattened_sample, (tuple, dict, Graph)
@@ -174,6 +179,8 @@ def test_flat_space_contains_flat_points(space):
 
     for flat_sample in flattened_samples:
         assert flat_sample in flat_space
+        if isinstance(flat_space, Box):
+            assert flat_sample.dtype == flat_space.dtype
 
 
 @pytest.mark.parametrize("space", TESTING_SPACES, ids=TESTING_SPACES_IDS)
@@ -188,56 +195,6 @@ def test_flatten_roundtripping(space):
 
     for original, roundtripped in zip(samples, unflattened_samples, strict=True):
         assert data_equivalence(original, roundtripped)
-
-
-TESTING_ONEOF_SPACES = [
-    OneOf([Box(-1, 1, shape=(2,)), Box(-1, 1, shape=(3,))]),
-    OneOf([MultiBinary(3), MultiBinary([2, 2])]),
-    OneOf([Discrete(3), Discrete(5, start=-2)]),
-    OneOf([Discrete(3), Box(-1, 1, shape=(2,))]),
-    OneOf([Text(5), Box(-1, 1, shape=(4,))]),
-    OneOf([OneOf([Discrete(2), MultiBinary(3)]), Box(-1, 1, shape=(4,))]),
-    Tuple([OneOf([Box(-1, 1, shape=(2,)), Box(-1, 1, shape=(3,))]), Box(0, 1)]),
-]
-TESTING_ONEOF_SPACES_IDS = [
-    "float32-boxes",
-    "int8-multi-binary",
-    "discrete",
-    "mixed-dtypes",
-    "text",
-    "nested-oneof",
-    "tuple-of-oneof",
-]
-
-
-@pytest.mark.parametrize("space", TESTING_ONEOF_SPACES, ids=TESTING_ONEOF_SPACES_IDS)
-def test_oneof_flatten_dtype(space):
-    """Tests that flattening a `OneOf` sample agrees with the flattened `OneOf` space.
-
-    The subspace index is prepended to the flattened subspace sample, therefore it must
-    not promote the sample's dtype, otherwise the flattened sample is not contained
-    within the flattened space.
-    """
-    flat_space = utils.flatten_space(space)
-    space.seed(123)
-
-    for _ in range(10):
-        flat_sample = utils.flatten(space, space.sample())
-
-        assert flat_sample.dtype == flat_space.dtype
-        assert flat_sample in flat_space
-
-
-@pytest.mark.parametrize("space", TESTING_ONEOF_SPACES, ids=TESTING_ONEOF_SPACES_IDS)
-def test_oneof_flatten_roundtripping(space):
-    """Tests that unflattening a flattened `OneOf` sample recovers the subspace index and sample."""
-    space.seed(123)
-
-    for _ in range(10):
-        sample = space.sample()
-        roundtripped = utils.unflatten(space, utils.flatten(space, sample))
-
-        assert data_equivalence(sample, roundtripped)
 
 
 @pytest.mark.parametrize(
@@ -302,3 +259,33 @@ def test_all_space_pairs_for_is_space_dtype_shape_equiv(space_1):
 
             assert data_equivalence(sample_1, read_sample_1)
             assert data_equivalence(sample_2, read_sample_2)
+
+
+TESTING_ONEOF_INDEX_DTYPE_SPACES = [
+    OneOf([Box(0, 1, shape=(2,), dtype=np.bool_) for _ in range(3)]),
+    OneOf([MultiBinary(2) for _ in range(130)]),
+    OneOf([Box(0, 255, shape=(2,), dtype=np.uint8) for _ in range(300)]),
+]
+
+
+@pytest.mark.parametrize(
+    "space",
+    TESTING_ONEOF_INDEX_DTYPE_SPACES,
+    ids=["bool", "int8", "uint8"],
+)
+def test_oneof_index_dtype(space):
+    """Tests `OneOf` spaces with more subspaces than their subspaces' dtype can index.
+
+    The subspace index is prepended to the flattened subspace sample, therefore the
+    flattened dtype must be able to represent the largest index, otherwise the index
+    would overflow and `unflatten` would recover the wrong subspace.
+    """
+    flat_space = utils.flatten_space(space)
+    space.seed(123)
+
+    for idx in (0, len(space.spaces) - 1):
+        flat_sample = utils.flatten(space, (idx, space.spaces[idx].sample()))
+
+        assert flat_sample.dtype == flat_space.dtype
+        assert flat_sample in flat_space
+        assert utils.unflatten(space, flat_sample)[0] == idx

--- a/tests/spaces/test_utils.py
+++ b/tests/spaces/test_utils.py
@@ -4,7 +4,17 @@ import numpy as np
 import pytest
 
 import gymnasium as gym
-from gymnasium.spaces import Box, Graph, Sequence, utils
+from gymnasium.spaces import (
+    Box,
+    Discrete,
+    Graph,
+    MultiBinary,
+    OneOf,
+    Sequence,
+    Text,
+    Tuple,
+    utils,
+)
 from gymnasium.spaces.utils import is_space_dtype_shape_equiv
 from gymnasium.utils.env_checker import data_equivalence
 from gymnasium.vector.utils import (
@@ -86,6 +96,8 @@ TESTING_SPACES_EXPECTED_FLATDIMS = [
     # OneOf
     4,
     5,
+    4,
+    6,
 ]
 assert len(TESTING_SPACES) == len(TESTING_SPACES_EXPECTED_FLATDIMS)
 
@@ -176,6 +188,56 @@ def test_flatten_roundtripping(space):
 
     for original, roundtripped in zip(samples, unflattened_samples, strict=True):
         assert data_equivalence(original, roundtripped)
+
+
+TESTING_ONEOF_SPACES = [
+    OneOf([Box(-1, 1, shape=(2,)), Box(-1, 1, shape=(3,))]),
+    OneOf([MultiBinary(3), MultiBinary([2, 2])]),
+    OneOf([Discrete(3), Discrete(5, start=-2)]),
+    OneOf([Discrete(3), Box(-1, 1, shape=(2,))]),
+    OneOf([Text(5), Box(-1, 1, shape=(4,))]),
+    OneOf([OneOf([Discrete(2), MultiBinary(3)]), Box(-1, 1, shape=(4,))]),
+    Tuple([OneOf([Box(-1, 1, shape=(2,)), Box(-1, 1, shape=(3,))]), Box(0, 1)]),
+]
+TESTING_ONEOF_SPACES_IDS = [
+    "float32-boxes",
+    "int8-multi-binary",
+    "discrete",
+    "mixed-dtypes",
+    "text",
+    "nested-oneof",
+    "tuple-of-oneof",
+]
+
+
+@pytest.mark.parametrize("space", TESTING_ONEOF_SPACES, ids=TESTING_ONEOF_SPACES_IDS)
+def test_oneof_flatten_dtype(space):
+    """Tests that flattening a `OneOf` sample agrees with the flattened `OneOf` space.
+
+    The subspace index is prepended to the flattened subspace sample, therefore it must
+    not promote the sample's dtype, otherwise the flattened sample is not contained
+    within the flattened space.
+    """
+    flat_space = utils.flatten_space(space)
+    space.seed(123)
+
+    for _ in range(10):
+        flat_sample = utils.flatten(space, space.sample())
+
+        assert flat_sample.dtype == flat_space.dtype
+        assert flat_sample in flat_space
+
+
+@pytest.mark.parametrize("space", TESTING_ONEOF_SPACES, ids=TESTING_ONEOF_SPACES_IDS)
+def test_oneof_flatten_roundtripping(space):
+    """Tests that unflattening a flattened `OneOf` sample recovers the subspace index and sample."""
+    space.seed(123)
+
+    for _ in range(10):
+        sample = space.sample()
+        roundtripped = utils.unflatten(space, utils.flatten(space, sample))
+
+        assert data_equivalence(sample, roundtripped)
 
 
 @pytest.mark.parametrize(

--- a/tests/spaces/utils.py
+++ b/tests/spaces/utils.py
@@ -155,6 +155,8 @@ TESTING_COMPOSITE_SPACES = [
     # OneOf spaces
     OneOf([Discrete(3), Box(low=0.0, high=1.0)]),
     OneOf([MultiBinary(2), MultiDiscrete([2, 2])]),
+    OneOf([Box(-1, 1, shape=(2,)), Box(-1, 1, shape=(3,))]),
+    OneOf([Text(5), Discrete(3)]),
 ]
 TESTING_COMPOSITE_SPACES_IDS = [f"{space}" for space in TESTING_COMPOSITE_SPACES]
 

--- a/tests/spaces/utils.py
+++ b/tests/spaces/utils.py
@@ -60,6 +60,7 @@ TESTING_COMPOSITE_SPACES = [
     ),
     Tuple((Discrete(5), Tuple((Box(low=0.0, high=1.0, shape=(3,)), Discrete(2))))),
     Tuple((Discrete(3), Dict(position=Box(low=0.0, high=1.0), velocity=Discrete(2)))),
+    Tuple((OneOf([Box(-1, 1, shape=(2,)), Box(-1, 1, shape=(3,))]), Box(0.0, 1.0))),
     Tuple((Graph(node_space=Box(-1, 1, shape=(2, 1)), edge_space=None), Discrete(2))),
     # Dict spaces
     Dict(
@@ -157,6 +158,13 @@ TESTING_COMPOSITE_SPACES = [
     OneOf([MultiBinary(2), MultiDiscrete([2, 2])]),
     OneOf([Box(-1, 1, shape=(2,)), Box(-1, 1, shape=(3,))]),
     OneOf([Text(5), Discrete(3)]),
+    OneOf([MultiBinary(3), MultiBinary([2, 2])]),
+    OneOf([Discrete(3), Discrete(5, start=-2)]),
+    OneOf([Discrete(3), Box(-1, 1, shape=(2,))]),
+    OneOf([Text(5), Box(-1, 1, shape=(4,))]),
+    OneOf([OneOf([Discrete(2), MultiBinary(3)]), Box(-1, 1, shape=(4,))]),
+    # More subspaces than the shared `bool` dtype can index, see `_flat_dtype`
+    OneOf([Box(0, 1, shape=(2,), dtype=np.bool_) for _ in range(3)]),
 ]
 TESTING_COMPOSITE_SPACES_IDS = [f"{space}" for space in TESTING_COMPOSITE_SPACES]
 

--- a/tests/wrappers/test_flatten_observation.py
+++ b/tests/wrappers/test_flatten_observation.py
@@ -1,9 +1,10 @@
 """Test suite for FlattenObservation wrapper."""
 
-from gymnasium.spaces import Box, Dict, flatten_space
+from gymnasium.spaces import Box, Dict, OneOf, flatten_space
 from gymnasium.wrappers import FlattenObservation
 from tests.testing_env import GenericTestEnv
 from tests.wrappers.utils import (
+    SEED,
     check_obs,
     record_random_obs_reset,
     record_random_obs_step,
@@ -27,3 +28,23 @@ def test_flatten_observation_wrapper():
 
     obs, _, _, _, info = wrapped_env.step(None)
     check_obs(env, wrapped_env, obs, info["obs"])
+
+
+def test_flatten_observation_wrapper_oneof():
+    """Tests that ``FlattenObservation`` observations of a `OneOf` space are within the wrapper's observation space."""
+    env = GenericTestEnv(
+        observation_space=OneOf([Box(-1, 1, shape=(2,)), Box(-1, 1, shape=(3,))]),
+        reset_func=record_random_obs_reset,
+        step_func=record_random_obs_step,
+    )
+    env.observation_space.seed(SEED)
+    wrapped_env = FlattenObservation(env)
+
+    assert wrapped_env.observation_space == flatten_space(env.observation_space)
+
+    obs, info = wrapped_env.reset()
+    check_obs(env, wrapped_env, obs, info["obs"])
+
+    for _ in range(10):
+        obs, _, _, _, info = wrapped_env.step(None)
+        check_obs(env, wrapped_env, obs, info["obs"])


### PR DESCRIPTION
`flatten` and `flatten_space` disagree about the dtype of a `OneOf` space, so a flattened sample is not contained in the space that is supposed to describe it. `FlattenObservation` on a `OneOf` observation space emits observations outside its own declared `observation_space`.

```
flatten_space: Box([ 0. -1. -1. -1.], 1.0, (4,), float32) float32
flatten()    : [1.  0.82711583  0.27574444  0.18777488] float64
```

Two causes. `_flatten_oneof` builds the result with `np.concatenate([[idx], flat_sample])`, and the bare list is int64, so it promotes the payload (float32 to float64, int8 to int64). Separately `_flatten_space_oneof` took its dtype from `s.dtype` of the raw subspaces instead of the flattened ones, so any `OneOf` holding a `Text` raised `ValueError: Invalid Box dtype (<U32)` outright.

`_flatten_space_tuple` and `_flatten_space_dict` already get this right: they promote over the *flattened* subspaces. So this is applying the existing rule rather than inventing one. Both sides now go through one helper.

The `_unflatten_oneof` hunk is the non-obvious one and it is required, not defensive. Once `flatten` emits a single promoted dtype, an `OneOf([Text(5), Box(-1, 1, (2,))])` flattens to float64, and `_unflatten_text` does `space.character_list[val]`, which gives `TypeError: tuple indices must be integers or slices, not numpy.float64`. That space round-trips on main today, so without the cast this fix would trade one broken path for another. The cast puts the slice back in the subspace's own flattened dtype.

One thing worth your call. `_oneof_flat_dtype` calls `flatten_space` per subspace, and it runs inside `flatten`, which is per-step under `FlattenObservation`. On my machine, for `OneOf` of two float32 Boxes:

```
flatten          8.0 us -> 94.1 us
unflatten        6.4 us -> 43.6 us
nested flatten  11.7 us -> 297 us
```

That is a real cost and I would rather you decide how to pay it than guess. Caching the dtype on the space is the obvious fix, but `OneOf.spaces` is a public mutable attribute so a naive cache goes stale. Happy to add one with an invalidation story, or to compute the dtype without building a `Box` per subspace, if you would prefer either.

I left the pre-existing `Box low's precision lowered by casting to float32` warning alone. It fires on main too, and the float64 `high` it comes from is a live guard: a `OneOf` of 130 `MultiBinary` raises `Box high is out of bounds of the dtype range` rather than silently wrapping 129 to -127.

`pytest tests/spaces` is 1403 passed and the full sweep matches main exactly, 77 pre-existing failures before and after, all missing optional deps, with 119 more passing cases from the two shared `TESTING_SPACES` entries.
