### PR TITLE
Fix AsyncVectorEnv final transition snapshots

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -11,6 +11,7 @@ from copy import deepcopy
 from enum import Enum
 from multiprocessing import Queue
 from multiprocessing.connection import Connection
+from multiprocessing.reduction import ForkingPickler
 from multiprocessing.sharedctypes import SynchronizedArray
 from typing import Any, TypeAlias
 
@@ -826,11 +827,15 @@ def _async_worker(
                     ) = env.step(data)
 
                     if terminated or truncated:
+                        # Snapshot the final values before reset can mutate reused buffers.
+                        final_obs, final_info = ForkingPickler.loads(
+                            ForkingPickler.dumps((observation, info))
+                        )
                         reset_observation, reset_info = env.reset()
 
                         info = {
-                            "final_info": info,
-                            "final_obs": observation,
+                            "final_info": final_info,
+                            "final_obs": final_obs,
                             **reset_info,
                         }
                         observation = reset_observation

--- a/tests/vector/test_autoreset_mode.py
+++ b/tests/vector/test_autoreset_mode.py
@@ -7,12 +7,20 @@ import pytest
 
 import gymnasium as gym
 from gymnasium import VectorizeMode
-from gymnasium.spaces import Discrete
+from gymnasium.spaces import Box, Discrete
 from gymnasium.utils.env_checker import data_equivalence
 from gymnasium.vector import AsyncVectorEnv, SyncVectorEnv
 from gymnasium.vector.vector_env import AutoresetMode
 from tests.spaces.utils import TESTING_SPACES, TESTING_SPACES_IDS
 from tests.testing_env import GenericTestEnv
+
+
+class PickleOnlyState:
+    def __init__(self):
+        self.value = 0
+
+    def __deepcopy__(self, memo):
+        raise TypeError("PickleOnlyState cannot be deep-copied")
 
 
 def count_reset(
@@ -28,6 +36,25 @@ def count_step(self: GenericTestEnv, action):
     self.count += 1
 
     return self.count, action, self.count == self.max_count, False, {}
+
+
+def reuse_reset_buffers(
+    self: GenericTestEnv, seed: int | None = None, options: dict | None = None
+):
+    super(GenericTestEnv, self).reset(seed=seed)
+
+    if not hasattr(self, "observation"):
+        self.observation = np.zeros(1, dtype=np.int64)
+        self.info = {"pickle_only": PickleOnlyState()}
+    self.observation[:] = 0
+    self.info["pickle_only"].value = 0
+    return self.observation, self.info
+
+
+def reuse_step_buffers(self: GenericTestEnv, action):
+    self.observation[:] = 1
+    self.info["pickle_only"].value = 1
+    return self.observation, action, True, False, self.info
 
 
 @pytest.mark.parametrize(
@@ -172,6 +199,39 @@ def test_autoreset_within_step(vectoriser):
     )
 
     envs.close()
+
+
+@pytest.mark.parametrize(
+    "vectoriser",
+    [
+        AsyncVectorEnv,
+        partial(AsyncVectorEnv, shared_memory=False),
+    ],
+    ids=["shared_memory=True", "shared_memory=False"],
+)
+def test_async_same_step_autoreset_copies_final_transition(vectoriser):
+    envs = vectoriser(
+        [
+            lambda: GenericTestEnv(
+                action_space=Discrete(1),
+                observation_space=Box(0, 1, shape=(1,), dtype=np.int64),
+                reset_func=reuse_reset_buffers,
+                step_func=reuse_step_buffers,
+            )
+        ],
+        autoreset_mode=AutoresetMode.SAME_STEP,
+    )
+
+    try:
+        envs.reset()
+        observations, _, _, _, info = envs.step([0])
+
+        assert observations.tolist() == [[0]]
+        assert info["pickle_only"][0].value == 0
+        assert info["final_obs"][0].tolist() == [1]
+        assert info["final_info"]["pickle_only"][0].value == 1
+    finally:
+        envs.close()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Fixes #1132.

`AsyncVectorEnv` in `SAME_STEP` autoreset mode currently calls `reset()` before the terminal observation and info are sent to the parent process. Environments that reuse their observation or info buffers can therefore mutate the terminal values into reset values before users receive them.

This snapshots the terminal observation and info before reset using the same `ForkingPickler` serializer that `multiprocessing.Connection.send` already requires. That keeps the existing Async IPC compatibility boundary (including values that are pickleable but intentionally not deepcopyable) while preserving the actual final transition in both shared-memory modes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- With only the regression test applied to unmodified `main`, both Async modes failed because `final_obs` was `[0]` instead of the terminal `[1]`.
- Focused regression: 2 passed (shared memory enabled and disabled).
- Complete `tests/vector/test_autoreset_mode.py`: 76 passed.
- Complete `tests/vector`: 1524 passed, 133 skipped, no failures.
- All applicable changed-file pre-commit hooks passed, including Ruff check/format, codespell, AST validation, private-key detection, and `ty`.
- `git diff --check` passed.

## AI assistance

This PR was implemented with AI assistance and independently reviewed and tested against the reported failure path.

# Checklist:

- [ ] I have run `pre-commit run --all-files` (all applicable hooks were run on the changed files)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation changes are not required because this restores existing final-transition semantics without changing the public API
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing vector unit tests pass locally
