### PR TITLE
Preserve integer ranges when batching Discrete spaces

### DIFF
--- a/gymnasium/vector/utils/space_utils.py
+++ b/gymnasium/vector/utils/space_utils.py
@@ -161,6 +161,10 @@ def batch_differing_spaces(spaces: _PySequence[Space]) -> Space:
     Returns:
         A batched space
 
+    For Discrete spaces, dtypes are promoted to a common integer dtype that can
+    represent the full range of each input dtype. Combinations without such a
+    dtype, including uint64 mixed with a signed integer dtype, raise ValueError.
+
     Example:
         >>> from gymnasium.spaces import Discrete
         >>> spaces = [Discrete(3), Discrete(5), Discrete(4), Discrete(8)]
@@ -206,14 +210,16 @@ def _batch_differing_spaces_box(spaces: _PySequence[Box]) -> Box:
 
 @batch_differing_spaces.register(Discrete)
 def _batch_differing_spaces_discrete(spaces: _PySequence[Discrete]) -> MultiDiscrete:
-    # select the "largest" to fit others.
-    # Assumes all spaces dtype are of int dtype
     dtypes = [space.dtype for space in spaces]
-    largest = max(dtypes, key=lambda dt: np.dtype(dt).itemsize)
+    dtype = np.result_type(*dtypes)
+    if not np.issubdtype(dtype, np.integer):
+        raise ValueError(
+            f"Cannot batch Discrete spaces with dtypes {dtypes}: no common integer dtype."
+        )
     return MultiDiscrete(
-        nvec=np.array([space.n for space in spaces]),
-        dtype=largest,
-        start=np.array([space.start for space in spaces]),
+        nvec=np.array([space.n for space in spaces], dtype=dtype),
+        dtype=dtype,
+        start=np.array([space.start for space in spaces], dtype=dtype),
         seed=deepcopy(spaces[0].np_random),
     )
 

--- a/tests/vector/utils/test_space_utils.py
+++ b/tests/vector/utils/test_space_utils.py
@@ -256,3 +256,60 @@ def test_batch_differing_discrete_spaces_dtype(spaces, expected_dtype):
     multi_discrete = batch_differing_spaces(spaces)
 
     assert multi_discrete.dtype == expected_dtype
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize(
+    "first, second, expected_dtype",
+    [
+        ((np.int8, -5, 3), (np.uint8, 200, 3), np.int16),
+        ((np.int8, 0, 3), (np.uint8, 0, 200), np.int16),
+        ((np.int16, -5, 3), (np.uint16, 60000, 3), np.int32),
+        ((np.int32, -5, 3), (np.uint32, 2**32 - 4, 3), np.int64),
+        ((np.int8, -5, 3), (np.uint16, 60000, 3), np.int32),
+        ((np.int64, -5, 3), (np.uint32, 2**32 - 4, 3), np.int64),
+        ((np.uint8, 200, 3), (np.uint16, 60000, 3), np.uint16),
+        ((np.uint64, 2**63 + 1, 3), (np.uint32, 5, 3), np.uint64),
+    ],
+    ids=[
+        "int8-uint8-starts",
+        "int8-uint8-counts",
+        "int16-uint16",
+        "int32-uint32",
+        "wider-unsigned",
+        "wider-signed",
+        "unsigned",
+        "large-uint64-start",
+    ],
+)
+def test_batch_differing_discrete_preserves_ranges(
+    first, second, expected_dtype, reverse
+):
+    """Promote integer dtypes without changing counts or starts in either input order."""
+    spaces = [
+        Discrete(n, start=start, dtype=dtype) for dtype, start, n in (first, second)
+    ]
+    if reverse:
+        spaces.reverse()
+    batched = batch_differing_spaces(spaces)
+
+    assert batched.dtype == expected_dtype
+    assert batched.nvec.tolist() == [int(space.n) for space in spaces]
+    assert batched.start.tolist() == [int(space.start) for space in spaces]
+    batched.seed(123)
+    for _ in range(10):
+        assert all(
+            space.contains(int(value))
+            for space, value in zip(spaces, batched.sample(), strict=True)
+        )
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+@pytest.mark.parametrize("signed_dtype", [np.int8, np.int16, np.int32, np.int64])
+def test_batch_differing_discrete_rejects_float_promotion(signed_dtype, reverse):
+    """Reject dtypes without a common integer type, even if these particular values fit."""
+    spaces = [Discrete(3, dtype=signed_dtype), Discrete(3, dtype=np.uint64)]
+    if reverse:
+        spaces.reverse()
+    with pytest.raises(ValueError, match="common integer dtype"):
+        batch_differing_spaces(spaces)


