### PR TITLE
Create shared memory from the multiprocessing typecode table

### DIFF
--- a/gymnasium/vector/utils/shared_memory.py
+++ b/gymnasium/vector/utils/shared_memory.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import multiprocessing as mp
-from array import typecodes
 from collections.abc import Mapping
 from ctypes import c_bool, c_int32, c_int64, c_uint8
 from functools import singledispatch
-from multiprocessing.sharedctypes import SynchronizedArray
+from multiprocessing.sharedctypes import SynchronizedArray, typecode_to_type
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, TypeAlias
 
@@ -86,11 +85,12 @@ def _create_base_shared_memory(
     dtype = space.dtype.char
     if dtype == "?":
         return ctx.Array(c_bool, size)
-    elif dtype in typecodes:
+    elif dtype in typecode_to_type:
         return ctx.Array(dtype, size)
     else:
-        # Some dtypes (e.g. float16) have no `array` typecode, allocate the equivalent
-        # number of bytes as read / write reinterpret the raw buffer with `space.dtype`.
+        # Some dtypes (e.g. float16) have no `multiprocessing` typecode, allocate the
+        # equivalent number of bytes as read / write reinterpret the raw buffer with
+        # `space.dtype`.
         return ctx.Array(c_uint8, size * space.dtype.itemsize)
 
 

--- a/tests/vector/utils/test_shared_memory.py
+++ b/tests/vector/utils/test_shared_memory.py
@@ -63,7 +63,7 @@ def test_shared_memory_create_read_write(space, num, ctx):
     ids=lambda dtype: np.dtype(dtype).name,
 )
 def test_shared_memory_no_array_typecode_dtypes(dtype):
-    """Test dtypes without an `array` module typecode (e.g. float16) roundtrip through shared memory."""
+    """Test dtypes without a `multiprocessing` typecode (e.g. float16) roundtrip through shared memory."""
     space = Box(low=-1.0, high=1.0, shape=(2, 3), dtype=dtype)
     num = 8
 


### PR DESCRIPTION
# Description

Related to #1686 (does not close it, see below).

Python 3.15 added float16 to the `array` module and changed `array.typecodes` from a string into a tuple:

    3.14  'bBuwhHiIlLqQfd'
    3.15  ('b','B','u','w','h','H','i','I','l','L','q','Q','e','f','d','Zf','Zd')

`_create_base_shared_memory` gates on `dtype in typecodes`, so on 3.15 a float16 `Box` takes the native array branch instead of the `c_uint8` fallback. `multiprocessing.sharedctypes.typecode_to_type` still has no `'e'`, so the allocation raises.

Repro on 3.15:

    from gymnasium.spaces import Box
    from gymnasium.vector.utils import create_shared_memory
    import numpy as np

    create_shared_memory(Box(-1.0, 1.0, (2, 3), dtype=np.float16), n=8)
    # TypeError: this type has no size

The allocation is a `multiprocessing` one, so this gates on the table `multiprocessing` actually uses rather than the `array` one. `array` gained `'Zf'` and `'Zd'` in the same release, so the two tables will keep diverging.

Found while auditing 3.15 for #1686. This is not the whole of that issue: torch has no cp315 wheel and no sdist, and ale-py, mujoco, pillow and tensorstore have no cp315 wheels either, so neither CI job can go green on 3.15 yet. Details in that thread. This fix stands on its own regardless of when 3.15 support lands.

Measured on 3.15.0rc2 against a 3.13 environment with an identical package set: 3 test failures unique to 3.15 before this change, 1 after. The remaining one is `test_pickling_env_stack`, which fails inside dill 0.4.1 because it reads `co_lnotab`, removed in 3.15. No 3.13 regressions.

    python -m pytest tests/vector/utils/test_shared_memory.py tests/vector/test_async_vector_env.py -q
    # 3.13: 291 passed, 114 skipped
    # 3.15: 291 passed, 114 skipped   (2 failures before this change)

`test_shared_memory_no_array_typecode_dtypes[float16]` already covered this and is what caught it. Its docstring said "without an `array` module typecode", which stopped being true in 3.15, so it now says `multiprocessing`.

`pre-commit run --all-files` passes, `ty` included. `pytest --doctest-modules gymnasium/vector/utils/ gymnasium/spaces/` passes on both versions; the full `--doctest-modules gymnasium/` run collects 46 errors on 3.13 and 3.15 alike, all from optional dependencies I do not have installed, so it is unaffected by this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
