### PR TITLE
Make Dict key sorting optional

### DIFF
--- a/gymnasium/spaces/dict.py
+++ b/gymnasium/spaces/dict.py
@@ -65,6 +65,7 @@ class Dict(
     """
 
     spaces: dict[str, Space[_T_co]]
+    sort_keys: bool
 
     def __init__(
         self,
@@ -72,29 +73,37 @@ class Dict(
             dict[str, Space[_T_co]] | Sequence[tuple[str, Space[_T_co]]] | None
         ) = None,
         seed: dict | int | np.random.Generator | None = None,
+        *,
+        sort_keys: bool = True,
         **spaces_kwargs: Space,
     ) -> None:
         """Constructor of :class:`Dict` space.
 
         This space can be instantiated in one of two ways: Either you pass a dictionary
         of spaces to :meth:`__init__` via the ``spaces`` argument, or you pass the spaces as separate
-        keyword arguments (where you will need to avoid the keys ``spaces`` and ``seed``)
+        keyword arguments (where you will need to avoid the keys ``spaces``, ``seed``, and ``sort_keys``)
 
         Args:
             spaces: A dictionary of spaces. This specifies the structure of the :class:`Dict` space
             seed: Optionally, you can use this argument to seed the RNGs of the spaces that make up the :class:`Dict` space.
+            sort_keys: Whether to sort the keys of a standard mapping. This does not affect :class:`OrderedDict` or sequence inputs.
             **spaces_kwargs: If ``spaces`` is ``None``, you need to pass the constituent spaces as keyword arguments, as described above.
         """
+        self.sort_keys = sort_keys
+
         if isinstance(spaces, OrderedDict):
             spaces_dict = dict(spaces.items())
         elif isinstance(spaces, collections.abc.Mapping):
-            # for legacy reasons, we need to preserve the sorted dictionary items.
-            # as this could matter for projects flatten the dictionary.
-            try:
-                spaces_dict = dict(sorted(spaces.items()))
-            except TypeError:
-                # Incomparable types (e.g. `int` vs. `str`, or user-defined types) found.
-                # The keys remain in the insertion order.
+            if self.sort_keys:
+                # for legacy reasons, we need to preserve the sorted dictionary items.
+                # as this could matter for projects flatten the dictionary.
+                try:
+                    spaces_dict = dict(sorted(spaces.items()))
+                except TypeError:
+                    # Incomparable types (e.g. `int` vs. `str`, or user-defined types) found.
+                    # The keys remain in the insertion order.
+                    spaces_dict = dict(spaces.items())
+            else:
                 spaces_dict = dict(spaces.items())
         elif isinstance(spaces, Sequence):
             spaces_dict = dict(spaces)

--- a/gymnasium/spaces/utils.py
+++ b/gymnasium/spaces/utils.py
@@ -557,7 +557,8 @@ def _flatten_space_dict(space: Dict) -> Box | Dict:
             dtype=np.result_type(*[s.dtype for s in space_list]),
         )
     return Dict(
-        spaces={key: flatten_space(space) for key, space in space.spaces.items()}
+        spaces={key: flatten_space(space) for key, space in space.spaces.items()},
+        sort_keys=space.sort_keys,
     )
 
 

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -130,6 +130,7 @@ def _batch_space_dict(space: Dict, n: int = 1) -> Dict:
     return Dict(
         {key: batch_space(subspace, n=n) for key, subspace in space.items()},
         seed=deepcopy(space.np_random),
+        sort_keys=space.sort_keys,
     )
 
 
@@ -280,6 +281,7 @@ def _batch_differing_spaces_dict(spaces: _PySequence[Dict]) -> Dict:
             for key in spaces[0].keys()
         },
         seed=deepcopy(spaces[0].np_random),
+        sort_keys=spaces[0].sort_keys,
     )
 
 

--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -232,7 +232,8 @@ class TimeAwareObservation(
                     f"The `dict_time_key` ({dict_time_key!r}) already exists in the observation space."
                 )
             observation_space = Dict(
-                {dict_time_key: time_space, **env.observation_space.spaces}
+                {dict_time_key: time_space, **env.observation_space.spaces},
+                sort_keys=env.observation_space.sort_keys,
             )
             self._append_data_func = lambda obs, time: {dict_time_key: time, **obs}
         elif isinstance(env.observation_space, Tuple):

--- a/gymnasium/wrappers/transform_observation.py
+++ b/gymnasium/wrappers/transform_observation.py
@@ -163,7 +163,8 @@ class FilterObservation(
                 )
 
             new_observation_space = spaces.Dict(
-                {key: env.observation_space[key] for key in filter_keys}
+                {key: env.observation_space[key] for key in filter_keys},
+                sort_keys=env.observation_space.sort_keys,
             )
             if len(new_observation_space) == 0:
                 raise ValueError(
@@ -732,7 +733,8 @@ class AddRenderObservation(
                 )
 
             obs_space = spaces.Dict(
-                {render_key: pixel_space, **env.observation_space.spaces}
+                {render_key: pixel_space, **env.observation_space.spaces},
+                sort_keys=env.observation_space.sort_keys,
             )
             TransformObservation.__init__(
                 self,

--- a/tests/spaces/test_dict.py
+++ b/tests/spaces/test_dict.py
@@ -41,18 +41,24 @@ def test_dict_init():
     with warnings.catch_warnings(record=True) as caught_warnings:
         # Sorting is applied to the keys
         a = Dict({"b": Box(low=0.0, high=1.0), "a": Discrete(2)})
-        assert a.keys() == {"a", "b"}
+        assert list(a.keys()) == ["a", "b"]
+
+        # Sorting is optional for standard dictionaries
+        unsorted = Dict(
+            {"b": Box(low=0.0, high=1.0), "a": Discrete(2)}, sort_keys=False
+        )
+        assert list(unsorted.keys()) == ["b", "a"]
 
         # Sorting is not applied to the keys
         b = Dict(OrderedDict(b=Box(low=0.0, high=1.0), a=Discrete(2)))
         c = Dict((("b", Box(low=0.0, high=1.0)), ("a", Discrete(2))))
         d = Dict(b=Box(low=0.0, high=1.0), a=Discrete(2))
-        assert b.keys() == c.keys() == d.keys() == {"b", "a"}
+        assert list(b.keys()) == list(c.keys()) == list(d.keys()) == ["b", "a"]
     assert len(caught_warnings) == 0
 
     # test sorting with different classes
     with warnings.catch_warnings(record=True) as caught_warnings:
-        assert Dict({1: Discrete(2), "a": Discrete(3)}).keys() == {1, "a"}
+        assert list(Dict({1: Discrete(2), "a": Discrete(3)}).keys()) == [1, "a"]
     assert len(caught_warnings) == 0
 
 

--- a/tests/vector/utils/test_space_utils.py
+++ b/tests/vector/utils/test_space_utils.py
@@ -9,7 +9,7 @@ import pytest
 
 from gymnasium import Space
 from gymnasium.error import CustomSpaceError
-from gymnasium.spaces import Box, Discrete, Tuple
+from gymnasium.spaces import Box, Dict, Discrete, Tuple
 from gymnasium.utils.env_checker import data_equivalence
 from gymnasium.vector.utils import (
     batch_differing_spaces,
@@ -159,6 +159,17 @@ def test_custom_space():
 
     empty_array = create_empty_array(custom_space)
     assert empty_array is None
+
+
+def test_batch_dict_preserves_key_order():
+    """Tests that batching doesn't reorder Dict spaces."""
+    space = Dict({"b": Discrete(2), "a": Discrete(3)}, sort_keys=False)
+
+    assert list(batch_space(space, n=2).keys()) == ["b", "a"]
+    assert list(batch_differing_spaces([space, copy.deepcopy(space)]).keys()) == [
+        "b",
+        "a",
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Adds a keyword-only `sort_keys` argument to `spaces.Dict`. It defaults to `True` to preserve existing behavior, while `sort_keys=False` retains standard mapping insertion order.

The setting is propagated through Gymnasium utilities and observation wrappers that reconstruct existing `Dict` spaces, including the batching path used by `FrameStackObservation`, so opted-out spaces are not silently reordered.

Fixes #1072

## Type of change

- [ ] Documentation only change (no code changed)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Screenshots

Not applicable.

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (the full pre-commit runner is not installed locally; Ruff lint and formatting checks pass for all changed files)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Validation

- `ruff check` on all changed files
- `ruff format --check` on all changed files
- `python -m pytest tests/spaces/test_dict.py tests/vector/utils/test_space_utils.py -q` (1,024 passed)