### PR TITLE
Fix MuJoCo camera controls

### DIFF
--- a/gymnasium/envs/mujoco/mujoco_rendering.py
+++ b/gymnasium/envs/mujoco/mujoco_rendering.py
@@ -12,6 +12,7 @@ from gymnasium.logger import warn
 # The marker API changed in MuJoCo 3.2.0, so we check the mujoco version and set a flag that
 # determines which function we use when adding markers to the scene.
 _MUJOCO_MARKER_LEGACY_MODE = Version(mujoco.__version__) < Version("3.2.0")
+_MUJOCO_CAMERA_LEGACY_MODE = Version(mujoco.__version__) < Version("3.11.0")
 
 
 def _import_egl(width, height):
@@ -568,6 +569,26 @@ class WindowViewer(BaseRender):
             glfw.destroy_window(self.window)
             glfw.terminate()
 
+    def _move_camera(self, action: int, rel_dx: float, rel_dy: float) -> None:
+        """Move the camera using the API for the installed MuJoCo version."""
+        if _MUJOCO_CAMERA_LEGACY_MODE:
+            mujoco.mjv_moveCamera(
+                self.model,
+                action,
+                rel_dx,
+                rel_dy,
+                self.scn,
+                self.cam,
+            )
+        else:
+            mujoco.mjv_moveCamera(
+                self.model,
+                action,
+                rel_dx,
+                rel_dy,
+                self.cam,
+            )
+
     def _cursor_pos_callback(
         self, window: "glfw.LP__GLFWwindow", xpos: float, ypos: float
     ):
@@ -597,9 +618,7 @@ class WindowViewer(BaseRender):
         dy = int(self._scale * ypos) - self._last_mouse_y
         width, height = glfw.get_framebuffer_size(window)
 
-        mujoco.mjv_moveCamera(
-            self.model, action, dx / width, dy / height, self.scn, self.cam
-        )
+        self._move_camera(action, dx / width, dy / height)
 
         self._last_mouse_x = int(self._scale * xpos)
         self._last_mouse_y = int(self._scale * ypos)
@@ -617,13 +636,10 @@ class WindowViewer(BaseRender):
         self._last_mouse_y = int(self._scale * y)
 
     def _scroll_callback(self, window, x_offset, y_offset: float):
-        mujoco.mjv_moveCamera(
-            self.model,
+        self._move_camera(
             mujoco.mjtMouse.mjMOUSE_ZOOM,
             0,
             -0.05 * y_offset,
-            self.scn,
-            self.cam,
         )
 
     def _create_overlay(self):


### PR DESCRIPTION
# Description

Fix camera interactions in human-rendered MuJoCo environments when using MuJoCo 3.11.0 or later.

MuJoCo 3.11 removed the `MjvScene` argument from `mjv_moveCamera`, while earlier versions still require it. As a result, dragging the mouse or scrolling inside the `WindowViewer` raises a `TypeError` and terminates the rendering loop with MuJoCo 3.11.

This change adds a version-aware `_move_camera` helper and uses it for both mouse movement and scrolling:

- MuJoCo versions earlier than 3.11 use the legacy six-argument API.
- MuJoCo 3.11 and later use the new five-argument API.

This restores camera movement and zooming with MuJoCo 3.11 while preserving compatibility with older supported versions.

No new dependencies are required.

Fixes #1677

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshots

Not applicable. This change prevents a runtime exception in the camera callbacks and does not alter the renderer's visual appearance.

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Testing

- Ran all pre-commit hooks successfully.
- Ran `pytest tests/envs/mujoco/test_mujoco_rendering.py`: 62 passed, 1 skipped.
- Manually verified mouse dragging and scroll zoom with MuJoCo 3.11.0.
- Manually verified backward compatibility with MuJoCo 3.5.0.