### PR TITLE
Preserve vector wrapper state across partial resets

### DIFF
--- a/gymnasium/vector/async_vector_env.py
+++ b/gymnasium/vector/async_vector_env.py
@@ -339,7 +339,9 @@ class AsyncVectorEnv(VectorEnv):
 
         Args:
             seed: The environment reset seeds
-            options: If to return the options
+            options: Options passed to each sub-environment. A boolean NumPy array
+                ``reset_mask`` selects which sub-environments to reset. This mask is
+                not passed to the sub-environments or removed from ``options``.
 
         Returns:
             A batch of observations and info from the vectorized environment.
@@ -358,7 +360,7 @@ class AsyncVectorEnv(VectorEnv):
 
         Args:
             seed: List of seeds for each environment
-            options: The reset option
+            options: Options as described in :meth:`reset`.
 
         Raises:
             ClosedEnvironmentError: If the environment was closed (if :meth:`close` was previously called).
@@ -384,6 +386,8 @@ class AsyncVectorEnv(VectorEnv):
             )
 
         if options is not None and "reset_mask" in options:
+            # Preserve the mask for vector wrappers and subsequent resets.
+            options = options.copy()
             reset_mask = options.pop("reset_mask")
             if not isinstance(reset_mask, np.ndarray):
                 raise TypeError(

--- a/gymnasium/vector/sync_vector_env.py
+++ b/gymnasium/vector/sync_vector_env.py
@@ -197,7 +197,9 @@ class SyncVectorEnv(VectorEnv):
                 * ``None`` - random seeds for all environment
                 * ``int`` - ``[seed, seed+1, ..., seed+n]``
                 * List of ints - ``[1, 2, 3, ..., n]``
-            options: Option information used for each sub-environment
+            options: Options passed to each sub-environment. A boolean NumPy array
+                ``reset_mask`` selects which sub-environments to reset. This mask is
+                not passed to the sub-environments or removed from ``options``.
 
         Returns:
             Concatenated observations and info from each sub-environment
@@ -212,6 +214,8 @@ class SyncVectorEnv(VectorEnv):
             )
 
         if options is not None and "reset_mask" in options:
