### PR TITLE
raise DependencyNotInstalled when array conversion dependencies are missing

### DIFF
--- a/gymnasium/wrappers/array_conversion.py
+++ b/gymnasium/wrappers/array_conversion.py
@@ -25,15 +25,19 @@ from types import ModuleType, NoneType
 from typing import Any, SupportsFloat
 
 import numpy as np
-from array_api_compat import is_numpy_namespace
-from packaging.version import Version
 
 import gymnasium as gym
 from gymnasium.core import RenderFrame, WrapperActType, WrapperObsType
 from gymnasium.error import DependencyNotInstalled
 
 try:
-    from array_api_compat import array_namespace, is_array_api_obj, to_device
+    from array_api_compat import (
+        array_namespace,
+        is_array_api_obj,
+        is_numpy_namespace,
+        to_device,
+    )
+    from packaging.version import Version
 
 except ImportError as e:
     raise DependencyNotInstalled(

--- a/gymnasium/wrappers/vector/jax_to_numpy.py
+++ b/gymnasium/wrappers/vector/jax_to_numpy.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
-import jax.numpy as jnp
 import numpy as np
 
 from gymnasium.error import DependencyNotInstalled
 from gymnasium.vector import VectorEnv
 from gymnasium.wrappers.vector.array_conversion import ArrayConversion
+
+try:
+    import jax.numpy as jnp
+except ImportError as e:
+    raise DependencyNotInstalled(
+        'Jax is not installed therefore cannot call `JaxToNumpy`, run `pip install "gymnasium[jax]"`'
+    ) from e
 
 __all__ = ["JaxToNumpy"]
 
@@ -32,8 +38,4 @@ class JaxToNumpy(ArrayConversion):
         Args:
             env: the vector jax environment to wrap
         """
-        if jnp is None:
-            raise DependencyNotInstalled(
-                'Jax is not installed, run `pip install "gymnasium[jax]"`'
-            )
         super().__init__(env, env_xp=jnp, target_xp=np)

--- a/gymnasium/wrappers/vector/jax_to_torch.py
+++ b/gymnasium/wrappers/vector/jax_to_torch.py
@@ -2,12 +2,24 @@
 
 from __future__ import annotations
 
-import jax.numpy as jnp
-import torch
-
+from gymnasium.error import DependencyNotInstalled
 from gymnasium.vector import VectorEnv
 from gymnasium.wrappers.jax_to_torch import Device
 from gymnasium.wrappers.vector.array_conversion import ArrayConversion
+
+try:
+    import jax.numpy as jnp
+except ImportError as e:
+    raise DependencyNotInstalled(
+        'Jax is not installed therefore cannot call `JaxToTorch`, run `pip install "gymnasium[jax]"`'
+    ) from e
+
+try:
+    import torch
+except ImportError as e:
+    raise DependencyNotInstalled(
+        'Torch is not installed therefore cannot call `JaxToTorch`, run `pip install "gymnasium[torch]"`'
+    ) from e
 
 __all__ = ["JaxToTorch"]
 

--- a/gymnasium/wrappers/vector/numpy_to_torch.py
+++ b/gymnasium/wrappers/vector/numpy_to_torch.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import numpy as np
-import torch
 
+from gymnasium.error import DependencyNotInstalled
 from gymnasium.vector import VectorEnv
 from gymnasium.wrappers.numpy_to_torch import Device
 from gymnasium.wrappers.vector.array_conversion import ArrayConversion
+
+try:
+    import torch
+except ImportError as e:
+    raise DependencyNotInstalled(
+        'Torch is not installed therefore cannot call `NumpyToTorch`, run `pip install "gymnasium[torch]"`'
+    ) from e
 
 __all__ = ["NumpyToTorch"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,9 @@ jax = [
     "jaxlib >=0.4.16",
     "flax >=0.5.0",
     "array-api-compat >=1.11.0",
+    "packaging >=23.0",
 ]
-torch = ["torch >=1.13.0", "array-api-compat >=1.11.0"]
+torch = ["torch >=1.13.0", "array-api-compat >=1.11.0", "packaging >=23.0"]
 array-api = ["array-api-compat >=1.11.0", "packaging >=23.0"]
 other = [
     "moviepy >=1.0.0",

--- a/tests/wrappers/test_import_wrappers.py
+++ b/tests/wrappers/test_import_wrappers.py
@@ -1,6 +1,8 @@
 """Test suite for import wrappers."""
 
 import re
+import subprocess
+import sys
 
 import pytest
 
@@ -50,3 +52,34 @@ def test_renamed_wrappers(wrapper_name):
         assert getattr(gymnasium.wrappers.vector, no_vector_wrapper_name)
     else:
         assert getattr(gymnasium.wrappers, new_wrapper_name)
+
+
+@pytest.mark.parametrize(
+    "missing_module, wrapper_name",
+    [
+        ("array_api_compat", "gymnasium.wrappers.ArrayConversion"),
+        ("packaging", "gymnasium.wrappers.ArrayConversion"),
+        ("array_api_compat", "gymnasium.wrappers.vector.ArrayConversion"),
+        ("jax", "gymnasium.wrappers.JaxToNumpy"),
+        ("jax", "gymnasium.wrappers.vector.JaxToNumpy"),
+        ("jax", "gymnasium.wrappers.vector.JaxToTorch"),
+        ("torch", "gymnasium.wrappers.NumpyToTorch"),
+        ("torch", "gymnasium.wrappers.vector.NumpyToTorch"),
+        ("torch", "gymnasium.wrappers.vector.JaxToTorch"),
+    ],
+)
+def test_array_conversion_missing_dependency(missing_module, wrapper_name):
+    """Check that the array conversion wrappers raise `DependencyNotInstalled` when a dependency is missing."""
+    code = (
+        "import sys\n"
+        f"sys.modules[{missing_module!r}] = None\n"
+        "import gymnasium\n"
+        f"{wrapper_name}\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=False
+    )
+
+    assert result.returncode != 0
+    assert "gymnasium.error.DependencyNotInstalled" in result.stderr
+    assert 'pip install "gymnasium[' in result.stderr


### PR DESCRIPTION
`pip install "gymnasium[torch]"` in a fresh environment gives a `NumpyToTorch` that fails to import with `ModuleNotFoundError: No module named 'packaging'` (same for `gymnasium[jax]` / `JaxToNumpy`). the `torch` and `jax` extras never depended on `packaging`; #1437 added it to `array-api` only, but `array_conversion.py` imports `packaging.version.Version` at module level for every conversion wrapper.

that import, and `array_api_compat.is_numpy_namespace` next to it, sat above the `try`/`except ImportError` meant to raise `DependencyNotInstalled` with a pip hint, so the guard never ran, and a base install got a bare `ModuleNotFoundError` instead. the vector `JaxToNumpy`/`JaxToTorch`/`NumpyToTorch` had the same problem: unguarded `import jax.numpy` / `import torch`.

fixes #1701.

- `pyproject.toml`: add `packaging >=23.0` to the `torch` and `jax` extras.
- `array_conversion.py`: move the two misplaced imports into the existing `try` block.
- vector `jax_to_numpy.py` / `jax_to_torch.py` / `numpy_to_torch.py`: guard the imports the same way, drop the now-dead `if jnp is None:` check.
- `test_import_wrappers.py`: new test blocking each dependency via `sys.modules[name] = None` in a subprocess, asserting `DependencyNotInstalled` with the pip hint.

verified on macos arm64, python 3.11.15, against `main` @ `ec4715d`: fresh `pip install ".[torch]"` from this branch imports `NumpyToTorch` cleanly (fails on main with the error above). `tests/wrappers/test_import_wrappers.py` goes from 4 failed / 42 passed on main to 51 passed / 4 skipped here. reverting either changed file locally reproduces the corresponding failures again.

hit this while working on a project of mine. drafted with claude opus / fable 5.1. i tested this myself before submitting (see commands above). reviewed by muse spark 1.3 and glm 5.3 as judges.
