### PR TITLE
Refactor CartPole observation construction into _get_obs

### DIFF
--- a/gymnasium/envs/classic_control/cartpole.py
+++ b/gymnasium/envs/classic_control/cartpole.py
@@ -161,6 +161,11 @@ class CartPoleEnv(gym.Env[np.ndarray, int | np.ndarray]):
 
         self.steps_beyond_terminated = None
 
+    def _get_obs(self):
+        """Return the current environment observation."""
+        assert self.state is not None
+        return np.array(self.state, dtype=np.float32)
+
     def step(self, action):
         assert self.action_space.contains(action), (
             f"{action!r} ({type(action)}) invalid"
@@ -223,7 +228,7 @@ class CartPoleEnv(gym.Env[np.ndarray, int | np.ndarray]):
             self.render()
 
         # truncation=False as the time limit is handled by the `TimeLimit` wrapper added during `make`
-        return np.array(self.state, dtype=np.float32), reward, terminated, False, {}
+        return self._get_obs(), reward, terminated, False, {}
 
     def reset(
         self,
@@ -244,7 +249,7 @@ class CartPoleEnv(gym.Env[np.ndarray, int | np.ndarray]):
 
         if self.render_mode == "human":
             self.render()
-        return np.array(self.state, dtype=np.float32), {}
+        return self._get_obs(), {}
 
     def render(self):
         if self.render_mode is None:


### PR DESCRIPTION
# Description

This change refactors observation construction in `CartPoleEnv` into a `_get_obs()` helper method.

Previously, both `step()` and `reset()` constructed the observation directly from `self.state`. They now call `_get_obs()` instead. The default observation returned by `CartPoleEnv` remains unchanged.

The motivation is to separate the environment's internal state from observation construction and provide a simple extension point for subclasses that need to customize observations without overriding both `step()` and `reset()`.

This pattern is also consistent with observation construction used in other Gymnasium environments.

No additional dependencies are required.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

* [ ] Documentation only change (no code changed)
* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

### Screenshots

Not applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

# Checklist:

* [x] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation
* [ ] My changes generate no new warnings
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->




Full pytest collection was attempted locally but was blocked by missing optional dependencies including MuJoCo, Box2D, SciPy, pygame, and moviepy.