### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
         numpy-version: ['>=1.21,<2.0', '>=2.1']
         exclude:
           - python-version: '3.13'
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v7
       - run: |
            docker build -f bin/necessary-py.Dockerfile \
-             --build-arg PYTHON_VERSION='3.10' \
+             --build-arg PYTHON_VERSION='3.11' \
              --tag gymnasium-necessary-docker .
       - name: Run tests
         run: |

--- a/gymnasium/core.py
+++ b/gymnasium/core.py
@@ -12,7 +12,7 @@ from gymnasium import spaces
 from gymnasium.utils import RecordConstructorArgs, seeding
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
+    from typing import Self
 
     from gymnasium.envs.registration import EnvSpec, WrapperSpec
 

--- a/gymnasium/vector/utils/shared_memory.py
+++ b/gymnasium/vector/utils/shared_memory.py
@@ -30,7 +30,9 @@ from gymnasium.spaces import (
 )
 
 if TYPE_CHECKING:
-    from typing_extensions import Never, Unpack
+    from typing import Never
+
+    from typing_extensions import Unpack
 
 __all__ = ["create_shared_memory", "read_from_shared_memory", "write_to_shared_memory"]
 

--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -34,7 +34,7 @@ from gymnasium.spaces import (
 )
 
 if TYPE_CHECKING:
-    from typing_extensions import Never
+    from typing import Never
 
 __all__ = [
     "batch_space",

--- a/gymnasium/vector/vector_env.py
+++ b/gymnasium/vector/vector_env.py
@@ -13,7 +13,7 @@ from gymnasium.logger import warn
 from gymnasium.utils import seeding
 
 if TYPE_CHECKING:
-    from typing_extensions import Self
+    from typing import Self
 
     from gymnasium.envs.registration import EnvSpec
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "gymnasium"
 description = "A standard API for reinforcement learning and a diverse set of reference environments (formerly Gym)."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.11"
 authors = [{ name = "Farama Foundation", email = "contact@farama.org" }]
 license = { text = "MIT License" }
 keywords = ["Reinforcement Learning", "game", "RL", "AI", "gymnasium"]
@@ -16,7 +16,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -143,7 +142,7 @@ respect-type-ignore-comments = false
 error-on-warning = false
 
 [tool.ty.environment]
-python-version = "3.10"
+python-version = "3.11"
 python-platform = "all"
 extra-paths = []
 


### PR DESCRIPTION
# Description

Python 3.10 reaches end of life this October, so this raises the floor to 3.11 ahead of the next release, as requested in #1684.

Changes: `requires-python` and the classifiers in `pyproject.toml`, the `ty` target version, the CI test matrix and the `build-necessary` job (which now builds on 3.11).

With 3.11 as the minimum, ruff's pyupgrade rule rewrites the `TYPE_CHECKING`-only imports of `Self` and `Never` to come from `typing` instead of `typing_extensions`. `Unpack` and `TypeVar` still come from `typing_extensions` since the forms used here need 3.12 and 3.13.

Rebased on main. The README edits are gone: a25de67c removed that whole line upstream, so there is nothing left to update there.

`ruff check .` and `ruff format --check .` are clean on the rebased tree (262 files). `tests/test_core.py` passed on a 3.11 install before the rebase; the rebase only dropped the README hunks.

Fixes #1684
