### PR TITLE
Fix rescale_box producing nan/inf for integer Box spaces

### DIFF
--- a/gymnasium/wrappers/utils.py
+++ b/gymnasium/wrappers/utils.py
@@ -230,6 +230,14 @@ def rescale_box(
     except AttributeError:
         high_low_diff_dtype = np.float64
 
+    # Rescaling maps the box onto a new, continuous range, so the transform and
+    # the resulting space are floating point. An integer input dtype would
+    # truncate the gradient and intercept to integers and cast the new (float)
+    # bounds back to integers, producing a degenerate transform (a constant
+    # forward map, and nan/inf from the inverse's division by a zero gradient).
+    # Promote to float in that case, mirroring NormalizeObservation.
+    dtype = box.dtype if np.issubdtype(box.dtype, np.floating) else np.float32
+
     min_finite = np.isfinite(new_min)
     max_finite = np.isfinite(new_max)
     both_finite = min_finite & max_finite
@@ -238,12 +246,12 @@ def rescale_box(
         box.high[both_finite], dtype=high_low_diff_dtype
     ) - np.array(box.low[both_finite], dtype=high_low_diff_dtype)
 
-    gradient = np.ones_like(new_min, dtype=box.dtype)
+    gradient = np.ones_like(new_min, dtype=dtype)
     gradient[both_finite] = (
         new_max[both_finite] - new_min[both_finite]
     ) / high_low_diff
 
-    intercept = np.zeros_like(new_min, dtype=box.dtype)
+    intercept = np.zeros_like(new_min, dtype=dtype)
     # In cases where both are finite, the lower operation takes precedence
     intercept[max_finite] = new_max[max_finite] - box.high[max_finite]
     intercept[min_finite] = (
@@ -254,7 +262,7 @@ def rescale_box(
         low=new_min,
         high=new_max,
         shape=box.shape,
-        dtype=box.dtype,
+        dtype=dtype,
     )
 
     def forward(obs: np.ndarray) -> np.ndarray:

--- a/tests/wrappers/test_rescale_action.py
+++ b/tests/wrappers/test_rescale_action.py
@@ -50,6 +50,33 @@ def test_rescale_action_wrapper():
         assert np.all(info["action"] == expected_action)
 
 
+def test_rescale_action_integer_box():
+    """Test rescaling an environment with an integer ``Box`` action space.
+
+    Rescaling maps onto a continuous range, so the rescaled action space and the
+    transform must be floating point. Previously the transform was computed in the
+    integer dtype, which truncated the gradient to zero and cast the float bounds
+    back to integers, so every action collapsed to a constant and the inverse map
+    returned ``nan`` / ``inf``.
+    """
+    env = GenericTestEnv(
+        step_func=record_action_step,
+        action_space=Box(0, 10, shape=(1,), dtype=np.int64),
+    )
+    wrapped_env = RescaleAction(env, min_action=-1.0, max_action=1.0)
+
+    assert wrapped_env.action_space == Box(-1.0, 1.0, shape=(1,), dtype=np.float32)
+
+    for sample_action, expected_action in (
+        (np.array([-1.0], dtype=np.float32), np.array([0.0], dtype=np.float32)),
+        (np.array([0.0], dtype=np.float32), np.array([5.0], dtype=np.float32)),
+        (np.array([1.0], dtype=np.float32), np.array([10.0], dtype=np.float32)),
+    ):
+        assert sample_action in wrapped_env.action_space
+        _, _, _, _, info = wrapped_env.step(sample_action)
+        assert np.allclose(info["action"], expected_action)
+
+
 def test_rescale_action_equal_bounds():
     """Test that a min action equal to the max action is rejected.
 


### PR DESCRIPTION
# Description

`rescale_box` (in `gymnasium/wrappers/utils.py`), which backs both `RescaleAction` and `RescaleObservation`, computes the gradient, intercept, and the output `Box` in the **input box's dtype**. For an integer `Box` this truncates the gradient to `0` and casts the new float bounds back to integers, so the rescaled space and transform are degenerate.

## Reproduction

```python
import numpy as np, gymnasium as gym
from gymnasium.spaces import Box
from gymnasium.wrappers import RescaleAction

class E(gym.Env):
    observation_space = Box(-1, 1, (1,), np.float32)
    action_space = Box(low=0, high=10, shape=(1,), dtype=np.int64)
    def reset(self, *, seed=None, options=None):
        super().reset(seed=seed); return np.zeros(1, np.float32), {}
    def step(self, a): return np.zeros(1, np.float32), 0.0, True, False, {"got": a}

w = RescaleAction(E(), min_action=-1.0, max_action=1.0)
print(w.action_space)                               # Box(-1, 1, (1,), int64)  -- float bounds cast to int
print(w.action(np.array([-1.0], np.float32)))       # [nan]
print(w.action(np.array([ 0.0], np.float32)))       # [inf]
print(w.action(np.array([ 1.0], np.float32)))       # [inf]
```

Expected: the policy actions `-1, 0, 1` map to `0, 5, 10`. Instead the gradient truncates to `0`, the forward map collapses to a constant, and the inverse (`RescaleAction` uses the backward map) divides by zero, yielding `nan`/`inf`. `RescaleObservation` on an integer observation `Box` is affected the same way.

## Fix

Rescaling maps a box onto a new continuous range, so the transform and the resulting space are floating point. When the input dtype is not already floating, compute the gradient/intercept and build the rescaled `Box` in `float32`. This mirrors `NormalizeObservation`, which already forces a `float32` output space for the same reason. Float boxes are completely unaffected (the output dtype and math are unchanged for them).

After the fix the reproduction above gives `Box(-1.0, 1.0, (1,), float32)` and maps `-1, 0, 1 -> 0, 5, 10`.

An alternative would be to reject integer boxes outright; I went with promotion to float since `RescaleObservation` of integer observations into a normalized float range is meaningful and consistent with `NormalizeObservation`. Happy to switch to a hard error instead if you'd prefer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Added `test_rescale_action_integer_box` in `tests/wrappers/test_rescale_action.py`, verified red/green: it fails on `main` (the wrapped space is `Box(-1, 1, int64)`) and passes with this change (`Box(-1.0, 1.0, float32)`, actions map `-1,0,1 -> 0,5,10`).
- `pytest tests/wrappers/test_rescale_action.py tests/wrappers/test_rescale_observation.py` and the vector rescale equivalence tests pass. The rest of `tests/wrappers/` shows no new failures versus `main` (the pre-existing failures are all optional-dependency/codec ones — CarRacing/Box2D, `record_video` ffmpeg, `resize_observation` opencv, `human_rendering` pygame — identical with and without this change in my environment).
- `ruff check`, `ruff format`, and `ty check` pass on the changed files.

Prepared with Claude Code (agent-assisted); the bug was found and all verification above was run locally.