### PR DESCRIPTION
## Description

`batch_differing_spaces` can change the ranges of accepted Discrete inputs when signed and unsigned dtypes are mixed. For example:

```python
import numpy as np
from gymnasium.spaces import Discrete
from gymnasium.vector.utils import batch_differing_spaces

spaces = [Discrete(3, start=-5, dtype=np.int8),
          Discrete(3, start=200, dtype=np.uint8)]
batched = batch_differing_spaces(spaces)
print(batched.dtype, batched.start.tolist())
# Before: int8 [-5, -56]; after: int16 [-5, 200]
```

Reversing those inputs previously produced `uint8 [200, 251]`. A `uint8` count of 200 paired with `int8` could also wrap to a negative count and fail construction. Selecting the first dtype with the largest itemsize does not account for signedness.

Use `np.result_type` to select a common integer dtype, check it before conversion, and construct the count/start arrays with that dtype. Add 24 parameterized regressions for both input orders, range preservation, exact large uint64 starts, and unsupported promotion.

**Compatibility:** NumPy promotes uint64 mixed with any signed integer dtype to float64. Such combinations now raise an explicit `ValueError`, including small-valued inputs that previously happened to work: no native integer dtype covers both full input dtype ranges. The utility's docstring documents this requirement.

Scope is the public batching utility, whose existing tests already cover mixed signed widths. Sync/Async vector constructors continue to require matching observation dtypes; this does not implement the broader vector-environment support discussed in [#1467](https://github.com/Farama-Foundation/Gymnasium/pull/1467#discussion_r2452822528). No separate issue filed or new dependency added.

## Type of change

- [x] Bug fix, with the rejection behavior described above.

## Validation

Base `ec4715dda7cda0b36e2cd80af4c6bbff7e8a4fee`; Ubuntu 22.04.5, Python 3.12.14, NumPy 2.5.3, pytest 9.1.1:

- Final tests against the original implementation: **18 failed, 1197 passed** in `tests/vector/utils/test_space_utils.py`.
- With the fix: **1215 passed** in that file.
- `pytest tests/spaces tests/vector tests/test_core.py -q -rs`: **3425 passed, 133 skipped**, versus **3401 passed, 133 skipped** on the unmodified baseline. Both runs have the same 719 warnings after path/PID normalization; skips are existing dynamic-shape exclusions.
- Vector space-utils doctests: **5 passed**.
- Separate NumPy 1.26.4 environment: all **28 Discrete batching tests passed**.
- Independent actual-source audit: **128 dtype-matrix cases** and **12 composite/RNG cases** passed, including expected rejection cases.
- All-files pre-commit, commit hooks, `git diff --check`, and sdist/wheel builds passed.

Local tests used the testing/classic-control/toy-text/box2d extras. The full optional-dependency and OS/Python/NumPy CI matrix was not run; no training or performance results are claimed.

## Checklist

- [x] Ran `pre-commit run --all-files`.
- [x] Documented the common integer dtype requirement.
- [x] Added regression tests and ran existing tests in the affected scope.
- [x] No new warnings in the tested scope compared with the baseline.

AI assistance: the implementation, tests, and this description were prepared with Codex; a separate Codex agent independently reviewed the change and ran the additional audit. This is not a claim of human or maintainer review.
