### PR TITLE
Fix MaxAndSkipObservation pooling on early episode endings

### DIFF
--- a/gymnasium/wrappers/stateful_observation.py
+++ b/gymnasium/wrappers/stateful_observation.py
@@ -568,6 +568,10 @@ class MaxAndSkipObservation(
 ):
     """Skips the N-th frame (observation) and return the max values between the two last observations.
 
+    If the episode terminates or is truncated before ``skip`` steps, the maximum
+    is taken over the last two observations received during that call. If only
+    one step is taken, that step's observation is returned unchanged.
+
     No vector version of the wrapper exists.
 
     Note:
@@ -638,9 +642,9 @@ class MaxAndSkipObservation(
         info = {}
         for i in range(self._skip):
             obs, reward, terminated, truncated, info = self.env.step(action)
-            if i == self._skip - 2:
-                self._obs_buffer[0] = obs
-            if i == self._skip - 1:
+            self._obs_buffer[i % 2] = obs
+            if i == 0:
+                # A one-step episode ending must not include a previous frame.
                 self._obs_buffer[1] = obs
             total_reward += float(reward)
             if terminated or truncated:

--- a/tests/wrappers/test_max_and_skip_observation.py
+++ b/tests/wrappers/test_max_and_skip_observation.py
@@ -2,6 +2,7 @@
 
 import re
 
+import numpy as np
 import pytest
 
 import gymnasium as gym
@@ -45,3 +46,96 @@ def test_skip_size_failures():
         ),
     ):
         MaxAndSkipObservation(env, skip=0)
+
+
+class _EarlyEndingEnv(gym.Env):
+    """Return known observations using a single mutable array until the chosen step."""
+
+    def __init__(self, end_step, truncate):
+        """Set the episode length and which ending flag to return."""
+        self.observation_space = gym.spaces.Box(-100, 100, (2,), dtype=np.float32)
+        self.action_space = gym.spaces.Discrete(2)
+        self.frames = np.array(
+            [[-9, -1], [-2, -8], [-7, -3], [-4, -6], [-8, -5], [-6, -9]],
+            dtype=np.float32,
+        )
+        self.end_step = end_step
+        self.truncate = truncate
+        self.observation_buffer = np.empty(2, dtype=np.float32)
+
+    def reset(self, *, seed=None, options=None):
+        """Start a new episode with an observation distinct from every step."""
+        super().reset(seed=seed)
+        self.steps = 0
+        self.observation_buffer[:] = 100
+        return self.observation_buffer, {"reset": True}
+
+    def step(self, action):
+        """Overwrite the observation buffer and stop exactly at the chosen step."""
+        assert self.steps < self.end_step
+        assert action == 1
+        self.observation_buffer[:] = self.frames[self.steps]
+        self.steps += 1
+        ended = self.steps == self.end_step
+        return (
+            self.observation_buffer,
+            float(self.steps),
+            ended and not self.truncate,
+            ended and self.truncate,
+            {"step": self.steps},
+        )
+
+
+@pytest.mark.parametrize("truncate", [False, True])
+@pytest.mark.parametrize(
+    "skip,end_step",
+    [(skip, end_step) for skip in (2, 3, 4) for end_step in range(1, skip + 1)],
+)
+def test_max_and_skip_early_ending(skip, end_step, truncate):
+    """Pool the last available frames, including when only one step is taken."""
+    base_env = _EarlyEndingEnv(end_step, truncate)
+    env = MaxAndSkipObservation(base_env, skip=skip)
+    env.reset()
+
+    obs, reward, terminated, truncated, info = env.step(1)
+
+    expected = base_env.frames[max(0, end_step - 2) : end_step].max(axis=0)
+    np.testing.assert_array_equal(obs, expected)
+    assert obs.dtype == np.float32
+    assert reward == sum(range(1, end_step + 1))
+    assert terminated is (not truncate)
+    assert truncated is truncate
+    assert info == {"step": end_step}
+    assert base_env.steps == end_step
+
+
+@pytest.mark.parametrize("truncate", [False, True])
+@pytest.mark.parametrize("reset_before_ending", [False, True])
+def test_max_and_skip_discards_previous_frames(truncate, reset_before_ending):
+    """An early ending must not pool frames from a previous call or episode."""
+    base_env = _EarlyEndingEnv(end_step=6, truncate=truncate)
+    env = MaxAndSkipObservation(base_env, skip=4)
+    env.reset()
+    previous_obs, reward, terminated, truncated, info = env.step(1)
+    np.testing.assert_array_equal(previous_obs, base_env.frames[2:4].max(axis=0))
+    assert reward == 10.0
+    assert not terminated and not truncated
+    assert info == {"step": 4}
+
+    if reset_before_ending:
+        base_env.end_step = 1
+        env.reset()
+        expected = base_env.frames[0]
+        expected_reward = 1.0
+    else:
+        expected = base_env.frames[4:6].max(axis=0)
+        expected_reward = 11.0
+
+    obs, reward, terminated, truncated, info = env.step(1)
+
+    np.testing.assert_array_equal(obs, expected)
+    np.testing.assert_array_equal(previous_obs, base_env.frames[2:4].max(axis=0))
+    assert reward == expected_reward
+    assert terminated is (not truncate)
+    assert truncated is truncate
+    assert info == {"step": base_env.end_step}


### PR DESCRIPTION
# Description

`MaxAndSkipObservation` returns zero or stale observations if the underlying episode terminates or truncates before the last skipped step. For example, with `skip=4`, an environment returning `[t, 10-t]` and ending at step 2 produces `[0, 0]` instead of the elementwise maximum `[2, 9]`. An early ending after a previous complete call can return that previous call's pooled observation.

The buffer was only updated at `skip-2` and `skip-1`. This change saves each observation in a two-slot circular buffer and initializes both slots on the first internal step. It pools the last two observations actually received during the current call; if only one step occurs, it returns that observation. Reward accumulation, ending flags and the final info remain unchanged.

The added tests cover every ending position for skips 2, 3 and 4, both ending flags, a previous complete call, and reset followed by a one-step ending. They use negative observations with crossing component values and an environment that reuses one ndarray, and check that an earlier returned observation is not mutated. The class documentation now specifies the early-ending behavior.

Each internal step now writes an observation into the buffer, with both slots initialized on the first step. This entails more frame copies than recording only the last two scheduled steps; no performance benchmark or training evaluation was performed.

## Type of change

- [x] Bug fix
- [x] Documentation update

## Validation

Base: `ec4715dda7cda0b36e2cd80af4c6bbff7e8a4fee`.

- Original implementation with the new tests: **16 failed, 8 passed** in `tests/wrappers/test_max_and_skip_observation.py`; failures were observation-value assertions. After the fix: **24 passed**.
- Wrapper/core regression group: **195 passed**, compared with **173 passed** on the unmodified base; both runs report the same eight warnings. This group includes the affected test file, frame stacking, delay, time awareness, observation normalization, action repetition, autoreset, time limits and `tests/test_core.py`.
- The repository's minimal-dependency CI test selection (`tests/test_core.py tests/envs/test_envs.py tests/spaces`): **1662 passed**, with 109 warnings. This overlaps the group above in `tests/test_core.py`; the counts are not additive.
- Doctests in `gymnasium/wrappers/stateful_observation.py`: **5 passed**, with three dependency warnings.
- `pre-commit run --all-files`: all applicable hooks passed, including Ruff and ty.
- Source distribution and wheel builds, and `git diff --check`: passed.

Local environment: Ubuntu 22.04.5 x86_64, Python 3.12.14, NumPy 2.5.3 and pytest 9.1.1, with `testing`, `classic-control`, `toy-text` and `box2d` extras. This does not constitute the full optional-dependency or multi-Python/NumPy CI matrix.

# Checklist

- [x] I have run `pre-commit run --all-files`.
- [x] I have commented the non-obvious buffer initialization.
- [x] I have updated the documentation.
- [x] My changes generate no new warnings in the tested regression group.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing unit tests pass locally in the reported scope.

AI assistance: the implementation, tests and this description were prepared with Codex. A separate agent reviewed the change, and the reported validation commands were executed locally.
