### PR TITLE
Enforce distinct objects for Env.reset and Env.step observations and info

### DIFF
--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -110,6 +110,11 @@ class Env(Generic[ObsType, ActType]):
                 return undefined results. This was removed in OpenAI Gym v26 in favor of terminated and truncated attributes.
                 A done signal may be emitted for different reasons: Maybe the task underlying the environment was solved successfully,
                 a certain timelimit was exceeded, or the physics simulation has entered an invalid state.
+
+        Note:
+            Users commonly keep the data from every timestep, most obviously in a replay or rollout buffer, so each
+            call must return new observation and info objects rather than modifying and returning the same buffer.
+            :func:`gymnasium.utils.env_checker.check_env` checks this.
         """
         raise NotImplementedError
 
@@ -153,6 +158,10 @@ class Env(Generic[ObsType, ActType]):
                 (typically a numpy array) and is analogous to the observation returned by :meth:`step`.
             info (dictionary):  This dictionary contains auxiliary information complementing ``observation``. It should be analogous to
                 the ``info`` returned by :meth:`step`.
+
+        Note:
+            As with :meth:`step`, the returned observation and info must be new data rather than a
+            buffer that a previous call already returned and that this call has mutated in place.
         """
         # Initialize the RNG if the seed is manually passed
         if seed is not None:

--- a/gymnasium/envs/mujoco/humanoid_v5.py
+++ b/gymnasium/envs/mujoco/humanoid_v5.py
@@ -483,8 +483,8 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
         info = {
             "x_position": self.data.qpos[0],
             "y_position": self.data.qpos[1],
-            "tendon_length": self.data.ten_length,
-            "tendon_velocity": self.data.ten_velocity,
+            "tendon_length": self.data.ten_length.copy(),
+            "tendon_velocity": self.data.ten_velocity.copy(),
             "distance_from_origin": np.linalg.norm(self.data.qpos[0:2], ord=2),
             "x_velocity": x_velocity,
             "y_velocity": y_velocity,
@@ -535,7 +535,7 @@ class HumanoidEnv(MujocoEnv, utils.EzPickle):
         return {
             "x_position": self.data.qpos[0],
             "y_position": self.data.qpos[1],
-            "tendon_length": self.data.ten_length,
-            "tendon_velocity": self.data.ten_velocity,
+            "tendon_length": self.data.ten_length.copy(),
+            "tendon_velocity": self.data.ten_velocity.copy(),
             "distance_from_origin": np.linalg.norm(self.data.qpos[0:2], ord=2),
         }

--- a/gymnasium/envs/mujoco/humanoidstandup_v5.py
+++ b/gymnasium/envs/mujoco/humanoidstandup_v5.py
@@ -430,8 +430,8 @@ class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
             "x_position": self.data.qpos[0],
             "y_position": self.data.qpos[1],
             "z_distance_from_origin": self.data.qpos[2] - self.init_qpos[2],
-            "tendon_length": self.data.ten_length,
-            "tendon_velocity": self.data.ten_velocity,
+            "tendon_length": self.data.ten_length.copy(),
+            "tendon_velocity": self.data.ten_velocity.copy(),
             **reward_info,
         }
 
@@ -481,6 +481,6 @@ class HumanoidStandupEnv(MujocoEnv, utils.EzPickle):
             "x_position": self.data.qpos[0],
             "y_position": self.data.qpos[1],
             "z_distance_from_origin": self.data.qpos[2] - self.init_qpos[2],
-            "tendon_length": self.data.ten_length,
-            "tendon_velocity": self.data.ten_velocity,
+            "tendon_length": self.data.ten_length.copy(),
+            "tendon_velocity": self.data.ten_velocity.copy(),
         }

--- a/gymnasium/utils/env_checker.py
+++ b/gymnasium/utils/env_checker.py
@@ -16,6 +16,7 @@ These projects are covered by the MIT License.
 
 import inspect
 from copy import deepcopy