+            # Preserve the mask for vector wrappers and subsequent resets.
+            options = options.copy()
             reset_mask = options.pop("reset_mask")
             if not isinstance(reset_mask, np.ndarray):
                 raise TypeError(

--- a/gymnasium/wrappers/vector/common.py
+++ b/gymnasium/wrappers/vector/common.py
@@ -119,11 +119,11 @@ class RecordEpisodeStatistics(VectorWrapper):
         seed: int | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[np.ndarray, dict[str, Any]]:
-        """Resets the environment using kwargs and resets the episode returns and lengths."""
+        """Resets the environment and the reset sub-environments' episode statistics."""
         obs, info = super().reset(seed=seed, options=options)
 
         if options is not None and "reset_mask" in options:
-            reset_mask = options.pop("reset_mask")
+            reset_mask = options["reset_mask"]
             if not isinstance(reset_mask, np.ndarray):
                 raise TypeError(
                     f"`options['reset_mask']` must be a numpy array, got {type(reset_mask)}"

--- a/gymnasium/wrappers/vector/stateful_reward.py
+++ b/gymnasium/wrappers/vector/stateful_reward.py
@@ -132,10 +132,16 @@ class NormalizeReward(VectorWrapper, gym.utils.RecordConstructorArgs):
         seed: int | None = None,
         options: dict[str, Any] | None = None,
     ) -> tuple[np.ndarray, dict[str, Any]]:
-        """Resets the environment and clears accumulated reward tracking state."""
-        self.accumulated_reward[:] = 0
-        self._prev_dones[:] = 0
-        return super().reset(seed=seed, options=options)
+        """Resets the environment and clears accumulated rewards for the reset sub-environments."""
+        obs, info = super().reset(seed=seed, options=options)
+        if options is not None and "reset_mask" in options:
+            reset_mask = options["reset_mask"]
+            self.accumulated_reward[reset_mask] = 0
+            self._prev_dones[reset_mask] = 0
+        else:
+            self.accumulated_reward[:] = 0
+            self._prev_dones[:] = 0
+        return obs, info
 
     def step(
         self, actions: np.ndarray

--- a/tests/vector/test_vector_env.py
+++ b/tests/vector/test_vector_env.py
@@ -239,15 +239,15 @@ def test_partial_reset(vectoriser):
     reset_obs, _ = envs.reset(seed=[0, 1, 2])
 
     envs.action_space.seed(123)
-    envs.step(envs.action_space.sample())
-    envs.step(envs.action_space.sample())
-    step_obs, *_ = envs.step(envs.action_space.sample())
+    options = {"reset_mask": np.array([True, True, False])}
+    for _ in range(2):
+        envs.step(envs.action_space.sample())
+        envs.step(envs.action_space.sample())
+        step_obs, *_ = envs.step(envs.action_space.sample())
 
-    reset_mask_obs, _ = envs.reset(
-        seed=[0, 1, 0], options={"reset_mask": np.array([True, True, False])}
-    )
-    assert np.all(reset_mask_obs[:2] == reset_obs[:2])
-    assert np.all(reset_mask_obs[2] == step_obs[2])
+        reset_mask_obs, _ = envs.reset(seed=[0, 1, 0], options=options)
+        assert np.all(reset_mask_obs[:2] == reset_obs[:2])
+        assert np.all(reset_mask_obs[2] == step_obs[2])
 
     envs.close()
 

--- a/tests/wrappers/vector/test_normalize_reward.py
+++ b/tests/wrappers/vector/test_normalize_reward.py
@@ -1,12 +1,15 @@
 """Test suite for vector NormalizeReward wrapper."""
 
+from functools import partial
+
 import numpy as np
 import pytest
 
 from gymnasium import wrappers
 from gymnasium.core import ActType
 from gymnasium.error import InvalidBound
-from gymnasium.vector import AutoresetMode, SyncVectorEnv
+from gymnasium.vector import AsyncVectorEnv, AutoresetMode, SyncVectorEnv
+from gymnasium.wrappers.utils import RunningMeanStd
 from tests.testing_env import GenericTestEnv
 
 
@@ -151,3 +154,46 @@ def test_same_step_autoreset_updates_return_rms(n_envs=2, episode_length=4, n_st
     # Every step is a real environment step under SAME_STEP.
     assert np.isclose(env.return_rms.count, n_steps * n_envs)
     env.close()
+
+
+@pytest.mark.parametrize("vectoriser", [SyncVectorEnv, AsyncVectorEnv])
+@pytest.mark.parametrize("record_statistics", [False, True])
+def test_partial_reset_preserves_normalized_rewards(vectoriser, record_statistics):
+    def step_func(self, action, episode_length):
+        self.step_id += 1
+        return (
+            self.observation_space.sample(),
+            1.0,
+            self.step_id == episode_length,
+            False,
+            {},
+        )
+
+    env = vectoriser(
+        [
+            lambda length=length: GenericTestEnv(
+                reset_func=reset_func,
+                step_func=partial(step_func, episode_length=length),
+            )
+            for length in (2, 4)
+        ],
+        autoreset_mode=AutoresetMode.DISABLED,
+    )
+    if record_statistics:
+        env = wrappers.vector.RecordEpisodeStatistics(env)
+    env = wrappers.vector.NormalizeReward(env, gamma=0.9)
+    try:
+        env.reset(seed=123)
+        env.step(env.action_space.sample())
+        env.step(env.action_space.sample())
+        env.reset(options={"reset_mask": np.array([True, False])})
+        _, rewards, *_ = env.step(env.action_space.sample())
+
+        # Worker 0 restarts its return on termination and on its explicit reset.
+        # Worker 1 is still running, so its discounted return reaches 2.71.
+        reference = RunningMeanStd(shape=())
+        reference.update(np.array([1.0, 1.0, 1.0, 1.9, 1.0, 2.71]))
+        expected_reward = 1.0 / np.sqrt(reference.var + env.epsilon)
+        np.testing.assert_allclose(rewards, expected_reward, rtol=1e-6)
+    finally:
+        env.close()

--- a/tests/wrappers/vector/test_record_episode_statistics.py
+++ b/tests/wrappers/vector/test_record_episode_statistics.py
@@ -3,7 +3,7 @@ import pytest
 
 import gymnasium as gym
 from gymnasium.utils.env_checker import data_equivalence
-from gymnasium.vector import AutoresetMode, SyncVectorEnv, VectorEnv
+from gymnasium.vector import AsyncVectorEnv, AutoresetMode, SyncVectorEnv, VectorEnv
 from tests.testing_env import GenericTestEnv
 
 
@@ -123,3 +123,32 @@ def test_episode_statistics_with_autoreset_mode(
     assert np.all(np.array(envs.return_queue) == episode_length)
     assert np.all(np.array(envs.length_queue) == episode_length)
     envs.close()
+
+
+@pytest.mark.parametrize("vectoriser", [SyncVectorEnv, AsyncVectorEnv])
+def test_partial_reset_preserves_episode_statistics(vectoriser):
+    def step_func(self, action):
+        return self.observation_space.sample(), 1.0, False, False, {}
+
+    envs = gym.wrappers.vector.RecordEpisodeStatistics(
+        vectoriser(
+            [
+                lambda length=length: gym.wrappers.TimeLimit(
+                    GenericTestEnv(step_func=step_func), max_episode_steps=length
+                )
+                for length in (2, 3)
+            ],
+            autoreset_mode=AutoresetMode.DISABLED,
+        )
+    )
+    try:
+        envs.reset(seed=123)
+        envs.step(envs.action_space.sample())
+        _, _, terminated, truncated, _ = envs.step(envs.action_space.sample())
+        envs.reset(options={"reset_mask": np.logical_or(terminated, truncated)})
+        *_, info = envs.step(envs.action_space.sample())
+
+        np.testing.assert_array_equal(info["episode"]["r"], [0.0, 3.0])
+        np.testing.assert_array_equal(info["episode"]["l"], [0, 3])
+    finally:
+        envs.close()


### PR DESCRIPTION
# Description

A partial reset currently removes `reset_mask` from the options shared with outer vector wrappers. `RecordEpisodeStatistics` consequently clears the history of environments that are still running. `NormalizeReward` also clears every environment's accumulated return on a partial reset.

I preserve the mask through the wrapper stack and reset only the selected entries. This also makes reusing the same reset options safe. Full resets and the underlying environments' dynamics are unchanged.

The regressions cover staggered episode lengths, sync and async backends, repeated use of reset options, and stacked statistics/reward-normalization wrappers.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

- Nine regression cases fail before the fix.
- Affected test files: 202 passed, 19 skipped, 4 warnings.
- Headless CPU suite: 4,775 passed, 160 skipped, 843 warnings. Optional Torch, JAX and Atari integrations were not installed in this environment.
- `pre-commit run --all-files` passes, including Ruff and ty.
- A standalone staggered-episode run confirms preserved episode returns/lengths and agreement with a numerical reward-normalization reference on both vector backends.

# Checklist

- [ ] I have run the `pre-commit` checks with `pre-commit run --all-files`
- [x] I have commented the non-obvious mask-preservation behavior
- [x] I have updated the relevant API docstrings
- [ ] My changes generate no new warnings
- [x] I have added tests that prove the fix is effective
- [x] New and existing unit tests pass locally with the skips noted above

AI assistance: I used AI assistance for investigation, implementation, and regression coverage. The local checks above were run through that workflow.
