### PR TITLE
feat(wrappers): add vector TimeAwareObservation

### DIFF
--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -121,7 +121,7 @@ class TimeAwareObservation(
     To flatten the observation, use the :attr:`flatten` parameter which will use the
     :func:`gymnasium.spaces.utils.flatten` function.
 
-    No vector version of the wrapper exists.
+    A vector version of the wrapper exists :class:`gymnasium.wrappers.vector.TimeAwareObservation`.
 
     Example:
         >>> import gymnasium as gym

--- a/gymnasium/wrappers/vector/__init__.py
+++ b/gymnasium/wrappers/vector/__init__.py
@@ -6,7 +6,10 @@ from typing import TYPE_CHECKING
 from gymnasium.wrappers.vector.common import RecordEpisodeStatistics
 from gymnasium.wrappers.vector.dict_info_to_list import DictInfoToList
 from gymnasium.wrappers.vector.rendering import HumanRendering, RecordVideo
-from gymnasium.wrappers.vector.stateful_observation import NormalizeObservation
+from gymnasium.wrappers.vector.stateful_observation import (
+    NormalizeObservation,
+    TimeAwareObservation,
+)
 from gymnasium.wrappers.vector.stateful_reward import NormalizeReward
 from gymnasium.wrappers.vector.vectorize_action import (
     ClipAction,
@@ -48,7 +51,7 @@ __all__ = [
     "DtypeObservation",
     "NormalizeObservation",
     # "RenderObservation",
-    # "TimeAwareObservation",
+    "TimeAwareObservation",
     # "FrameStackObservation",
     # "DelayObservation",
     # --- Action Wrappers ---

--- a/gymnasium/wrappers/vector/stateful_observation.py
+++ b/gymnasium/wrappers/vector/stateful_observation.py
@@ -1,6 +1,7 @@
 """A collection of stateful observation wrappers.
 
 * ``NormalizeObservation`` - Normalize the observations
+* ``TimeAwareObservation`` - Add per-environment elapsed episode time
 """
 
 from __future__ import annotations
@@ -13,15 +14,16 @@ import gymnasium as gym
 from gymnasium.error import InvalidBound
 from gymnasium.logger import warn
 from gymnasium.spaces import Box
-from gymnasium.vector.utils import batch_space
+from gymnasium.vector.utils import batch_space, concatenate, create_empty_array, iterate
 from gymnasium.vector.vector_env import (
     AutoresetMode,
     VectorEnv,
     VectorObservationWrapper,
+    VectorWrapper,
 )
 from gymnasium.wrappers.utils import RunningMeanStd
 
-__all__ = ["NormalizeObservation"]
+__all__ = ["NormalizeObservation", "TimeAwareObservation"]
 
 
 class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructorArgs):
@@ -158,3 +160,211 @@ class NormalizeObservation(VectorObservationWrapper, gym.utils.RecordConstructor
             (observations - self.obs_rms.mean)
             / np.sqrt(self.obs_rms.var + self.epsilon)
         ).astype(np.float32)
+
+
+class TimeAwareObservation(VectorWrapper, gym.utils.RecordConstructorArgs):
+    """Add each environment's elapsed episode time to its observation.
+
+    Matches :class:`gymnasium.wrappers.TimeAwareObservation`: time is an int32
+    elapsed step count, or float32 elapsed time divided by the episode limit.
+    Dict observations gain ``dict_time_key``, Tuple observations gain a final
+    element, and other observations are placed under ``obs`` alongside ``time``.
+    Flattening follows :func:`gymnasium.spaces.flatten` for each environment.
+
+    Supports SyncVectorEnv and AsyncVectorEnv (including vector wrappers around
+    them) with a common time limit and identical observation spaces. Limits are
+    read from sub-environment specs, falling back to ``_max_episode_steps`` when
+    all sub-environments expose it through their TimeLimit wrappers.
+
+    All autoreset modes and partial resets are supported. SAME_STEP final
+    observations contain terminal time; the returned reset observations have
+    time zero. NEXT_STEP resets time on the subsequent reset-only step.
+
+    Example:
+        >>> import gymnasium as gym
+        >>> envs = gym.make_vec("CartPole-v1", num_envs=2, vectorization_mode="sync")
+        >>> envs = TimeAwareObservation(envs, flatten=False)
+        >>> envs.reset(seed=42)[0]["time"]
+        array([[0],
+               [0]], dtype=int32)
+        >>> envs.step([0, 1])[0]["time"]
+        array([[1],
+               [1]], dtype=int32)
+        >>> envs.close()
+    """
+
+    def __init__(
+        self,
+        env: VectorEnv,
+        flatten: bool = True,
+        normalize_time: bool = False,
+        *,
+        dict_time_key: str = "time",
+    ) -> None:
+        """Initialize the per-environment clocks and augmented spaces.
+
+        Args:
+            env: The vector environment with a common finite episode limit.
+            flatten: Flatten each augmented observation.
+            normalize_time: Divide elapsed steps by the episode limit.
+            dict_time_key: Time key for Dict observation spaces.
+        """
+        gym.utils.RecordConstructorArgs.__init__(
+            self,
+            flatten=flatten,
+            normalize_time=normalize_time,
+            dict_time_key=dict_time_key,
+        )
+        VectorWrapper.__init__(self, env)
+        if "autoreset_mode" not in env.metadata:
+            warn(f"{env} is missing `autoreset_mode` metadata. Assuming NEXT_STEP.")
+            self.autoreset_mode = AutoresetMode.NEXT_STEP
+        else:
+            self.autoreset_mode = env.metadata["autoreset_mode"]
+            if not isinstance(self.autoreset_mode, AutoresetMode):
+                raise TypeError(
+                    "Expected env.metadata['autoreset_mode'] to be an AutoresetMode, "
+                    f"got {type(self.autoreset_mode)}"
+                )
+
+        base_env = env.unwrapped
+        if not isinstance(
+            base_env, (gym.vector.SyncVectorEnv, gym.vector.AsyncVectorEnv)
+        ):
+            raise TypeError(
+                "TimeAwareObservation requires SyncVectorEnv or AsyncVectorEnv."
+            )
+        if env.observation_space != batch_space(
+            env.single_observation_space, env.num_envs
+        ):
+            raise ValueError(
+                "TimeAwareObservation requires identical observation spaces."
+            )
+        limits = [
+            spec.max_episode_steps if spec is not None else None
+            for spec in base_env.get_attr("spec")
+        ]
+        if any(limit is None for limit in limits):
+            # Check first: a failed attribute call would shut down async workers.
+            if not all(base_env.call("has_wrapper_attr", "_max_episode_steps")):
+                raise ValueError(
+                    "Each environment must have a spec with max_episode_steps, "
+                    "or all environments must expose a TimeLimit's _max_episode_steps."
+                )
+            fallback_limits = base_env.get_attr("_max_episode_steps")
+            limits = [
+                fallback if limit is None else limit
+                for limit, fallback in zip(limits, fallback_limits, strict=True)
+            ]
+        if any(limit != limits[0] for limit in limits):
+            raise ValueError(
+                "TimeAwareObservation requires a common episode time limit."
+            )
+        limit = limits[0]
+        if not isinstance(limit, (int, np.integer)) or limit <= 0:
+            raise ValueError("The episode time limit must be a positive integer.")
+        self.max_timesteps = int(limit)
+        self.flatten = flatten
+        self.normalize_time = normalize_time
+        self.dict_time_key = dict_time_key
+        self.timesteps = np.zeros(self.num_envs, dtype=np.int64)
+        self._prev_dones = np.zeros(self.num_envs, dtype=np.bool_)
+
+        time_space = (
+            Box(0.0, 1.0)
+            if normalize_time
+            else Box(0, self.max_timesteps, dtype=np.int32)
+        )
+        space = env.single_observation_space
+        if isinstance(space, gym.spaces.Dict):
+            if dict_time_key in space.spaces:
+                raise ValueError(
+                    f"The `dict_time_key` ({dict_time_key!r}) already exists in the observation space."
+                )
+            self._time_observation_space = gym.spaces.Dict(
+                {dict_time_key: time_space, **space.spaces}, sort_keys=space.sort_keys
+            )
+        elif isinstance(space, gym.spaces.Tuple):
+            self._time_observation_space = gym.spaces.Tuple(
+                space.spaces + (time_space,)
+            )
+        else:
+            self._time_observation_space = gym.spaces.Dict(obs=space, time=time_space)
+        self.single_observation_space = (
+            gym.spaces.flatten_space(self._time_observation_space)
+            if flatten
+            else self._time_observation_space
+        )
+        self.observation_space = batch_space(
+            self.single_observation_space, self.num_envs
+        )
+
+    def _observation(self, observation: Any, timestep: int) -> Any:
+        """Add time to one observation using the scalar wrapper's representation."""
+        time = (
+            np.array([timestep / self.max_timesteps], dtype=np.float32)
+            if self.normalize_time
+            else np.array([timestep], dtype=np.int32)
+        )
+        if isinstance(self.env.single_observation_space, gym.spaces.Dict):
+            observation = {self.dict_time_key: time, **observation}
+        elif isinstance(self.env.single_observation_space, gym.spaces.Tuple):
+            observation = observation + (time,)
+        else:
+            observation = {"obs": observation, "time": time}
+        if self.flatten:
+            return gym.spaces.flatten(self._time_observation_space, observation)
+        return observation
+
+    def observations(self, observations: Any) -> Any:
+        """Augment and batch observations without retaining a mutable output buffer."""
+        return concatenate(
+            self.single_observation_space,
+            [
+                self._observation(obs, int(t))
+                for obs, t in zip(
+                    iterate(self.env.observation_space, observations),
+                    self.timesteps,
+                    strict=True,
+                )
+            ],
+            create_empty_array(self.single_observation_space, self.num_envs),
+        )
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[Any, dict[str, Any]]:
+        """Reset selected clocks only after the underlying reset succeeds."""
+        # Sync/AsyncVectorEnv pop reset_mask from options, so preserve it first.
+        reset_mask = (
+            options.get("reset_mask", slice(None))
+            if options is not None
+            else slice(None)
+        )
+        obs, info = self.env.reset(seed=seed, options=options)
+        self.timesteps[reset_mask] = 0
+        self._prev_dones[reset_mask] = False
+        return self.observations(obs), info
+
+    def step(self, actions: Any) -> tuple[Any, Any, Any, Any, dict[str, Any]]:
+        """Advance clocks, transform terminal observations, and account for autoresets."""
+        obs, rewards, terminations, truncations, infos = self.env.step(actions)
+        self.timesteps += 1
+        if self.autoreset_mode == AutoresetMode.NEXT_STEP:
+            self.timesteps[self._prev_dones] = 0
+        dones = np.logical_or(terminations, truncations)
+        if self.autoreset_mode == AutoresetMode.SAME_STEP:
+            if "final_obs" in infos:
+                infos = infos.copy()
+                final_obs = infos["final_obs"].copy()
+                for i in np.flatnonzero(infos["_final_obs"]):
+                    final_obs[i] = self._observation(
+                        final_obs[i], int(self.timesteps[i])
+                    )
+                infos["final_obs"] = final_obs
+            self.timesteps[dones] = 0
+        self._prev_dones = dones
+        return self.observations(obs), rewards, terminations, truncations, infos

--- a/tests/wrappers/vector/test_time_aware_observation.py
+++ b/tests/wrappers/vector/test_time_aware_observation.py
@@ -1,0 +1,251 @@
+"""Per-environment clocks, terminal observations, and scalar wrapper equivalence."""
+
+from contextlib import closing
+from copy import deepcopy
+from functools import partial
+
+import numpy as np
+import pytest
+
+import gymnasium as gym
+from gymnasium.spaces import Box, Dict, Discrete, Tuple
+from gymnasium.utils.env_checker import data_equivalence
+from gymnasium.vector import AsyncVectorEnv, AutoresetMode, SyncVectorEnv, VectorWrapper
+from gymnasium.wrappers import TimeAwareObservation as ScalarTime
+from gymnasium.wrappers import TimeLimit
+from gymnasium.wrappers.vector import TimeAwareObservation
+
+
+class ClockEnv(gym.Env):
+    """Deterministic observations with staggered early terminations and truncation."""
+
+    def __init__(self, end=2, space_kind="box"):
+        """Create a constant observation so clock errors cannot hide in the input."""
+        self.end = end
+        self.action_space = Discrete(2)
+        box = Box(0, 1, shape=(1,), dtype=np.float32)
+        self.observation_space = {
+            "box": box,
+            "dict": Dict({"z": box, "a": Discrete(2)}, sort_keys=False),
+            "tuple": Tuple((box, Discrete(2))),
+        }[space_kind]
+        self.space_kind = space_kind
+        self.t = 0
+
+    def _obs(self):
+        """Return a fresh observation with a known value."""
+        box = np.array([0.5], dtype=np.float32)
+        return {"box": box, "dict": {"z": box, "a": 1}, "tuple": (box, 1)}[
+            self.space_kind
+        ]
+
+    def reset(self, *, seed=None, options=None):
+        """Start an episode and expose the seed/options forwarding in info."""
+        super().reset(seed=seed)
+        self.t = 0
+        return self._obs(), {"option": (options or {}).get("marker", 0)}
+
+    def step(self, action):
+        """Terminate at the configured step, leaving truncation to TimeLimit."""
+        self.t += 1
+        return self._obs(), float(action), self.t == self.end, False, {"step": self.t}
+
+
+def make_env(end=2, space_kind="box", scalar=False, kwargs=None, limit=5):
+    """Build a custom environment without a spec, inside an extra wrapper."""
+    env = gym.Wrapper(TimeLimit(ClockEnv(end, space_kind), limit))
+    return ScalarTime(env, **(kwargs or {})) if scalar else env
+
+
+def vector_env(backend, factories, mode):
+    """Use spawn for async tests to avoid depending on fork behavior."""
+    kwargs = {"context": "spawn"} if backend is AsyncVectorEnv else {}
+    return backend(factories, autoreset_mode=mode, **kwargs)
+
+
+@pytest.mark.parametrize("backend", [SyncVectorEnv, AsyncVectorEnv])
+@pytest.mark.parametrize("mode", list(AutoresetMode))
+@pytest.mark.parametrize("space_kind", ["box", "dict", "tuple"])
+@pytest.mark.parametrize(
+    "flatten,normalize", [(False, False), (False, True), (True, False), (True, True)]
+)
+def test_staggered_equivalence(backend, mode, space_kind, flatten, normalize):
+    """Compare whole transitions, including masked final obs, over unequal episodes."""
+    kwargs = {"flatten": flatten, "normalize_time": normalize, "dict_time_key": "clock"}
+    factories = [partial(make_env, end, space_kind) for end in (2, 3, 100)]
+    reference_factories = [
+        partial(make_env, end, space_kind, scalar=True, kwargs=kwargs)
+        for end in (2, 3, 100)
+    ]
+    with (
+        closing(vector_env(backend, factories, mode)) as base,
+        closing(vector_env(backend, reference_factories, mode)) as reference,
+    ):
+        env = TimeAwareObservation(VectorWrapper(base), **kwargs)
+        assert env.observation_space == reference.observation_space
+        assert env.single_observation_space == reference.single_observation_space
+        initial = env.reset(seed=[1, 2, 3])
+        saved_initial = deepcopy(initial)
+        assert data_equivalence(initial, reference.reset(seed=[1, 2, 3]))
+        clocks = np.zeros(3, dtype=int)
+        prev_dones = np.zeros(3, dtype=bool)
+        for step in range(13):
+            actual = env.step(np.array([0, 1, 0]))
+            expected = reference.step(np.array([0, 1, 0]))
+            assert data_equivalence(actual, expected)
+            assert actual[0] in env.observation_space
+            clocks += 1
+            if mode == AutoresetMode.NEXT_STEP:
+                clocks[prev_dones] = 0
+            dones = actual[2] | actual[3]
+            if mode == AutoresetMode.SAME_STEP:
+                for i in np.flatnonzero(dones):
+                    assert actual[4]["final_obs"][i] in env.single_observation_space
+                clocks[dones] = 0
+            np.testing.assert_array_equal(env.timesteps, clocks)
+            prev_dones = dones
+            # Explicit partial reset while another environment is pending reset.
+            mask = (
+                np.array([False, True, False]) if step == 1 else np.zeros(3, dtype=bool)
+            )
+            if mode == AutoresetMode.DISABLED:
+                mask |= dones
+            if mask.any():
+                options = {"reset_mask": mask.copy(), "marker": 7}
+                reset_result = env.reset(options=deepcopy(options))
+                assert data_equivalence(
+                    reset_result, reference.reset(options=deepcopy(options))
+                )
+                clocks[mask] = 0
+                prev_dones[mask] = False
+                np.testing.assert_array_equal(env.timesteps, clocks)
+        assert data_equivalence(initial, saved_initial)
+        assert data_equivalence(env.reset(seed=42), reference.reset(seed=42))
+        np.testing.assert_array_equal(env.timesteps, 0)
+
+
+@pytest.mark.parametrize("mode", list(AutoresetMode))
+@pytest.mark.parametrize("normalize", [False, True])
+def test_explicit_clock_values(mode, normalize):
+    """Assert elapsed time and terminal/reset distinction independently of the scalar wrapper."""
+    with closing(
+        SyncVectorEnv(
+            [partial(make_env, 2), partial(make_env, 100)], autoreset_mode=mode
+        )
+    ) as base:
+        env = TimeAwareObservation(base, flatten=False, normalize_time=normalize)
+        env.reset()
+        first = env.step([0, 0])[0]
+        terminal = env.step([0, 0])
+        scale = 5 if normalize else 1
+        np.testing.assert_allclose(first["time"], np.array([[1], [1]]) / scale)
+        assert first["time"].dtype == (np.float32 if normalize else np.int32)
+        np.testing.assert_allclose(
+            terminal[0]["time"],
+            np.array([[0 if mode == AutoresetMode.SAME_STEP else 2], [2]]) / scale,
+        )
+        if mode == AutoresetMode.SAME_STEP:
+            np.testing.assert_allclose(terminal[4]["final_obs"][0]["time"], [2 / scale])
+            np.testing.assert_array_equal(terminal[4]["_final_obs"], [True, False])
+        elif mode == AutoresetMode.NEXT_STEP:
+            np.testing.assert_allclose(
+                env.step([0, 0])[0]["time"], np.array([[0], [3]]) / scale
+            )
+        else:
+            obs, _ = env.reset(options={"reset_mask": np.array([True, False])})
+            np.testing.assert_allclose(obs["time"], np.array([[0], [2]]) / scale)
+
+
+@pytest.mark.parametrize(
+    "mask,error",
+    [
+        ([True, False], TypeError),
+        (np.array([True]), ValueError),
+        (np.array([1, 0]), TypeError),
+        (np.array([False, False]), ValueError),
+    ],
+)
+def test_invalid_partial_reset(mask, error):
+    """Failed mask validation must not reset any clocks."""
+    with closing(SyncVectorEnv([make_env, make_env])) as base:
+        env = TimeAwareObservation(base)
+        env.reset()
+        env.step([0, 0])
+        with pytest.raises(error, match="reset_mask"):
+            env.reset(options={"reset_mask": mask})
+        np.testing.assert_array_equal(env.timesteps, [1, 1])
+
+
+@pytest.mark.parametrize("backend", [SyncVectorEnv, AsyncVectorEnv])
+def test_time_limit_validation(backend):
+    """Reject missing/different limits, without losing async workers on missing limits."""
+    with closing(vector_env(backend, [ClockEnv], AutoresetMode.NEXT_STEP)) as base:
+        with pytest.raises(ValueError, match="max_episode_steps"):
+            TimeAwareObservation(base)
+        base.reset()
+        base.step([0])
+    with closing(
+        vector_env(
+            backend, [make_env, partial(make_env, limit=6)], AutoresetMode.NEXT_STEP
+        )
+    ) as base:
+        with pytest.raises(ValueError, match="common episode time limit"):
+            TimeAwareObservation(base)
+
+
+def test_metadata_and_key_validation():
+    """Match vector metadata conventions and scalar Dict collision validation."""
+    with closing(SyncVectorEnv([partial(make_env, space_kind="dict")])) as base:
+        with pytest.raises(ValueError, match="already exists"):
+            TimeAwareObservation(base, dict_time_key="z")
+        base.metadata = {"autoreset_mode": "NextStep"}
+        with pytest.raises(TypeError, match="AutoresetMode"):
+            TimeAwareObservation(base)
+        base.metadata = {}
+        with pytest.warns(UserWarning, match="missing.*autoreset_mode"):
+            env = TimeAwareObservation(base)
+        env.reset()
+        env.step([0])
+        np.testing.assert_array_equal(env.timesteps, [1])
+
+
+def make_spec_env(limit=7):
+    """Expose a spec limit without a TimeLimit wrapper, as the scalar API permits."""
+    env = ClockEnv()
+    env.spec = gym.envs.registration.EnvSpec("Clock-v0", max_episode_steps=limit)
+    return env
+
+
+@pytest.mark.parametrize("backend", [SyncVectorEnv, AsyncVectorEnv])
+def test_spec_limit(backend):
+    """Use a public spec even when no private TimeLimit attribute is available."""
+    with closing(vector_env(backend, [make_spec_env], AutoresetMode.NEXT_STEP)) as base:
+        env = TimeAwareObservation(base, flatten=False, normalize_time=True)
+        env.reset()
+        np.testing.assert_allclose(env.step([0])[0]["time"], [[1 / 7]])
+        assert env.max_timesteps == 7
+    with closing(
+        vector_env(backend, [partial(make_spec_env, 0)], AutoresetMode.NEXT_STEP)
+    ) as base:
+        with pytest.raises(ValueError, match="positive integer"):
+            TimeAwareObservation(base)
+
+
+def test_scope_validation():
+    """Reject unsupported native backends and different observation bounds explicitly."""
+    native = gym.vector.VectorEnv()
+    native.metadata = {"autoreset_mode": AutoresetMode.NEXT_STEP}
+    with pytest.raises(TypeError, match="SyncVectorEnv or AsyncVectorEnv"):
+        TimeAwareObservation(native)
+
+    def different_space():
+        """Keep the shape but change bounds to exercise observation_mode='different'."""
+        env = make_env()
+        env.observation_space = Box(0, 2, shape=(1,), dtype=np.float32)
+        return env
+
+    with closing(
+        SyncVectorEnv([make_env, different_space], observation_mode="different")
+    ) as base:
+        with pytest.raises(ValueError, match="identical observation spaces"):
+            TimeAwareObservation(base)

--- a/tests/wrappers/vector/test_vector_wrappers.py
+++ b/tests/wrappers/vector/test_vector_wrappers.py
@@ -59,7 +59,7 @@ def custom_environments():
         ),
         ("CarRacing-v3", "DtypeObservation", {"dtype": np.int32}),
         # ("CartPole-v1", "RenderObservation", {}),  # not implemented
-        # ("CartPole-v1", "TimeAwareObservation", {}),  # not implemented
+        ("CartPole-v1", "TimeAwareObservation", {}),
         # ("CartPole-v1", "FrameStackObservation", {}),  # not implemented
         # ("CartPole-v1", "DelayObservation", {}),  # not implemented
         ("MountainCarContinuous-v0", "ClipAction", {}),
@@ -81,10 +81,19 @@ def test_vector_wrapper_equivalence(
     vectorization_mode: str = "sync",
     num_steps: int = 50,
 ):
+    # Exercise the new stateful wrapper with the requested autoreset mode.
+    vector_kwargs = (
+        {"autoreset_mode": autoreset_mode}
+        if wrapper_name == "TimeAwareObservation"
+        else {}
+    )
     vector_wrapper = getattr(wrappers.vector, wrapper_name)
     wrapper_vector_env: VectorEnv = vector_wrapper(
         gym.make_vec(
-            id=env_id, num_envs=num_envs, vectorization_mode=vectorization_mode
+            id=env_id,
+            num_envs=num_envs,
+            vectorization_mode=vectorization_mode,
+            vector_kwargs=vector_kwargs,
         ),
         **kwargs,
     )
@@ -94,6 +103,7 @@ def test_vector_wrapper_equivalence(
         num_envs=num_envs,
         vectorization_mode=vectorization_mode,
         wrappers=(lambda env: env_wrapper(env, **kwargs),),
+        vector_kwargs=vector_kwargs,
     )
 
     assert wrapper_vector_env.action_space == vector_wrapper_env.action_space


### PR DESCRIPTION
# Description

Draft proposal implementing the `TimeAwareObservation` entry currently commented out of the vector wrappers and equivalence tests. Related historical vector-wrapper discussions include #140 and #509; this does not close those umbrella discussions.

Add one wrapper, `gymnasium.wrappers.vector.TimeAwareObservation`. It matches the scalar wrapper's elapsed-time representation, flattening and normalization options, while keeping an independent clock for each worker. Dict and Tuple observation layouts follow scalar behavior.

- NEXT_STEP retains terminal time, then resets the completed worker's clock on the next reset-only step.
- SAME_STEP adds terminal time to masked `final_obs` while returning reset observations at time zero.
- DISABLED changes clocks only on actual steps and explicit resets.
- Partial resets clear only selected clocks, after the underlying reset succeeds. Prior returned observation buffers are not mutated.

The implementation enables the existing equivalence case and adds staggered-episode tests against scalar wrappers inside independent vector environments.

## Scope for discussion

This first version supports SyncVectorEnv and AsyncVectorEnv, including vector wrappers around them, with identical observation spaces and a common positive episode limit. Worker specs supply that limit; when a spec lacks it, all workers must expose `_max_episode_steps` for fallback. Native vector implementations and heterogeneous horizons are rejected explicitly. An explicit horizon argument or general discovery API could extend that scope, but neither is invented here.

Is this bounded outer-wrapper API useful alongside wrapping each scalar environment individually? The source placeholder establishes the missing capability, but current maintainers have not approved this implementation. This remains a draft for that decision.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Validation

The new suite checks Sync and spawn-based Async backends, all autoreset modes, Box/Dict/Tuple spaces, flattening/normalization combinations, full/partial resets, options/seeds, terminal observations, and invalid limits/masks. It compares complete observations and step results against scalar-wrapper equivalents and also asserts direct expected clock values.

The final combined wrapper suite passes (161 tests), including all 88 focused cases. Seven affected-module doctests pass. Configured pre-commit hooks pass on changed files. Full-repository doctest collection is blocked by missing optional MuJoCo, JAX, Torch and related extras; no complete repository-suite pass is claimed.

# Checklist

- [ ] Repository-wide `pre-commit run --all-files` (changed-file configured checks pass)
- [x] Implementation comments explain reset ordering and worker-attribute safeguards
- [x] Public docstring example and scalar counterpart documentation updated
- [ ] No warnings (existing Box precision/SWIG warnings remain)
- [x] Behavioral regression/equivalence tests added
- [x] Relevant new and existing wrapper tests pass locally

Prepared and validated with OpenAI Codex assistance. No human-only implementation or prior maintainer approval is asserted.
