### PR TITLE
Keep Discrete support when DtypeObservation changes dtype

### DIFF
--- a/gymnasium/wrappers/transform_observation.py
+++ b/gymnasium/wrappers/transform_observation.py
@@ -607,13 +607,15 @@ class DtypeObservation(
         elif isinstance(env.observation_space, spaces.Discrete):
             new_observation_space = spaces.Box(
                 low=env.observation_space.start,
-                high=env.observation_space.start + env.observation_space.n,
+                high=env.observation_space.start + env.observation_space.n - 1,
                 shape=(),
                 dtype=self.dtype,
             )
         elif isinstance(env.observation_space, spaces.MultiDiscrete):
             new_observation_space = spaces.MultiDiscrete(
-                env.observation_space.nvec, dtype=dtype
+                env.observation_space.nvec,
+                dtype=dtype,
+                start=env.observation_space.start,
             )
         elif isinstance(env.observation_space, spaces.MultiBinary):
             new_observation_space = spaces.Box(

--- a/tests/wrappers/test_dtype_observation.py
+++ b/tests/wrappers/test_dtype_observation.py
@@ -1,7 +1,9 @@
 """Test suite for DtypeObservation wrapper."""
 
 import numpy as np
+import pytest
 
+from gymnasium.spaces import Box, Discrete, MultiDiscrete
 from gymnasium.wrappers import DtypeObservation
 from tests.testing_env import GenericTestEnv
 from tests.wrappers.utils import record_random_obs_reset, record_random_obs_step
@@ -21,3 +23,50 @@ def test_dtype_observation():
     obs, _, _, _, info = wrapped_env.step(None)
     assert obs.dtype != info["obs"].dtype
     assert obs.dtype == np.uint8
+
+
+@pytest.mark.parametrize(
+    "space,dtype",
+    [
+        (Discrete(2), np.int64),
+        (Discrete(3, start=-1), np.int32),
+        (Discrete(4, start=10, dtype=np.int32), np.int16),
+    ],
+)
+def test_dtype_observation_discrete_space_matches_original_support(space, dtype):
+    """The wrapped Discrete space has the same closed interval as the original.
+
+    Discrete(n, start=s) is {s, ..., s + n - 1}. The wrapper used
+    ``Box(s, s + n)``, which both includes ``s + n`` and, for integer dtypes,
+    samples that extra value.
+    """
+    env = GenericTestEnv(observation_space=space)
+    wrapped_env = DtypeObservation(env, dtype=dtype)
+
+    low = dtype(space.start)
+    high = dtype(space.start + space.n - 1)
+    assert wrapped_env.observation_space == Box(low=low, high=high, shape=(), dtype=dtype)
+
+    last = dtype(space.start + space.n)
+    assert last not in wrapped_env.observation_space
+    assert last not in space
+
+    for _ in range(50):
+        sample = wrapped_env.observation_space.sample()
+        assert sample in wrapped_env.observation_space
+        assert int(sample) in space
+
+
+def test_dtype_observation_multidiscrete_keeps_start():
+    """Changing dtype of a MultiDiscrete must not drop a non-zero start."""
+    space = MultiDiscrete([3, 4], start=[-1, 2])
+    env = GenericTestEnv(observation_space=space)
+    wrapped_env = DtypeObservation(env, dtype=np.int32)
+
+    assert wrapped_env.observation_space == MultiDiscrete(
+        [3, 4], start=[-1, 2], dtype=np.int32
+    )
+
+    obs, _ = wrapped_env.reset()
+    assert obs in wrapped_env.observation_space
+    assert obs.dtype == np.int32

--- a/tests/wrappers/test_dtype_observation.py
+++ b/tests/wrappers/test_dtype_observation.py
@@ -45,7 +45,9 @@ def test_dtype_observation_discrete_space_matches_original_support(space, dtype)
 
     low = dtype(space.start)
     high = dtype(space.start + space.n - 1)
-    assert wrapped_env.observation_space == Box(low=low, high=high, shape=(), dtype=dtype)
+    assert wrapped_env.observation_space == Box(
+        low=low, high=high, shape=(), dtype=dtype
+    )
 
     last = dtype(space.start + space.n)
     assert last not in wrapped_env.observation_space


### PR DESCRIPTION
DtypeObservation builds a Box from Discrete(n, start=s) with high=s+n. Discrete is {s, ..., s+n-1}, so the extra value is both contained and sampled for integer dtypes. MultiDiscrete dropped a non-zero start when the dtype changed.

Repro:

    from gymnasium.spaces import Discrete
    from gymnasium.wrappers import DtypeObservation
    from tests.testing_env import GenericTestEnv

    env = DtypeObservation(GenericTestEnv(observation_space=Discrete(2)), dtype="int64")
    env.observation_space.contains(2)  # True, should be False

Clamped Discrete high to s+n-1 and passed start through on MultiDiscrete.

PYTHONPATH=. python -m pytest tests/wrappers/test_dtype_observation.py tests/wrappers/vector/test_vector_wrappers.py -q -k "dtype or Dtype"
