### PR TITLE
Set an infinite bound's dtype limit after the cast, not into the caller's array

### DIFF
--- a/gymnasium/spaces/box.py
+++ b/gymnasium/spaces/box.py
@@ -280,6 +280,8 @@ class Box(Space[NDArray[_ScalarT_co]]):
             neginf = np.isneginf(low)
             if np.any(neginf):
                 if self.dtype.kind == "i":  # signed int
+                    # set the limit after the cast, where low's float dtype cannot round it
+                    low = np.where(neginf, 0, low).astype(self.dtype)
                     low[neginf] = dtype_min
                 elif self.dtype.kind in {"u", "b"}:  # unsigned int and bool
                     raise ValueError(
@@ -347,6 +349,8 @@ class Box(Space[NDArray[_ScalarT_co]]):
             posinf = np.isposinf(high)
             if np.any(posinf):
                 if self.dtype.kind == "i":  # signed int
+                    # set the limit after the cast, where high's float dtype cannot round it
+                    high = np.where(posinf, 0, high).astype(self.dtype)
                     high[posinf] = dtype_max
                 elif self.dtype.kind in {"u", "b"}:  # unsigned int
                     raise ValueError(

--- a/tests/spaces/test_box.py
+++ b/tests/spaces/test_box.py
@@ -397,6 +397,36 @@ def test_infinite_space(low, high, shape, dtype):
     assert np.all(np.sign(space.low) <= np.sign(sample))
 
 
+@pytest.mark.parametrize("dtype", [np.int8, np.int16, np.int32, np.int64])
+@pytest.mark.parametrize("bound_dtype", [np.float32, np.float64])
+def test_infinite_array_bounds(dtype, bound_dtype):
+    """Tests that an infinite bound passed as an array reaches the dtype's limit.
+
+    The limit used to be written into the caller's float array before the cast,
+    so a limit that float dtype cannot represent rounded up and overflowed the
+    cast: ``np.int64`` max in any float, ``np.int32`` max in ``float32``.
+    """
+    space = Box(
+        low=np.array([-np.inf, 0], dtype=bound_dtype),
+        high=np.array([0, np.inf], dtype=bound_dtype),
+        dtype=dtype,
+    )
+
+    assert space.low[0] == np.iinfo(dtype).min
+    assert space.high[1] == np.iinfo(dtype).max
+
+
+def test_bounds_are_not_modified_in_place():
+    """Tests that Box leaves the low and high arrays it was given alone."""
+    low = np.array([-np.inf, 0.0], dtype=np.float32)
+    high = np.array([0.0, np.inf], dtype=np.float32)
+
+    Box(low=low, high=high, dtype=np.int64)
+
+    assert np.isneginf(low[0])
+    assert np.isposinf(high[1])
+
+
 def test_equality():
     # Check if two spaces are equivalent.
     space_a = Box(low=0, high=1, shape=[2], dtype=np.float32)


### PR DESCRIPTION
## Summary

When the dtype is a signed integer, `Box` replaces an infinite bound with that dtype's limit. Given an array bound it writes the limit into the array the caller passed, and it writes it *before* the cast:

```python
posinf = np.isposinf(high)
if np.any(posinf):
    if self.dtype.kind == "i":  # signed int
        high[posinf] = dtype_max
...
return high.astype(self.dtype), bounded_above
```

Two things follow from that.

**The limit is rounded away, and the cast overflows.** `np.int64`'s maximum is 9223372036854775807; no float holds it, and the nearest `float64` is 2<sup>63</sup>. `np.int32`'s maximum needs 31 bits of mantissa and `float32` carries 24. So the assignment rounds *up*, out of the dtype's range, and the cast wraps to the dtype's **minimum**:

```python
import numpy as np
from gymnasium.spaces import Box

Box(low=np.array([0.0, 0.0]), high=np.array([1.0, np.inf]), dtype=np.int64)
# ValueError: Box all low values must be less than or equal to high (some values break this),
#             low=[0 0], high=[                  1 -9223372036854775808]
```

The same space built from scalars is correct, because that branch assigns the limit and then builds the array directly in the target dtype:

```python
Box(low=0, high=np.inf, shape=(2,), dtype=np.int64).high
# array([9223372036854775807, 9223372036854775807])
```

| bound dtype | int8 | int16 | int32 | int64 |
|---|---|---|---|---|
| `float32` | ok | ok | **overflows** | **overflows** |
| `float64` | ok | ok | ok | **overflows** |

`-np.inf` is never affected: a dtype's minimum is a power of two, so it survives the round trip. Only the upper limit is lost, which is why the failure shows up as `high` sitting below `low`.

**The caller's array is written to.** The bounds handed to `Box` come back changed:

```python
import gymnasium as gym
from gymnasium.wrappers import DtypeObservation

env = gym.make("CartPole-v1")
env.observation_space.low     # array([-4.8, -inf, -0.41887903, -inf], dtype=float32)
DtypeObservation(env, np.int32)
env.observation_space.low     # array([-4.8000002e+00, -2.1474836e+09, -4.1887903e-01, -2.1474836e+09], dtype=float32)
```

Together they leave `DtypeObservation` advertising a space that holds none of its observations on any environment with an unbounded one:

```python
env = DtypeObservation(gym.make("CartPole-v1"), np.int32)
obs, _ = env.reset(seed=0)

env.observation_space
# Box([-4 -2147483648 0 -2147483648], [4 -2147483648 0 -2147483648], (4,), int32)
env.observation_space.contains(obs)   # False
```

The suite does not catch this because `test_infinite_space` shares its parametrised arrays across dtypes: the case `(np.array([-np.inf, 0]), np.array([0.0, np.inf]), None)` runs for four dtypes, and the first of them replaces the infinities in place, so the later three never see an infinite bound. Selected on its own, the `int64` case fails on current `main`:

```
$ pytest "tests/spaces/test_box.py::test_infinite_space" -k int64
FAILED tests/spaces/test_box.py::test_infinite_space[int64-low6-high6-None]
1 failed, 6 passed, 21 deselected
```

## Changes

* `gymnasium/spaces/box.py` — `_cast_low` and `_cast_high` blank the infinite entries, cast to the target dtype, and write the limit afterwards, where the input's float dtype can no longer round it. `np.where` returns a new array, so the caller's bounds are left alone. The scalar branch is untouched; it was already correct.
* `tests/spaces/test_box.py`
  * `test_infinite_array_bounds` — each signed integer dtype against `float32` and `float64` bounds, asserting `low[0]` and `high[1]` are the dtype's limits;
  * `test_bounds_are_not_modified_in_place` — the arrays passed to `Box` still carry their infinities afterwards.

## Verification

`tests/spaces/test_box.py`: **129 passed**, against 120 on an unmodified checkout — the nine new parametrisations and nothing else moved.

With the fix reverted and the tests kept, three of the eight `test_infinite_array_bounds` cases fail — `float32-int32`, `float32-int64`, `float64-int64`, exactly the combinations in the table — and so does `test_bounds_are_not_modified_in_place`. The tests detect the defect rather than passing regardless.

`tests/spaces`: **1592 passed, 2 failed**. `tests/utils`: **131 passed**. `tests/wrappers`, `tests/vector` and `tests/envs` together: **2812 passed, 62 failed, 225 skipped, 2 errors** — the same counts, test for test, as a checkout without this commit.

Every one of those failures is present on an unmodified checkout too. The two in `tests/spaces/test_discrete.py` come from `int` being `int32` on Windows; the rest come from optional dependencies this machine does not have (Box2D, MuJoCo, the torch bridge) and from human rendering without a display.

`ruff check`, `ruff format --check` and `codespell` are clean on both files, using the arguments from `.pre-commit-config.yaml`.