+from itertools import combinations
 from typing import Any
 
 import numpy as np
@@ -25,6 +26,7 @@ from gymnasium import logger, spaces
 from gymnasium.utils.passive_env_checker import (
     check_action_space,
     check_observation_space,
+    data_shares_objects,
     env_render_passive_checker,
     env_reset_passive_checker,
     env_step_passive_checker,
@@ -265,6 +267,43 @@ def check_step_determinism(env: gym.Env, seed: int = 123) -> None:
         )
 
 
+def check_returned_data_not_reused(env: gym.Env, seed: int = 123) -> None:
+    """Check that the environment returns new observation and info data on every call.
+
+    As this compares identity rather than value, an array or dictionary that an environment intends
+    to be constant must also be copied into each observation or info, as neither the user nor this
+    check can know that a later call will not modify it.
+
+    Raises:
+        AssertionError: Two calls returned observations or infos that share an object.
+    """
+    env.action_space.seed(seed)
+
+    calls = [("env.reset() (call 1)", env.reset(seed=seed))]
+    for _ in range(2):
+        obs, _, terminated, truncated, info = env.step(env.action_space.sample())
+        calls.append((f"env.step() (call {len(calls) + 1})", (obs, info)))
+
+        if terminated or truncated:
+            break
+    # `AutoresetMode.SAME_STEP` resets a sub-environment as it terminates or truncates
+    calls.append((f"env.reset() (call {len(calls) + 1})", env.reset(seed=seed)))
+
+    for (source_1, (obs_1, info_1)), (source_2, (obs_2, info_2)) in combinations(
+        calls, 2
+    ):
+        assert not data_shares_objects(obs_1, obs_2), (
+            f"The observations returned by `{source_1}` and `{source_2}` share an object, "
+            "therefore, modifying one will modify the other. Environments must return new "
+            "observation data on every call as users keep the data returned to them."
+        )
+        assert not data_shares_objects(info_1, info_2), (
+            f"The infos returned by `{source_1}` and `{source_2}` share an object, therefore, "
+            "modifying one will modify the other. Environments must return new info data on "
+            "every call as users keep the data returned to them."
+        )
+
+
 def check_reset_return_info_deprecation(env: gym.Env) -> None:
     """Makes sure support for deprecated `return_info` argument is dropped.
 
@@ -437,6 +476,7 @@ def check_env(
 
     # ==== Check the step method ====
     check_step_determinism(env)
+    check_returned_data_not_reused(env)
 
     # ==== Check the render method and the declared render modes ====
     if not skip_render_check:

--- a/gymnasium/utils/passive_env_checker.py
+++ b/gymnasium/utils/passive_env_checker.py
@@ -176,6 +176,77 @@ def check_obs(obs: Any, observation_space: spaces.Space[Any], method_name: str) 
         logger.warn(f"{pre} is not within the observation space with exception: {e}")
 
 
+def data_shares_objects(data_1: Any, data_2: Any) -> bool:
+    """Check if data 1 and 2 share a mutable object, i.e. observations, actions, info.
+
+    Where :func:`data_equivalence` compares the values of two data structures, this compares their
+    identity. Immutable and unknown data is ignored.
+
+    Args:
+        data_1: data structure 1 (expects equivalent data shape to data_2)
+        data_2: data structure 2
+
+    Returns:
+        If data 1 and 2 share a mutable object
+    """
+    if type(data_1) is not type(data_2):
+        return False
+    elif isinstance(data_1, dict):
+        return data_1 is data_2 or any(
+            data_shares_objects(data_1[key], data_2[key])
+            for key in data_1.keys() & data_2.keys()
+        )
+    elif isinstance(data_1, tuple):
+        # A tuple is immutable, however the data within it might not be.
+        #   Differing lengths simply means fewer positions to compare, so `strict=False`.
+        return data_1 is data_2 or any(
+            data_shares_objects(o_1, o_2)
+            for o_1, o_2 in zip(data_1, data_2, strict=False)
+        )
+    elif isinstance(data_1, np.ndarray):
+        if data_1.dtype == object:
+            return data_1 is data_2 or any(
+                data_shares_objects(o_1, o_2)
+                for o_1, o_2 in zip(data_1.flat, data_2.flat, strict=False)
+            )
+        else:
+            # `shares_memory` additionally catches a new view of a reused buffer, e.g. `buffer[:]`
+            return bool(np.shares_memory(data_1, data_2))
+    else:
+        # Immutable data (e.g. `int`) is commonly interned, such that `is` would spuriously
+        #   match equal values, and an unknown object is not treated as timestep data.
+        return False
+
+
+def env_data_reuse_passive_checker(
+    previous_data: tuple[Any, dict[str, Any]],
+    data: tuple[Any, dict[str, Any]],
+    previous_source: str,
+    source: str,
+) -> None:
+    """Warns if two calls returned observation or info data that share an object.
+
+    Users commonly keep the data from every timestep, most obviously in a replay or rollout buffer,
+    so an environment that modifies and returns the same buffer corrupts data the user still holds.
+    See :meth:`gymnasium.Env.step` and :func:`gymnasium.utils.env_checker.check_env`.
+    """
+    previous_obs, previous_info = previous_data
+    obs, info = data
+
+    if data_shares_objects(previous_obs, obs):
+        logger.warn(
+            f"The observations returned by `{previous_source}` and the following `{source}` share "
+            "an object, therefore, modifying one will modify the other. Environments should return "
+            "new observation data on every call as users commonly keep the data returned to them."
+        )
+    if data_shares_objects(previous_info, info):
+        logger.warn(
+            f"The infos returned by `{previous_source}` and the following `{source}` share an "
+            "object, therefore, modifying one will modify the other. Environments should return "
+            "new info data on every call as users commonly keep the data returned to them."
+        )
+
+
 def env_reset_passive_checker(
     env: Env[_ObsT, Any], **kwargs: Any
 ) -> tuple[_ObsT, dict[str, Any]]:

--- a/gymnasium/utils/passive_env_checker.py
+++ b/gymnasium/utils/passive_env_checker.py
@@ -199,7 +199,7 @@ def data_shares_objects(data_1: Any, data_2: Any) -> bool:
     elif isinstance(data_1, tuple):
         # A tuple is immutable, however the data within it might not be.
         #   Differing lengths simply means fewer positions to compare, so `strict=False`.
-        return data_1 is data_2 or any(
+        return any(
             data_shares_objects(o_1, o_2)
             for o_1, o_2 in zip(data_1, data_2, strict=False)
         )

--- a/gymnasium/wrappers/common.py
+++ b/gymnasium/wrappers/common.py
@@ -21,6 +21,7 @@ from gymnasium.error import ResetNeeded
 from gymnasium.utils.passive_env_checker import (
     check_action_space,
     check_observation_space,
+    env_data_reuse_passive_checker,
     env_render_passive_checker,
     env_reset_passive_checker,
     env_step_passive_checker,
@@ -278,15 +279,35 @@ class PassiveEnvChecker(
         self.checked_render: bool = False
         self.close_called: bool = False
 
+        # For checking that `reset` and `step` do not reuse their observation and info objects,
+        #   comparing the reset with the first step, then the first step with the second step.
+        self.checked_data_reuse: bool = False
+        self._previous_data: tuple[ObsType, dict[str, Any]] | None = None
+
     def step(
         self, action: ActType
     ) -> tuple[ObsType, SupportsFloat, bool, bool, dict[str, Any]]:
         """Steps through the environment that on the first call will run the `passive_env_step_check`."""
         if self.checked_step is False:
             self.checked_step = True
-            return env_step_passive_checker(self.env, action)
+            result = env_step_passive_checker(self.env, action)
+            obs, reward, terminated, truncated, info = result
+
+            env_data_reuse_passive_checker(
+                self._previous_data, (obs, info), "reset", "step"
+            )
+            self._previous_data = (obs, info)
+            return result
         else:
-            return self.env.step(action)
+            result = self.env.step(action)
+            obs, reward, terminated, truncated, info = result
+
+            if self._previous_data is not None:
+                env_data_reuse_passive_checker(
+                    self._previous_data, (obs, info), "step", "step"
+                )
+                self._previous_data = None
+            return result
 
     def reset(
         self, *, seed: int | None = None, options: dict[str, Any] | None = None
@@ -294,7 +315,10 @@ class PassiveEnvChecker(
         """Resets the environment that on the first call will run the `passive_env_reset_check`."""
         if self.checked_reset is False:
             self.checked_reset = True
-            return env_reset_passive_checker(self.env, seed=seed, options=options)
+            self._previous_data = env_reset_passive_checker(
+                self.env, seed=seed, options=options
+            )
+            return self._previous_data
         else:
             return self.env.reset(seed=seed, options=options)
 

--- a/gymnasium/wrappers/common.py
+++ b/gymnasium/wrappers/common.py
@@ -291,22 +291,25 @@ class PassiveEnvChecker(
         if self.checked_step is False:
             self.checked_step = True
             result = env_step_passive_checker(self.env, action)
-            obs, reward, terminated, truncated, info = result
 
+            obs, reward, terminated, truncated, info = result
             env_data_reuse_passive_checker(
                 self._previous_data, (obs, info), "reset", "step"
             )
             self._previous_data = (obs, info)
+
             return result
         else:
             result = self.env.step(action)
-            obs, reward, terminated, truncated, info = result
 
-            if self._previous_data is not None:
+            if self.checked_data_reuse is False:
+                obs, reward, terminated, truncated, info = result
                 env_data_reuse_passive_checker(
                     self._previous_data, (obs, info), "step", "step"
                 )
                 self._previous_data = None
+                self.checked_data_reuse = True
+
             return result
 
     def reset(

--- a/tests/utils/test_env_checker.py
+++ b/tests/utils/test_env_checker.py
@@ -390,13 +390,12 @@ def test_data_shares_objects_distinct(data_1, data_2, shared):
 
 def test_data_shares_objects_shared():
     """Every mutable container and a view of an array must be detected as shared."""
-    array, dictionary, listing = np.zeros(3), {"a": np.zeros(3)}, [np.zeros(3)]
+    array, dictionary = np.zeros(3), {"a": np.zeros(3)}
 
     assert data_shares_objects(array, array)
     assert data_shares_objects(array, array[:])
     assert data_shares_objects(dictionary, dictionary)
     assert data_shares_objects({"a": array}, {"a": array})
-    assert data_shares_objects(listing, listing)
     assert data_shares_objects((array,), (array,))
     assert data_shares_objects(
         np.array([dictionary], dtype=object), np.array([dictionary], dtype=object)

--- a/tests/utils/test_env_checker.py
+++ b/tests/utils/test_env_checker.py
@@ -16,8 +16,10 @@ from gymnasium.utils.env_checker import (
     check_reset_return_info_deprecation,
     check_reset_return_type,
     check_reset_seed_determinism,
+    check_returned_data_not_reused,
     check_seed_deprecation,
     check_step_determinism,
+    data_shares_objects,
 )
 from tests.testing_env import GenericTestEnv
 
@@ -324,6 +326,131 @@ def test_check_step_determinism_snapshots_reused_observations():
         match="Deterministic step observations are not equivalent for the same seed and action",
     ):
         check_step_determinism(env)
+
+
+def _buffer_reusing_info_reset(self, seed=None, options=None):
+    """Return a reused info dictionary, mutated in place on every call."""
+    super(GenericTestEnv, self).reset(seed=seed)
+    self._info = getattr(self, "_info", {})
+    self._info["count"] = 0
+    return self.observation_space.sample(), self._info
+
+
+def _buffer_reusing_info_step(self, action):
+    """Mutate one shared info dictionary on every step call."""
+    self._info["count"] += 1
+    return self.observation_space.sample(), 0.0, False, False, self._info
+
+
+def _buffer_viewing_reset(self, seed=None, options=None):
+    """Return a new view of a reused buffer, which is not the same object but shares its memory."""
+    super(GenericTestEnv, self).reset(seed=seed)
+    self._observation_buffer = getattr(
+        self, "_observation_buffer", np.zeros(1, dtype=np.float32)
+    )
+    self._observation_buffer[...] = 0
+    return self._observation_buffer[:], {}
+
+
+def _buffer_viewing_step(self, action):
+    """Mutate one shared observation buffer, returning a new view of it on every step call."""
+    self._observation_buffer += 1
+    return self._observation_buffer[:], 0.0, False, False, {}
+
+
+def test_check_returned_data_not_reused_buffer_view():
+    """A new view of a reused buffer must be rejected, as modifying it modifies the older view."""
+    env = GenericTestEnv(
+        observation_space=spaces.Box(0, 100, (1,), dtype=np.float32),
+        reset_func=_buffer_viewing_reset,
+        step_func=_buffer_viewing_step,
+    )
+
+    with pytest.raises(AssertionError, match="share an object"):
+        check_returned_data_not_reused(env)
+
+
+@pytest.mark.parametrize(
+    "data_1,data_2,shared",
+    [
+        (np.zeros(3), np.zeros(3), False),
+        (0, 0, False),
+        ("abc", "abc", False),
+        ({"a": np.zeros(3)}, {"a": np.zeros(3)}, False),
+        # differing types and keys mean there is nothing that can be shared
+        (np.zeros(3), 0, False),
+        ({"a": np.zeros(3)}, {"b": np.zeros(3)}, False),
+    ],
+    ids=["arrays", "ints", "strs", "dicts", "differing types", "differing keys"],
+)
+def test_data_shares_objects_distinct(data_1, data_2, shared):
+    """Distinct data must never be reported as sharing an object."""
+    assert data_shares_objects(data_1, data_2) is shared
+
+
+def test_data_shares_objects_shared():
+    """Every mutable container and a view of an array must be detected as shared."""
+    array, dictionary, listing = np.zeros(3), {"a": np.zeros(3)}, [np.zeros(3)]
+
+    assert data_shares_objects(array, array)
+    assert data_shares_objects(array, array[:])
+    assert data_shares_objects(dictionary, dictionary)
+    assert data_shares_objects({"a": array}, {"a": array})
+    assert data_shares_objects(listing, listing)
+    assert data_shares_objects((array,), (array,))
+    assert data_shares_objects(
+        np.array([dictionary], dtype=object), np.array([dictionary], dtype=object)
+    )
+
+
+def test_check_returned_data_not_reused():
+    """A reused observation buffer must be rejected as users keep the data returned to them."""
+    env = GenericTestEnv(
+        observation_space=spaces.Box(0, 100, (1,), dtype=np.float32),
+        reset_func=_buffer_reusing_deterministic_reset,
+        step_func=_buffer_reusing_nondeterministic_step,
+    )
+
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "The observations returned by `env.reset() (call 1)` and `env.step() (call 2)` "
+            "share an object"
+        ),
+    ):
+        check_returned_data_not_reused(env)
+
+
+def test_check_returned_data_not_reused_info():
+    """A reused info dictionary must be rejected in the same way as a reused observation."""
+    env = GenericTestEnv(
+        reset_func=_buffer_reusing_info_reset, step_func=_buffer_reusing_info_step
+    )
+
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "The infos returned by `env.reset() (call 1)` and `env.step() (call 2)` "
+            "share an object"
+        ),
+    ):
+        check_returned_data_not_reused(env)
+
+
+def test_check_returned_data_not_reused_immutable_info_value():
+    """Returning the same immutable info value on every call is safe and must be allowed."""
+    constant = ("unchanging", 3)
+
+    def reset_func(self, seed=None, options=None):
+        super(GenericTestEnv, self).reset(seed=seed)
+        return self.observation_space.sample(), {"constant": constant}
+
+    def step_func(self, action):
+        return self.observation_space.sample(), 0, False, False, {"constant": constant}
+
+    check_returned_data_not_reused(
+        GenericTestEnv(reset_func=reset_func, step_func=step_func)
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_passive_env_checker.py
+++ b/tests/utils/test_passive_env_checker.py
@@ -478,7 +478,10 @@ def test_env_data_reuse_passive_checker():
         env_data_reuse_passive_checker((buffer[:], {}), (buffer[:], {}), "step", "step")
 
     shared, fresh = np.zeros(3), np.zeros(3)
-    with pytest.warns(UserWarning, match=re.escape("Shared keys: ['shared']")):
+    with pytest.warns(
+        UserWarning,
+        match="The infos returned by `reset` and the following `step` share an object",
+    ):
         env_data_reuse_passive_checker(
             (fresh, {"shared": shared, "fresh": np.zeros(3)}),
             (np.zeros(3), {"shared": shared, "fresh": np.zeros(3)}),

--- a/tests/utils/test_passive_env_checker.py
+++ b/tests/utils/test_passive_env_checker.py
@@ -11,6 +11,7 @@ from gymnasium.utils.passive_env_checker import (
     check_action_space,
     check_obs,
     check_observation_space,
+    env_data_reuse_passive_checker,
     env_render_passive_checker,
     env_reset_passive_checker,
     env_step_passive_checker,
@@ -453,3 +454,47 @@ def test_passive_render_checker(test, env: GenericTestEnv, message: str):
             with pytest.raises(test, match=f"^{re.escape(message)}$"):
                 env_render_passive_checker(env)
         assert len(caught_warnings) == 0
+
+
+def test_env_data_reuse_passive_checker():
+    """Sharing an observation or info object between two calls must warn."""
+    buffer = np.zeros(3)
+
+    with pytest.warns(
+        UserWarning,
+        match=re.escape(
+            "The observations returned by `reset` and the following `step` share an object"
+        ),
+    ):
+        env_data_reuse_passive_checker((buffer, {}), (buffer, {}), "reset", "step")
+
+    # a new view of a reused buffer is a different object, but modifying it modifies the other
+    with pytest.warns(
+        UserWarning,
+        match=re.escape(
+            "The observations returned by `step` and the following `step` share an object"
+        ),
+    ):
+        env_data_reuse_passive_checker((buffer[:], {}), (buffer[:], {}), "step", "step")
+
+    shared, fresh = np.zeros(3), np.zeros(3)
+    with pytest.warns(UserWarning, match=re.escape("Shared keys: ['shared']")):
+        env_data_reuse_passive_checker(
+            (fresh, {"shared": shared, "fresh": np.zeros(3)}),
+            (np.zeros(3), {"shared": shared, "fresh": np.zeros(3)}),
+            "reset",
+            "step",
+        )
+
+
+def test_env_data_reuse_passive_checker_distinct_data():
+    """Distinct observation and info data must not warn."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        env_data_reuse_passive_checker(
+            (np.zeros(3), {"a": np.zeros(3), "b": 0}),
+            (np.zeros(3), {"a": np.zeros(3), "b": 0}),
+            "reset",
+            "step",
+        )

