### PR TITLE
Support empty stacked Sequence operations

### DIFF
--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -392,6 +392,9 @@ def concatenate(
 ) -> tuple[Any, ...] | dict[str, Any] | np.ndarray:
     """Concatenate multiple samples from space into a single object.
 
+    For NumPy-based spaces, empty inputs are supported when ``out`` has shape
+    ``(0, *space.shape)``. The empty output array is returned unchanged.
+
     Args:
         space: Space of each item (e.g. `single_action_space` from vectorized environment)
         items: Samples to be concatenated (e.g. all sample should be an element of the `space`).
@@ -427,7 +430,15 @@ def _concatenate_base(
     items: Iterable,
     out: np.ndarray,
 ) -> np.ndarray:
-    return np.stack(list(items), axis=0, out=out)
+    items = list(items)
+    if (
+        not items
+        and isinstance(out, np.ndarray)
+        and space.shape is not None
+        and out.shape == (0, *space.shape)
+    ):
+        return out
+    return np.stack(items, axis=0, out=out)
 
 
 @concatenate.register(Tuple)

--- a/tests/spaces/test_sequence.py
+++ b/tests/spaces/test_sequence.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytest
 
 import gymnasium as gym
+from gymnasium.spaces.utils import flatten, flatten_space, unflatten
+from gymnasium.utils.env_checker import data_equivalence
 
 
 def test_stacked_sequence():
@@ -128,3 +130,99 @@ def test_sample_with_probability():
     assert np.all(value in space for value in sample)
     counts = np.bincount(sample[:], minlength=3) / len(sample)
     np.testing.assert_allclose(counts, probability[1], atol=0.05)
+
+
+EMPTY_STACKED_SEQUENCES = [
+    pytest.param(
+        gym.spaces.Box(-1, 1, shape=(), dtype=np.float32),
+        np.empty((0,), dtype=np.float32),
+        np.empty((0, 1), dtype=np.float32),
+        id="scalar-box",
+    ),
+    pytest.param(
+        gym.spaces.Box(-1, 1, shape=(2, 3), dtype=np.float32),
+        np.empty((0, 2, 3), dtype=np.float32),
+        np.empty((0, 6), dtype=np.float32),
+        id="matrix-box",
+    ),
+    pytest.param(
+        gym.spaces.Discrete(3, start=2, dtype=np.int16),
+        np.empty((0,), dtype=np.int16),
+        np.empty((0, 3), dtype=np.int16),
+        id="discrete",
+    ),
+    pytest.param(
+        gym.spaces.MultiDiscrete([[2, 3], [4, 2]], dtype=np.int32),
+        np.empty((0, 2, 2), dtype=np.int32),
+        np.empty((0, 11), dtype=np.int32),
+        id="multidiscrete",
+    ),
+    pytest.param(
+        gym.spaces.MultiBinary((2, 3)),
+        np.empty((0, 2, 3), dtype=np.int8),
+        np.empty((0, 6), dtype=np.int8),
+        id="multibinary",
+    ),
+    pytest.param(
+        gym.spaces.Dict(
+            {
+                "position": gym.spaces.Box(-1, 1, shape=(2,), dtype=np.float32),
+                "status": gym.spaces.Tuple(
+                    (
+                        gym.spaces.Discrete(3, dtype=np.int16),
+                        gym.spaces.MultiBinary(2),
+                    )
+                ),
+            }
+        ),
+        {
+            "position": np.empty((0, 2), dtype=np.float32),
+            "status": (
+                np.empty((0,), dtype=np.int16),
+                np.empty((0, 2), dtype=np.int8),
+            ),
+        },
+        np.empty((0, 7), dtype=np.float32),
+        id="nested-dict-tuple",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "feature_space, expected, flat_expected", EMPTY_STACKED_SEQUENCES
+)
+@pytest.mark.parametrize("mask_type", ["mask", "probability"])
+@pytest.mark.parametrize("length", [0, np.array([0])], ids=["integer", "array"])
+def test_empty_stacked_sample(
+    feature_space, expected, flat_expected, mask_type, length
+):
+    """Zero-length masks preserve the feature shape, dtype, and nested structure."""
+    space = gym.spaces.Sequence(feature_space, stack=True)
+
+    sample = space.sample(**{mask_type: (length, None)})
+
+    assert sample in space
+    assert data_equivalence(sample, expected, exact=True)
+
+
+@pytest.mark.parametrize(
+    "feature_space, expected, flat_expected", EMPTY_STACKED_SEQUENCES
+)
+@pytest.mark.parametrize(
+    "transform", [flatten, unflatten], ids=["flatten", "unflatten"]
+)
+def test_empty_stacked_transform(feature_space, expected, flat_expected, transform):
+    """Flatten and unflatten each accept valid empty samples without prior sampling."""
+    space = gym.spaces.Sequence(feature_space, stack=True)
+    flat_space = flatten_space(space)
+    assert expected in space
+    assert flat_expected in flat_space
+
+    if transform is flatten:
+        transformed = flatten(space, expected)
+        assert transformed in flat_space
+        assert data_equivalence(transformed, flat_expected, exact=True)
+    else:
+        transformed = unflatten(space, flat_expected)
+        assert transformed in space
+        assert data_equivalence(transformed, expected, exact=True)

--- a/tests/vector/utils/test_space_utils.py
+++ b/tests/vector/utils/test_space_utils.py
@@ -9,7 +9,7 @@ import pytest
 
 from gymnasium import Space
 from gymnasium.error import CustomSpaceError
-from gymnasium.spaces import Box, Dict, Discrete, Tuple
+from gymnasium.spaces import Box, Dict, Discrete, MultiBinary, MultiDiscrete, Tuple
 from gymnasium.utils.env_checker import data_equivalence
 from gymnasium.vector.utils import (
     batch_differing_spaces,
@@ -256,3 +256,55 @@ def test_batch_differing_discrete_spaces_dtype(spaces, expected_dtype):
     multi_discrete = batch_differing_spaces(spaces)
 
     assert multi_discrete.dtype == expected_dtype
+
+
+@pytest.mark.parametrize(
+    "space",
+    [
+        Box(-1, 1, shape=(), dtype=np.float32),
+        Box(-1, 1, shape=(2, 3), dtype=np.float64),
+        Box(-1, 1, shape=(0,), dtype=np.float32),
+        Discrete(3, dtype=np.int32),
+        MultiDiscrete([2, 3], dtype=np.int16),
+        MultiBinary((2, 3)),
+    ],
+)
+@pytest.mark.parametrize("use_iterator", [False, True])
+def test_concatenate_empty_samples(space, use_iterator):
+    """Empty batches preserve the preallocated array, shape and dtype."""
+    out = create_empty_array(space, n=0)
+    items = iter(()) if use_iterator else ()
+
+    result = concatenate(space, items, out)
+
+    assert result is out
+    assert result.shape == (0, *space.shape)
+    assert result.dtype == space.dtype
+
+
+@pytest.mark.parametrize("out_shape", [(), (1, 2), (0, 3), (0, 2, 1)])
+def test_concatenate_empty_samples_invalid_shape(out_shape):
+    """An empty input must not accept a mismatched output shape."""
+    space = Box(-1, 1, shape=(2,), dtype=np.float32)
+    out = np.empty(out_shape, dtype=space.dtype)
+
+    with pytest.raises(ValueError):
+        concatenate(space, (), out)
+
+
+def test_concatenate_empty_samples_without_output():
+    """Empty input still requires a compatible output array."""
+    with pytest.raises(ValueError):
+        concatenate(Box(-1, 1, shape=(2,)), (), None)
+
+
+def test_concatenate_nonempty_zero_width_samples():
+    """Zero-size samples still require the output batch dimension to match."""
+    space = Box(-1, 1, shape=(0,), dtype=np.float32)
+    samples = [space.sample(), space.sample()]
+    out = create_empty_array(space, n=2)
+
+    assert concatenate(space, samples, out) is out
+    assert out.shape == (2, 0)
+    with pytest.raises(ValueError):
+        concatenate(space, samples, create_empty_array(space, n=0))


### PR DESCRIPTION
# Description

Zero-length sequences are accepted by `Sequence`'s length masks, but `Sequence(..., stack=True).sample(mask=(0, None))` raises `ValueError: need at least one array to stack`. Flattening or unflattening a valid empty stacked sequence fails the same way. For a `Box(shape=(2,))` feature, these operations should produce an empty array of shape `(0, 2)`.

All three paths already allocate a correctly shaped output and pass it to `concatenate`. This change lets the base NumPy handler return that output when the input iterable is empty and the output shape is exactly `(0, *space.shape)`. Other cases retain the existing `np.stack` path, including incorrect empty-output shapes. The provided array's identity and dtype are preserved, and existing Tuple/Dict recursion handles nested features. The public utility docstring describes this behavior.

The regressions cover integer and array zero-length requests through `mask` and `probability`, independent flatten/unflatten calls, scalar and multidimensional feature spaces, discrete dtypes, nested containers, empty iterators, mismatched output shapes, and nonempty zero-width samples.

## Type of change

- [x] Bug fix
- [x] Documentation update

## Validation

Base: `ec4715dda7cda0b36e2cd80af4c6bbff7e8a4fee`.

- Original implementation with the new tests: **36 failed / 4 passed** in `tests/spaces/test_sequence.py`; **12 failed / 1197 passed** in the vector utility file. The failures are empty-input `np.stack` errors.
- After the fix: **1249 passed** across those two files.
- `pytest tests/spaces tests/vector tests/test_core.py -q`: **3455 passed, 133 skipped**, compared with **3401 passed, 133 skipped** on the unmodified base. The skips explicitly exclude dynamic-shape spaces from vector/shared-memory tests. Both versions emit the same 719 warnings; warning blocks match after normalizing filesystem paths and process IDs.
- Doctests in `spaces/sequence.py`, `spaces/utils.py` and `vector/utils/space_utils.py`: **9 passed**.
- `pre-commit run --all-files`, source distribution and wheel builds, and `git diff --check`: passed.

Local environment: Ubuntu 22.04.5 x86_64, Python 3.12.14, NumPy 2.5.3 and pytest 9.1.1, with testing/classic-control/toy-text/box2d extras. The full optional-dependency and multi-Python/NumPy CI matrix was not run. No training or performance result is claimed. Existing Graph/Sequence-feature unflatten limitations are outside this patch.

# Checklist

- [x] I have run `pre-commit run --all-files`.
- [x] The empty-output condition is explicit in the code.
- [x] I have updated the relevant API documentation.
- [x] My changes generate no new warnings in the tested scope.
- [x] I have added tests that prove the fix is effective.
- [x] New and existing unit tests pass locally in the reported scope.

AI assistance: the implementation, tests and this description were prepared with Codex. Another agent independently reviewed the final change. The reported validation commands were executed locally.
