### PR TITLE
Flatten n-d Box observations in DiscretizeObservation

### DIFF
--- a/gymnasium/wrappers/transform_observation.py
+++ b/gymnasium/wrappers/transform_observation.py
@@ -829,9 +829,9 @@ class DiscretizeObservation(
                 "DiscretizeObservation is only compatible with Box continuous observations."
             )
 
-        self.low = env.observation_space.low
-        self.high = env.observation_space.high
-        self.n_dims = self.low.shape[0]
+        self.low = np.ravel(env.observation_space.low)
+        self.high = np.ravel(env.observation_space.high)
+        self.n_dims = int(self.low.size)
 
         if np.any(np.isinf(self.low)) or np.any(np.isinf(self.high)):
             raise ValueError(
@@ -871,7 +871,7 @@ class DiscretizeObservation(
         # index could be out of range for the number of bins.
         # Solution: clip to ensure 0 <= index < bins[i], and add a small margin
         # to prevent precision issues.
-        clipped = np.clip(observation, self.low, self.high - 1e-8)
+        clipped = np.clip(np.ravel(observation), self.low, self.high - 1e-8)
         indices = [
             int(np.digitize(clipped[i], self.bin_edges[i])) for i in range(self.n_dims)
         ]

--- a/tests/wrappers/test_discretize_observation.py
+++ b/tests/wrappers/test_discretize_observation.py
@@ -58,3 +58,17 @@ def test_discretize_observation_dtype():
     """Tests the discretize observation wrapper with spaces that should raise an error."""
     with pytest.raises((TypeError,)):
         DiscretizeObservation(GenericTestEnv(observation_space=Discrete(10)))
+
+
+def test_discretize_observation_multidimensional_box():
+    """DiscretizeObservation should accept any finite Box, not only 1-D.
+
+    ``n_dims`` was taken from ``shape[0]``, so a Box of shape ``(2, 2)``
+    constructed a Discrete space but crashed on ``reset`` / ``observation``
+    with ``ValueError: object too deep for desired array``.
+    """
+    env = GenericTestEnv(observation_space=Box(0, 1, shape=(2, 2), dtype=np.float32))
+    wrapped = DiscretizeObservation(env, bins=2)
+    assert wrapped.observation_space == Discrete(16)
+    obs, _ = wrapped.reset()
+    assert obs in wrapped.observation_space


### PR DESCRIPTION
DiscretizeObservation takes n_dims from shape[0], so a finite 2-D Box constructs a Discrete space then crashes digitize on reset with ValueError: object too deep for desired array. The class says it discretizes any finite Box.

Repro:

    from gymnasium.spaces import Box
    from gymnasium.wrappers import DiscretizeObservation
    from tests.testing_env import GenericTestEnv

    env = DiscretizeObservation(
        GenericTestEnv(observation_space=Box(0, 1, shape=(2, 2))), bins=2
    )
    env.reset()  # ValueError

Raveled low, high, and the observation so n_dims is the Box size.

PYTHONPATH=. python -m pytest tests/wrappers/test_discretize_observation.py -q