--- a/tests/wrappers/test_passive_env_checker.py
+++ b/tests/wrappers/test_passive_env_checker.py
@@ -149,22 +149,18 @@ def test_passive_checker_wrapper_data_reuse():
         for _ in range(4):
             checker_env.step(0)
 
-    sources = [
-        str(warning.message)
-        .split("returned by `")[1]
-        .split("` share an object")[0]
-        .replace("` and the following `", " -> ")
-        for warning in caught_warnings
-        if "share an object" in str(warning.message)
+    assert len(caught_warnings) == 4
+    expected_warnings = [
+        "The observations returned by `reset` and the following `step` share an object",
+        "The infos returned by `reset` and the following `step` share an object",
+        "The observations returned by `step` and the following `step` share an object",
+        "The infos returned by `step` and the following `step` share an object",
     ]
-    # both the observations and the infos are shared for each of the two checked pairs
-    assert sources == [
-        "reset -> step",
-        "reset -> step",
-        "step -> step",
-        "step -> step",
-    ], sources
+    assert all(
+        expected in actual.message.args[0]
+        for expected, actual in zip(expected_warnings, caught_warnings, strict=True)
+    )
 
     # the checks are not repeated and the wrapper stops holding a reference to the user's data
-    assert checker_env.checked_data_reuse == 2
+    assert checker_env.checked_data_reuse
     assert checker_env._previous_data is None

--- a/tests/wrappers/test_passive_env_checker.py
+++ b/tests/wrappers/test_passive_env_checker.py
@@ -110,3 +110,61 @@ def test_api_failures():
     assert env.checked_render
 
     env.close()
+
+
+def _reused_buffer_reset(self, seed=None, options=None):
+    """Reset an environment that reuses one observation buffer and one info dictionary."""
+    super(GenericTestEnv, self).reset(seed=seed)
+    self.buffer = getattr(self, "buffer", np.zeros(1, dtype=np.float32))
+    self.buffer[...] = 0
+    self.info = getattr(self, "info", {})
+    self.info["count"] = 0
+
+    return self.buffer, self.info
+
+
+def _reused_buffer_step(self, action):
+    """Mutate the reused observation buffer and info dictionary."""
+    self.buffer += 1
+    self.info["count"] += 1
+
+    return self.buffer, 0.0, False, False, self.info
+
+
+def test_passive_checker_wrapper_data_reuse():
+    """The wrapper warns for the reset to the first step, then the first to the second step."""
+    checker_env = PassiveEnvChecker(
+        GenericTestEnv(
+            action_space=gym.spaces.Discrete(1),
+            observation_space=gym.spaces.Box(0, 100, (1,), dtype=np.float32),
+            reset_func=_reused_buffer_reset,
+            step_func=_reused_buffer_step,
+        )
+    )
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+
+        checker_env.reset()
+        for _ in range(4):
+            checker_env.step(0)
+
+    sources = [
+        str(warning.message)
+        .split("returned by `")[1]
+        .split("` share an object")[0]
+        .replace("` and the following `", " -> ")
+        for warning in caught_warnings
+        if "share an object" in str(warning.message)
+    ]
+    # both the observations and the infos are shared for each of the two checked pairs
+    assert sources == [
+        "reset -> step",
+        "reset -> step",
+        "step -> step",
+        "step -> step",
+    ], sources
+
+    # the checks are not repeated and the wrapper stops holding a reference to the user's data
+    assert checker_env.checked_data_reuse == 2
+    assert checker_env._previous_data is None


### PR DESCRIPTION
# Description
An environment's reset and step both return observation and info data which is commonly saved to a replay or rollout buffer. The problem is that users can accidentally use the same object for sequential observations / info which can mean that the incorrect timestep's data is used for training, generating dataset, etc. 
This PR strengths Gymnasium's testing of this through adding checking to the `check_env` and to the passive env checker that runs silently for most users when creating an environment. Running this updated check found that for the Humanoid and HumanoidStandup environments, two info elements were not using a unique buffer for each timestep which is now fixed. 
Further, this should help users detect issues in repos automatically 

Fix for https://github.com/Farama-Foundation/Gymnasium/pull/1680